### PR TITLE
feat: add highlight command (v0.7.5)

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -23,7 +23,7 @@
 
 ## Low Priority
 
-- [ ] **`highlight` command** — `highlight <locator>` as shortcut for `page.locator(<locator>).highlight()`. Useful for visualizing non-unique locator matches. Depends on editor implementation. ([#14](https://github.com/stevez/playwright-repl/issues/14))
+- [x] **`highlight` command** — `highlight <locator>` as shortcut for `page.locator(<locator>).highlight()`. Useful for visualizing non-unique locator matches. ([#14](https://github.com/stevez/playwright-repl/issues/14))
 - [ ] **Improve README structure** — Consider splitting README into per-package docs (`packages/cli/README.md`, `packages/extension/README.md`) with a concise root README linking to both.
 - [x] **Convert to TypeScript** — All packages migrated to TypeScript.
 - [x] **Extension server (Phase 8)** — `playwright-repl --extension` starts HTTP server; extension connects as thin CDP relay.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## v0.7.5 — Highlight Command
+
+**2026-03-01**
+
+### Features
+
+- **`highlight` command**: Visualize which elements a locator matches with `highlight <locator>` (closes [#14](https://github.com/stevez/playwright-repl/issues/14))
+  - CSS selectors: `highlight .btn` → `page.locator(".btn").highlight()`
+  - Text matching: `highlight Submit` → `page.getByText("Submit").highlight()`
+  - Auto-detects selector vs text based on CSS-like characters (`.#[]>:=`)
+- **`hl` alias**: Short alias for `highlight` (e.g., `hl .btn`)
+- **Autocomplete**: `highlight` appears in ghost text suggestions
+
 ## v0.7.4 — CLI .clear and .history Commands
 
 **2026-03-01**

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "playwright-repl",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "description": "Interactive REPL for Playwright browser automation — keyword-driven testing from your terminal",
   "type": "module",
   "bin": {

--- a/packages/cli/src/repl.ts
+++ b/packages/cli/src/repl.ts
@@ -261,7 +261,7 @@ export async function processLine(ctx: ReplContext, line: string): Promise<void>
   if (!cmdName) return;
 
   // Validate command exists
-  const knownExtras = ['help', 'list', 'close-all', 'kill-all', 'install', 'install-browser',
+  const knownExtras = ['help', 'highlight', 'list', 'close-all', 'kill-all', 'install', 'install-browser',
                        'verify', 'verify-text', 'verify-element', 'verify-value', 'verify-list',
                        'verify-title', 'verify-url', 'verify-no-text', 'verify-no-element'];
   if (!ALL_COMMANDS.includes(cmdName) && !knownExtras.includes(cmdName)) {

--- a/packages/cli/test/repl-processline.test.ts
+++ b/packages/cli/test/repl-processline.test.ts
@@ -313,6 +313,12 @@ describe('processLine', () => {
     expect(output).toContain('Unknown command');
   });
 
+  it('passes highlight command through to engine', async () => {
+    const ctx = makeCtx();
+    await processLine(ctx, 'highlight .btn');
+    expect(ctx.conn.run).toHaveBeenCalledWith(expect.objectContaining({ _: ['highlight', '.btn'] }));
+  });
+
   it('auto-resolves text to run-code for click', async () => {
     const ctx = makeCtx();
     await processLine(ctx, 'click "Submit"');

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@playwright-repl/core",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/core/src/completion-data.ts
+++ b/packages/core/src/completion-data.ts
@@ -25,6 +25,7 @@ const META_COMMANDS = [
 ];
 
 const EXTRA_COMMANDS = [
+  { cmd: 'highlight',       desc: 'Highlight matching elements' },
   { cmd: 'verify',          desc: 'Assert page state (title, url, text, element, value, list)' },
   { cmd: 'verify-text',     desc: 'Assert text is visible on page' },
   { cmd: 'verify-element',  desc: 'Assert element exists by role and name' },

--- a/packages/core/src/engine.ts
+++ b/packages/core/src/engine.ts
@@ -242,6 +242,17 @@ export class Engine {
     if (!this._backend)
       throw new Error('Engine not started');
 
+    // ── highlight → run-code translation ──
+    if (args._[0] === 'highlight') {
+      const loc = args._.slice(1).join(' ');
+      if (!loc) return { text: 'Usage: highlight <locator>', isError: true };
+      const isSelector = /[.#\[\]>:=]/.test(loc);
+      const locExpr = isSelector
+        ? `page.locator(${JSON.stringify(loc)})`
+        : `page.getByText(${JSON.stringify(loc)})`;
+      args = { _: ['run-code', `async (page) => { await ${locExpr}.highlight(); return "Highlighted"; }`] };
+    }
+
     const deps = this._deps || loadDeps();
     const command = deps.commands[args._[0]];
     if (!command)

--- a/packages/core/src/parser.ts
+++ b/packages/core/src/parser.ts
@@ -33,6 +33,7 @@ export const ALIASES: Record<string, string> = {
   'unchk':'uncheck',
 
   // Inspection
+  'hl':   'highlight',
   's':    'snapshot',
   'snap': 'snapshot',
   'ss':   'screenshot',

--- a/packages/core/test/completion-data.test.ts
+++ b/packages/core/test/completion-data.test.ts
@@ -45,7 +45,7 @@ describe('buildCompletionItems', () => {
   });
 
   it('has correct count (commands + extra + meta-commands)', () => {
-    const expected = Object.keys(COMMANDS).length + 9 + 10;
+    const expected = Object.keys(COMMANDS).length + 10 + 13;
     expect(items.length).toBe(expected);
   });
 

--- a/packages/core/test/engine.test.ts
+++ b/packages/core/test/engine.test.ts
@@ -40,6 +40,12 @@ function createMockDeps() {
       args: { shape: { ref: true } },
     },
     close: { name: 'close', toolName: '', toolParams: () => ({}) },
+    'run-code': {
+      name: 'run-code',
+      toolName: 'browser_run_code',
+      toolParams: ({ code }) => ({ code }),
+      args: { shape: { code: true } },
+    },
   };
 
   return {
@@ -218,6 +224,48 @@ describe('Engine', () => {
       const result = await engine.run({ _: ['snapshot'] });
       expect(result.isError).toBe(true);
       expect(result.text).toContain('Error');
+    });
+  });
+
+  // ─── highlight ────────────────────────────────────────────────────────
+
+  describe('highlight', () => {
+    beforeEach(async () => {
+      await engine.start({});
+      mocks.callTool.mockResolvedValue({
+        content: [{ type: 'text', text: 'Highlighted' }],
+        isError: false,
+      });
+    });
+
+    it('uses page.locator() for CSS selectors', async () => {
+      await engine.run({ _: ['highlight', '.btn'] });
+      expect(mocks.callTool).toHaveBeenCalledWith(
+        'browser_run_code',
+        expect.objectContaining({ code: expect.stringContaining('page.locator(".btn").highlight()') }),
+      );
+    });
+
+    it('uses page.getByText() for plain text', async () => {
+      await engine.run({ _: ['highlight', 'Submit'] });
+      expect(mocks.callTool).toHaveBeenCalledWith(
+        'browser_run_code',
+        expect.objectContaining({ code: expect.stringContaining('page.getByText("Submit").highlight()') }),
+      );
+    });
+
+    it('joins multi-word text args and uses getByText', async () => {
+      await engine.run({ _: ['highlight', 'Submit', 'Button'] });
+      expect(mocks.callTool).toHaveBeenCalledWith(
+        'browser_run_code',
+        expect.objectContaining({ code: expect.stringContaining('page.getByText("Submit Button").highlight()') }),
+      );
+    });
+
+    it('returns error when no locator provided', async () => {
+      const result = await engine.run({ _: ['highlight'] });
+      expect(result.isError).toBe(true);
+      expect(result.text).toContain('Usage');
     });
   });
 

--- a/packages/core/test/parser.test.ts
+++ b/packages/core/test/parser.test.ts
@@ -105,7 +105,7 @@ describe('ALIASES', () => {
   it('maps most aliases to known commands', () => {
     // verify-* aliases map to commands handled as knownExtras in repl.ts,
     // not in the COMMANDS vocabulary — that's intentional.
-    const extras = ['verify', 'verify-text', 'verify-element', 'verify-value', 'verify-list'];
+    const extras = ['highlight', 'verify', 'verify-text', 'verify-element', 'verify-value', 'verify-list'];
     for (const [alias, cmd] of Object.entries(ALIASES)) {
       if (extras.includes(cmd)) continue;
       expect(ALL_COMMANDS, `alias "${alias}" → "${cmd}"`).toContain(cmd);


### PR DESCRIPTION
## Summary

- Adds `highlight <locator>` command that visualizes which elements match a locator by drawing colored boxes around them
- Auto-detects CSS selectors vs text: `highlight .btn` uses `page.locator()`, `highlight Submit` uses `page.getByText()`
- Adds `hl` alias and autocomplete support

## Changes

| File | Change |
|---|---|
| `packages/core/src/engine.ts` | highlight → run-code translation with selector/text detection |
| `packages/core/src/parser.ts` | `hl` alias |
| `packages/core/src/completion-data.ts` | autocomplete entry |
| `packages/cli/src/repl.ts` | `highlight` in knownExtras |
| Tests | engine, parser, completion-data, processline |
| `CHANGELOG.md` | v0.7.5 entry |
| `BACKLOG.md` | Mark #14 as done |

## Test plan

- [x] `npm test` — all 441 tests pass
- [x] Manual: `highlight h1` highlights heading in browser
- [x] Manual: `hl .btn` works with alias
- [x] `highlight Submit` uses getByText for text matching

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)