### PR TITLE
Fix path of playwright dependencies commands.js and command.js

### DIFF
--- a/packages/core/src/engine.mjs
+++ b/packages/core/src/engine.mjs
@@ -28,8 +28,8 @@ function loadDeps() {
     BrowserServerBackend: pwReq('lib/mcp/browser/browserServerBackend.js').BrowserServerBackend,
     contextFactory:       pwReq('lib/mcp/browser/browserContextFactory.js').contextFactory,
     resolveConfig:        pwReq('lib/mcp/browser/config.js').resolveConfig,
-    commands:             pwReq('lib/mcp/terminal/commands.js').commands,
-    parseCommand:         pwReq('lib/mcp/terminal/command.js').parseCommand,
+    commands:             pwReq('lib/cli/daemon/commands.js').commands,
+    parseCommand:         pwReq('lib/cli/daemon/command.js').parseCommand,
   };
   return _deps;
 }


### PR DESCRIPTION
Since commit [#951911](https://github.com/microsoft/playwright/commit/951911cefedb1dd5a2a15f854a51bd7c34504a5f) the paths to commands.js and command.js changed. This PR updates the paths, so that playwright-repl can start.