### PR TITLE
fix: cleanup fixes across codebase

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -2,24 +2,22 @@
 
 ## High Priority
 
-- [ ] **History loads in wrong order** — `packages/cli/src/repl.mjs`: `.reverse()` before `.push()` means Up arrow shows oldest commands first instead of most recent
-- [ ] **String escaping misses newlines** — `packages/cli/src/repl.mjs`: `esc()` for verify commands doesn't escape `\n`, `\r`, `\t` — multiline user input breaks generated code
-- [ ] **Ghost completion crash on empty array** — `packages/cli/src/repl.mjs`: `renderGhost(matches[0])` has no guard if `cmds` is empty
-
+- [ ] **History loads in wrong order** — `packages/cli/src/repl.ts`: `.reverse()` before `.push()` means Up arrow shows oldest commands first instead of most recent
+- [ ] **Dark mode toggle** — Add a toggle button to the extension toolbar to switch between light/dark themes. The `.theme-dark` CSS variables already exist in `panel.css` but nothing applies them. Plan: `useState` in `App.tsx`, pass `isDark`/`onToggleTheme` to `Toolbar`, wrap children in a div with `theme-dark` class, move `background`/`color` from `html,body` to `#root` in CSS, persist with `localStorage`.
+- [ ] **Extension spawn path bug** — `engine.ts:133` resolves `--load-extension` to `packages/extension` instead of `packages/extension/dist`. Chrome needs the folder containing `manifest.json`, which is in `dist/`. Fix: append `/dist` to the resolved path.
 - [ ] **Auto-inject `expect` in `run-code`** — auto-prepend `const { expect } = require('@playwright/test')` in the `run-code` auto-wrap so users can write `run-code await expect(page).toHaveTitle('Todo')` without manual imports
 
 ## Medium Priority
 
-- [ ] **Failed commands not recorded** — `packages/cli/src/repl.mjs`: `session.record(line)` only runs after success; replay files miss failed commands
-- [ ] **History write errors silently swallowed** — `packages/cli/src/repl.mjs`: `catch {}` hides disk-full or permission errors
+- [ ] **Extract shared `resolveArgs`** — The verify-command translation, text-locator resolution, and run-code auto-wrap logic is duplicated between `extension-server.ts` and `repl.ts`. Extract to a shared `core` utility.
+- [ ] **Failed commands not recorded** — `packages/cli/src/repl.ts`: `session.record(line)` only runs after success; replay files miss failed commands
+- [ ] **History write errors silently swallowed** — `packages/cli/src/repl.ts`: `catch {}` hides disk-full or permission errors
 - [ ] **Playwright version too loose** — `packages/cli/package.json`: `>=1.59.0-alpha` accepts any future version; pin to `<1.60.0` or similar
-- [ ] **README lists commands that don't exist** — storage commands like `cookie-set`, `cookie-delete`, `localstorage-set` etc. are documented but not in COMMANDS
+- [ ] **Publish CLI to npm** — Requires fixing `file:../core` dependency (bundle core into CLI or publish core separately) and waiting for Playwright 1.59 stable.
 
 ## Low Priority
 
-- [ ] **`@types/chrome` types `sendCommand` as void** — `packages/extension/background.js`: `await chrome.debugger.sendCommand(...)`, `chrome.debugger.attach()`, `chrome.debugger.detach()` are correctly awaited (MV3 returns Promises) but `@types/chrome` still types them as `void`, causing IDE "await has no effect" warnings. Revisit when `@types/chrome` updates or if migrating to TypeScript.
-
-- [ ] **Convert to TypeScript** — migrate `.mjs` files to `.ts` across `packages/core` and `packages/cli` for type safety and better IDE support
-- [x] **Extension server (Phase 8)** — `playwright-repl --extension` starts a WebSocket server; extension connects as thin CDP relay instead of reimplementing all commands
-- [ ] **Improve README structure** — Consider splitting README into per-package docs (`packages/cli/README.md`, `packages/extension/README.md`) with a concise root README linking to both. Current root README covers both CLI and extension but could be better organized.
-- [ ] **Restructure the extension code structure, add src folder, and add build step
+- [ ] **Improve README structure** — Consider splitting README into per-package docs (`packages/cli/README.md`, `packages/extension/README.md`) with a concise root README linking to both.
+- [x] **Convert to TypeScript** — All packages migrated to TypeScript.
+- [x] **Extension server (Phase 8)** — `playwright-repl --extension` starts HTTP server; extension connects as thin CDP relay.
+- [x] **Restructure the extension code structure** — Extension has `src/` folder with React components, Vite build step.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,21 +35,25 @@ playwright-repl/
 │   │   ├── test/
 │   │   └── examples/               # .pw session files
 │   │
