### PR TITLE
When connecting over CDP reuse the current browser context

### DIFF
--- a/packages/core/src/engine.mjs
+++ b/packages/core/src/engine.mjs
@@ -179,6 +179,7 @@ export class Engine {
     if (opts.connect) {
       const port = typeof opts.connect === 'number' ? opts.connect : 9222;
       config.browser.cdpEndpoint = `http://localhost:${port}`;
+      config.browser.isolated = false;
     }
 
     return await deps.resolveConfig(config);


### PR DESCRIPTION
The `CdpContextFactory` in Playwright uses the following logic for creating a context:

```js
this.config.browser.isolated ? await browser.newContext() : browser.contexts()[0];
```

The purpose of connecting Playwright REPL to a running browser is to be able to automate the page currently open. This requires reusing the browser context, which is achieved by setting config.browser.isolated to false.