### PR TITLE
feat: add .clear and .history commands to CLI REPL (v0.7.4)

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -9,7 +9,7 @@
 - [x] **Auto-inject `expect` in `run-code`** — Not feasible: Playwright's `browser_run_code` uses `vm.createContext()` with only `page` in scope; `require()` is not available in the sandbox.
 
 ## Medium Priority
-- [ ] **CLI `clear` command** — Add `clear` to the CLI REPL to clear terminal output, matching the extension behavior. ([#15](https://github.com/stevez/playwright-repl/issues/15))
+- [x] **CLI `clear` command** — Add `clear` to the CLI REPL to clear terminal output, matching the extension behavior. ([#15](https://github.com/stevez/playwright-repl/issues/15))
 - [ ] **Chaining selectors with `>>`** — When args contain `>>`, use `page.locator(<chained>)` instead of ref-based lookup. Similar to `run-code` logic. ([#16](https://github.com/stevez/playwright-repl/issues/16))
 - [ ] **Upgrade editor to CodeMirror 6** — Replace plain `<textarea>` in `EditorPane.tsx` with CodeMirror 6 (~30KB gzipped). Gains: syntax highlighting, proper selections, undo/redo, search. Potential custom `.pw` syntax mode later.
 - [ ] **Toolbar icons** — Replace text buttons (Open, Save, Export) with SVG icons in `Toolbar.tsx`, similar to existing sun/moon toggle in `Icons.tsx`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## v0.7.4 — CLI .clear and .history Commands
+
+**2026-03-01**
+
+### Features
+
+- **`.clear` command**: Clears terminal output in the CLI REPL (closes [#15](https://github.com/stevez/playwright-repl/issues/15))
+- **`.history` command**: Shows commands entered in the current session
+- **`.history clear` command**: Clears the current session history
+- **Ghost text for new commands**: `.clear`, `.history`, and `.history clear` now appear in autocomplete suggestions
+- **Multi-word ghost text**: Ghost text now supports commands with spaces (e.g., typing `.history ` suggests `clear`)
+
 ## v0.7.3 — Unified Verify Command
 
 **2026-03-01**

--- a/package-lock.json
+++ b/package-lock.json
@@ -4472,7 +4472,7 @@
     },
     "packages/cli": {
       "name": "playwright-repl",
-      "version": "0.6.0",
+      "version": "0.7.4",
       "license": "MIT",
       "dependencies": {
         "@playwright-repl/core": "file:../core",
@@ -4490,7 +4490,7 @@
     },
     "packages/core": {
       "name": "@playwright-repl/core",
-      "version": "0.6.0",
+      "version": "0.7.4",
       "dependencies": {
         "minimist": "^1.2.8"
       },
@@ -4517,7 +4517,7 @@
     },
     "packages/extension": {
       "name": "@playwright-repl/extension",
-      "version": "1.1.0",
+      "version": "0.7.3",
       "dependencies": {
         "react": "^19.2.4",
         "react-dom": "^19.2.4"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "playwright-repl",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "description": "Interactive REPL for Playwright browser automation — keyword-driven testing from your terminal",
   "type": "module",
   "bin": {

--- a/packages/cli/src/repl.ts
+++ b/packages/cli/src/repl.ts
@@ -36,6 +36,7 @@ export interface ReplContext {
   opts: ReplOpts;
   log: (...args: unknown[]) => void;
   historyFile: string;
+  sessionHistory: string[];
   commandCount: number;
   errors: number;
 }
@@ -84,6 +85,9 @@ export function showHelp(): void {
   console.log(`  .pause                Pause/resume recording`);
   console.log(`  .discard              Discard recording`);
   console.log(`  .replay <filename>    Replay a recorded session`);
+  console.log(`  .clear                Clear terminal output`);
+  console.log(`  .history              Show command history`);
+  console.log(`  .history clear        Clear command history`);
   console.log(`  .exit                 Exit REPL\n`);
 }
 
@@ -177,6 +181,24 @@ export async function processLine(ctx: ReplContext, line: string): Promise<void>
   if (line === '.help' || line === '?') return showHelp();
   if (line === '.aliases') return showAliases();
   if (line === '.status') return showStatus(ctx);
+
+  if (line === '.clear') {
+    console.clear();
+    ctx.rl!.prompt();
+    return;
+  }
+
+  if (line === '.history clear') {
+    ctx.sessionHistory.length = 0;
+    console.log('History cleared.');
+    return;
+  }
+
+  if (line === '.history') {
+    const hist = ctx.sessionHistory;
+    console.log(hist.length ? hist.join('\n') : '(no history)');
+    return;
+  }
 
   if (line === '.exit' || line === '.quit') {
     ctx.conn.close();
@@ -540,6 +562,7 @@ export function startCommandLoop(ctx: ReplContext): void {
       const line = commandQueue.shift()!;
       await processLine(ctx, line);
       if (line.trim()) {
+        ctx.sessionHistory.push(line.trim());
         try {
           fs.mkdirSync(path.dirname(ctx.historyFile), { recursive: true });
           fs.appendFileSync(ctx.historyFile, line.trim() + '\n');
@@ -602,8 +625,12 @@ export function promptStr(ctx: ReplContext): string {
  * the exact match is included so the user can cycle through all options.
  */
 export function getGhostMatches(cmds: string[], input: string): string[] {
-  if (input.length > 0 && !input.includes(' ')) {
-    const longer = cmds.filter(cmd => cmd.startsWith(input) && cmd !== input);
+  if (input.length > 0) {
+    // Only match commands with spaces if the input itself contains a space
+    const candidates = input.includes(' ')
+      ? cmds.filter(cmd => cmd.includes(' '))
+      : cmds;
+    const longer = candidates.filter(cmd => cmd.startsWith(input) && cmd !== input);
     if (longer.length > 0 && cmds.includes(input)) longer.push(input);
     return longer;
   }
@@ -716,7 +743,7 @@ export async function startRepl(opts: ReplOpts = {}): Promise<void> {
   const session = new SessionManager();
   const historyDir = path.join(os.homedir(), '.playwright-repl');
   const historyFile = path.join(historyDir, '.repl-history');
-  const ctx: ReplContext = { conn, session, rl: null, opts, log, historyFile, commandCount: 0, errors: 0 };
+  const ctx: ReplContext = { conn, session, rl: null, opts, log, historyFile, sessionHistory: [], commandCount: 0, errors: 0 };
 
   // Auto-start recording if --record was passed
   if (opts.record) {

--- a/packages/cli/test/repl-helpers.test.ts
+++ b/packages/cli/test/repl-helpers.test.ts
@@ -156,8 +156,13 @@ describe('getGhostMatches', () => {
     expect(getGhostMatches(cmds, '')).toEqual([]);
   });
 
-  it('returns empty when input contains a space', () => {
+  it('returns empty when input contains a space but no multi-word commands match', () => {
     expect(getGhostMatches(cmds, 'close ')).toEqual([]);
+  });
+
+  it('matches multi-word commands when input contains a space', () => {
+    const withMulti = [...cmds, '.history', '.history clear'];
+    expect(getGhostMatches(withMulti, '.history ')).toEqual(['.history clear']);
   });
 
   it('returns empty when no commands match', () => {

--- a/packages/cli/test/repl-integration.test.ts
+++ b/packages/cli/test/repl-integration.test.ts
@@ -34,6 +34,7 @@ function makeCtx(overrides = {}) {
     opts: {},
     log: vi.fn(),
     historyFile: path.join(os.tmpdir(), 'pw-test-history-' + Date.now()),
+    sessionHistory: [],
     commandCount: 0,
     errors: 0,
     ...overrides,

--- a/packages/cli/test/repl-processline.test.ts
+++ b/packages/cli/test/repl-processline.test.ts
@@ -1,5 +1,6 @@
 // @ts-nocheck
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
 import { SessionManager } from '../src/recorder.js';
 import {
   processLine,
@@ -28,6 +29,7 @@ function makeCtx(overrides = {}) {
     opts: {},
     log: vi.fn(),
     historyFile: '/tmp/test-history',
+    sessionHistory: [],
     commandCount: 0,
     errors: 0,
     ...overrides,
@@ -255,6 +257,38 @@ describe('processLine', () => {
     ctx.conn.start = vi.fn().mockRejectedValue(new Error('launch failed'));
     await processLine(ctx, '.reconnect');
     expect(errorSpy).toHaveBeenCalled();
+  });
+
+  it('.clear clears the terminal', async () => {
+    const clearSpy = vi.spyOn(console, 'clear').mockImplementation(() => {});
+    const ctx = makeCtx();
+    await processLine(ctx, '.clear');
+    expect(clearSpy).toHaveBeenCalled();
+    expect(ctx.rl!.prompt).toHaveBeenCalled();
+    clearSpy.mockRestore();
+  });
+
+  it('.history prints session command history', async () => {
+    const ctx = makeCtx();
+    ctx.sessionHistory.push('goto https://example.com', 'click e5');
+    await processLine(ctx, '.history');
+    const output = logSpy.mock.calls.map(c => c.join(' ')).join('\n');
+    expect(output).toContain('goto https://example.com');
+    expect(output).toContain('click e5');
+  });
+
+  it('.history prints message when empty', async () => {
+    const ctx = makeCtx();
+    await processLine(ctx, '.history');
+    const output = logSpy.mock.calls.map(c => c.join(' ')).join('\n');
+    expect(output).toContain('(no history)');
+  });
+
+  it('.history clear clears session history', async () => {
+    const ctx = makeCtx();
+    ctx.sessionHistory.push('click e5', 'goto https://example.com');
+    await processLine(ctx, '.history clear');
+    expect(ctx.sessionHistory).toHaveLength(0);
   });
 
   it('sends regular command to daemon and increments count', async () => {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@playwright-repl/core",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/core/src/completion-data.ts
+++ b/packages/core/src/completion-data.ts
@@ -9,8 +9,11 @@ import { COMMANDS } from './resolve.js';
 // ─── Meta-commands ───────────────────────────────────────────────────────────
 
 const META_COMMANDS = [
+  { cmd: '.clear',     desc: 'Clear terminal output' },
   { cmd: '.help',      desc: 'Show available commands' },
   { cmd: '.aliases',   desc: 'Show command aliases' },
+  { cmd: '.history',   desc: 'Show command history' },
+  { cmd: '.history clear', desc: 'Clear command history' },
   { cmd: '.status',    desc: 'Show connection status' },
   { cmd: '.reconnect', desc: 'Reconnect to daemon' },
   { cmd: '.record',    desc: 'Start recording commands' },


### PR DESCRIPTION
## Summary

- Adds `.clear` command to clear terminal output (`console.clear()`)
- Adds `.history` command to show commands entered in the current session (not from file)
- Adds `.history clear` to clear the current session history
- Ghost text now supports multi-word commands (e.g., typing `.history ` suggests `clear`)
- Added `.clear`, `.history`, `.history clear` to autocomplete data

Closes #15

## Test plan

- [x] 170 CLI tests pass (4 new tests + 1 updated ghost text test)
- [ ] Manual: run `playwright-repl`, type `.clear` — terminal clears
- [ ] Manual: type commands, then `.history` — shows current session only
- [ ] Manual: `.history clear` — clears session history
- [ ] Manual: type `.h` — ghost text suggests `.history`
- [ ] Manual: type `.history ` — ghost text suggests `clear`

🤖 Generated with [Claude Code](https://claude.com/claude-code)