-│   └── extension/                  # Chrome side panel extension (TypeScript, Vite)
+│   └── extension/                  # Chrome side panel extension (React, Vite, Tailwind)
 │       ├── public/
 │       │   └── manifest.json       # Manifest V3 config (copied to dist/ by Vite)
 │       ├── src/
 │       │   ├── background.ts       # Side panel behavior + recording handlers
-│       │   ├── panel/              # Side panel UI
+│       │   ├── panel/              # Side panel UI (React)
 │       │   │   ├── panel.html
-│       │   │   ├── panel.ts
-│       │   │   └── panel.css
-│       │   ├── content/
-│       │   │   └── recorder.ts     # Event recorder injected into pages
-│       │   └── lib/
-│       │       └── converter.ts    # .pw → Playwright test export
+│       │   │   ├── panel.tsx       # React entry point
+│       │   │   ├── panel.css       # Theme variables + residual styles
+│       │   │   ├── App.tsx         # Root component
+│       │   │   ├── reducer.ts      # useReducer state management
+│       │   │   ├── components/     # Toolbar, EditorPane, ConsolePane, etc.
+│       │   │   ├── hooks/          # useCommandHistory
+│       │   │   └── lib/            # server, run, autocomplete, filter, etc.
+│       │   └── content/
+│       │       └── recorder.ts     # Event recorder injected into pages
 │       ├── dist/                   # Vite build output (gitignored, loaded by Chrome)
 │       ├── vite.config.ts          # Vite build config (3 entry points)
+│       ├── test/                   # Vitest browser component tests
 │       └── e2e/                    # Playwright E2E tests
 ```
 
@@ -117,8 +121,8 @@ Key Playwright internals used (via `createRequire`):
 - `playwright/lib/mcp/browser/browserServerBackend` → `BrowserServerBackend`
 - `playwright/lib/mcp/browser/browserContextFactory` → `contextFactory`
 - `playwright/lib/mcp/browser/config` → `resolveConfig`
-- `playwright/lib/mcp/terminal/commands` → `commands` map
-- `playwright/lib/mcp/terminal/command` → `parseCommand`
+- `playwright/lib/cli/daemon/commands` → `commands` map
+- `playwright/lib/cli/daemon/command` → `parseCommand`
 
 ### CommandServer (packages/core/src/extension-server.ts)
 
@@ -134,7 +138,7 @@ When `--extension` mode is used, `CommandServer` starts an HTTP server:
       │                                    │
       │                                    ▼
 ┌─────────────────────────────────────────────────────┐
-│  CommandServer (HTTP :3000)                          │
+│  CommandServer (HTTP :6781)                          │
 │    ├── POST /run   ← panel sends commands here      │
 │    └── GET /health ← panel checks server status     │
 │  Engine → connectOverCDP → CDP :3001 → Chrome       │

--- a/README.md
+++ b/README.md
@@ -4,13 +4,13 @@
 
 Interactive browser automation powered by Playwright — use it from your **terminal** or as a **Chrome side panel**.
 
-Two frontends, one engine: the CLI gives you a terminal REPL with recording and replay; the Chrome extension gives you a DevTools panel with a script editor and visual recorder. Both run the same 35+ Playwright commands through a shared Engine — no command duplication.
+Two frontends, one engine: the CLI gives you a terminal REPL with recording and replay; the Chrome extension gives you a DevTools panel with a script editor and visual recorder. Both run the same 55+ Playwright commands through a shared Engine — no command duplication.
 
 ## Why?
 
 **playwright-repl** runs Playwright's browser tools in-process. Type a command, see the result instantly. No code, no tokens, no setup.
 
-- **CLI** — terminal REPL with recording, replay, piping, and 50+ aliases
+- **CLI** — terminal REPL with recording, replay, piping, and 20+ aliases
 - **Extension** — Chrome DevTools panel with script editor, recorder, and light/dark themes
 - **Same commands everywhere** — `click`, `fill`, `snapshot`, `verify-text` work identically in both
 
@@ -137,7 +137,7 @@ playwright-repl --connect         # default port 9222
 playwright-repl --connect 9333    # custom port
 
 # Extension mode (launches Chrome with side panel)
-playwright-repl --extension              # default port 3000
+playwright-repl --extension              # default port 6781
 playwright-repl --extension --port 4000  # custom command server port
 ```
 
