### PR TITLE
Add project name to package.json so that npm link works

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+  "name": "playwright-repl",
   "private": true,
   "workspaces": ["packages/*"],
   "scripts": {


### PR DESCRIPTION
Currently, `npm link` fails with "Cannot destructure property 'name' of '.for' as it is undefined.". This is a known [issue](https://github.com/npm/cli/issues/6006), which is easily fixed by adding the "name" field in package.json.