@@ -151,7 +151,7 @@ playwright-repl --extension --port 4000  # custom command server port
 | `--profile <dir>` | Persistent profile directory |
 | `--connect [port]` | Connect to existing Chrome via CDP (default: `9222`) |
 | `--extension` | Launch Chrome with side panel extension and command server |
-| `--port <number>` | Command server port (default: `3000`) |
+| `--port <number>` | Command server port (default: `6781`) |
 | `--config <file>` | Path to config file |
 | `--replay <files...>` | Replay `.pw` file(s) or folder(s) |
 | `--record <file>` | Start REPL with recording to file |

--- a/packages/core/src/extension-server.ts
+++ b/packages/core/src/extension-server.ts
@@ -185,10 +185,11 @@ function resolveArgs(args: ParsedArgs): ParsedArgs {
 // ─── Helpers ────────────────────────────────────────────────────────────────
 
 function readBody(req: IncomingMessage): Promise<string> {
-  return new Promise((resolve) => {
+  return new Promise((resolve, reject) => {
     let data = '';
     req.on('data', (chunk: Buffer) => data += chunk);
     req.on('end', () => resolve(data));
+    req.on('error', reject);
   });
 }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -2,7 +2,7 @@
  * @playwright-repl/core — shared engine, parser, and utilities.
  */
 
-export { minimist, replVersion, packageLocation, COMMANDS } from './resolve.js';
+export { minimist, replVersion, COMMANDS } from './resolve.js';
 export { parseInput, ALIASES, ALL_COMMANDS, booleanOptions } from './parser.js';
 export { buildCompletionItems } from './completion-data.js';
 export { c } from './colors.js';

--- a/packages/core/src/resolve.ts
+++ b/packages/core/src/resolve.ts
@@ -1,9 +1,7 @@
 /**
  * Shared dependencies and command vocabulary.
- * No @playwright/cli — we start the daemon ourselves via daemon-launcher.cjs.
  */
 
-import { fileURLToPath } from 'node:url';
 import { createRequire } from 'node:module';
 
 const require = createRequire(import.meta.url);
@@ -13,12 +11,8 @@ const require = createRequire(import.meta.url);
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 export const minimist: (args: string[], opts?: Record<string, unknown>) => Record<string, unknown> & { _: string[] } = require('minimist');
 
-const pkgUrl = new URL('../package.json', import.meta.url);
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 export const replVersion: string = require('../../cli/package.json').version;
-
-// Must match what daemon-launcher.cjs computes via require.resolve('../package.json')
-export const packageLocation: string = fileURLToPath(pkgUrl);
 
 // ─── Command vocabulary ──────────────────────────────────────────────────────
 

--- a/packages/extension/src/panel/components/Splitter.tsx
+++ b/packages/extension/src/panel/components/Splitter.tsx
@@ -4,7 +4,7 @@ interface SplitterProps {
     editorPaneRef: React.RefObject<HTMLDivElement | null>
 }
 function Splitter({editorPaneRef}: SplitterProps) {
-    const [isDragging, setisDragging] = useState(false);
+    const [isDragging, setIsDragging] = useState(false);
     const dragStartY = useRef(0);
     const dragStartHeight = useRef(0);
 
@@ -17,7 +17,7 @@ function Splitter({editorPaneRef}: SplitterProps) {
     };
 
     function handleMouseUp() {
-        setisDragging(false);
+        setIsDragging(false);
         dragStartHeight.current = 0;
         dragStartY.current = 0;
         document.body.style.cursor = '';
@@ -30,7 +30,7 @@ function Splitter({editorPaneRef}: SplitterProps) {
         dragStartY.current = event.clientY;
         const editorPane = editorPaneRef.current;
         dragStartHeight.current = editorPane!.offsetHeight;
-        setisDragging(true);
+        setIsDragging(true);
     }
 
     useEffect(() => {

--- a/packages/extension/src/panel/components/Toolbar.tsx
+++ b/packages/extension/src/panel/components/Toolbar.tsx
@@ -83,14 +83,14 @@ function Toolbar({ editorContent, fileName, stepLine, dispatch }: ToolbarProps) 
     }
 
     function findExecutableIndex(fromIndex: number) {
-        let excutableIndex = -1;
+        let executableIndex = -1;
         for (let i = fromIndex; i < lines.length; i++) {
             if (!lines[i].startsWith('#') && lines[i].trim()) {
-                excutableIndex = i;
+                executableIndex = i;
                 break;
             }
         }
-        return excutableIndex;
+        return executableIndex;
     }
     async function handleStep() {
         if (stepLine === -1) {
@@ -131,7 +131,7 @@ function Toolbar({ editorContent, fileName, stepLine, dispatch }: ToolbarProps) 
 
     function commitPort(e: React.SyntheticEvent<HTMLInputElement>) {
         const val = parseInt(e.currentTarget.value, 10);
-        if(val > 0 && val < 65535) {
+        if(val > 0 && val <= 65535) {
             setPort(val);
             setServerPort(val);
         }

--- a/packages/extension/test/components/Toolbar.browser.test.tsx
+++ b/packages/extension/test/components/Toolbar.browser.test.tsx
@@ -454,7 +454,7 @@ describe('Toolbar component tests', () => {
     expect(window.chrome.runtime.sendMessage).not.toHaveBeenCalled();
   })
 
-  it('should not send chrome message whtn tabs[0] is null', async () => {
+  it('should not send chrome message when tabs[0] is null', async () => {
     window.chrome.tabs.query = vi.fn().mockResolvedValue([null]);
 
     const dispatch = vi.fn();


### PR DESCRIPTION
## Summary

- Fix port validation off-by-one (`< 65535` → `<= 65535`) in Toolbar
- Add missing `req.on('error', reject)` to `readBody` in extension-server
- Fix typos: `excutableIndex` → `executableIndex`, `setisDragging` → `setIsDragging`, `whtn` → `when`
- Remove dead code: `packageLocation` export, `fileURLToPath` import, stale daemon-launcher comments in resolve.ts
- Update CLAUDE.md: correct Playwright import paths (`lib/cli/daemon/` not `lib/mcp/terminal/`), React extension structure, default port 6781
- Update README: correct default port (6781 not 3000), accurate command count (55+) and alias count (20+)
- Clean up BACKLOG.md: remove stale/fixed items, update `.mjs` → `.ts` file paths, mark completed items

## Test plan

- [ ] `npm run build` succeeds
- [ ] `npm run test:component -w packages/extension` passes
- [ ] Manual: verify extension loads and port input accepts 65535

🤖 Generated with [Claude Code](https://claude.com/claude-code)