### PR TITLE
feat: support chaining selectors with >> (v0.7.6)

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -10,7 +10,7 @@
 
 ## Medium Priority
 - [x] **CLI `clear` command** — Add `clear` to the CLI REPL to clear terminal output, matching the extension behavior. ([#15](https://github.com/stevez/playwright-repl/issues/15))
-- [ ] **Chaining selectors with `>>`** — When args contain `>>`, use `page.locator(<chained>)` instead of ref-based lookup. Similar to `run-code` logic. ([#16](https://github.com/stevez/playwright-repl/issues/16))
+- [x] **Chaining selectors with `>>`** — When args contain `>>`, use `page.locator(<chained>)` instead of ref-based lookup. ([#16](https://github.com/stevez/playwright-repl/issues/16))
 - [ ] **Upgrade editor to CodeMirror 6** — Replace plain `<textarea>` in `EditorPane.tsx` with CodeMirror 6 (~30KB gzipped). Gains: syntax highlighting, proper selections, undo/redo, search. Potential custom `.pw` syntax mode later.
 - [ ] **Toolbar icons** — Replace text buttons (Open, Save, Export) with SVG icons in `Toolbar.tsx`, similar to existing sun/moon toggle in `Icons.tsx`.
 - [ ] **Editor context menu** — Right-click menu in the editor with: Run line, Copy, Export to TypeScript, Copy to clipboard.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## v0.7.6 — Chaining Selectors with >>
+
+**2026-03-01**
+
+### Features
+
+- **`>>` chaining**: Use Playwright's chained selector syntax with any interaction command (closes [#16](https://github.com/stevez/playwright-repl/issues/16))
+  - `click ".nav >> button"` → `page.locator(".nav >> button").click()`
+  - `fill ".form >> input" "hello"` → `page.locator(".form >> input").fill("hello")`
+  - Works with: click, dblclick, hover, check, uncheck, fill, select
+  - Supports both quoted (`click ".nav >> button"`) and unquoted (`click .nav >> button`) syntax
+
 ## v0.7.5 — Highlight Command
 
 **2026-03-01**

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "playwright-repl",
-  "version": "0.7.5",
+  "version": "0.7.6",
   "description": "Interactive REPL for Playwright browser automation — keyword-driven testing from your terminal",
   "type": "module",
   "bin": {

--- a/packages/cli/src/repl.ts
+++ b/packages/cli/src/repl.ts
@@ -341,7 +341,7 @@ export async function processLine(ctx: ReplContext, line: string): Promise<void>
     click: actionByText as PageScriptFn, dblclick: actionByText as PageScriptFn, hover: actionByText as PageScriptFn,
     fill: fillByText as PageScriptFn, select: selectByText as PageScriptFn, check: checkByText as PageScriptFn, uncheck: uncheckByText as PageScriptFn,
   };
-  if (textFns[cmdName] && args._[1] && !/^e\d+$/.test(args._[1])) {
+  if (textFns[cmdName] && args._[1] && !/^e\d+$/.test(args._[1]) && !args._.some(a => a.includes('>>'))) {
     const textArg = args._[1];
     const extraArgs = args._.slice(2);
     const fn = textFns[cmdName];

--- a/packages/cli/test/repl-processline.test.ts
+++ b/packages/cli/test/repl-processline.test.ts
@@ -319,6 +319,14 @@ describe('processLine', () => {
     expect(ctx.conn.run).toHaveBeenCalledWith(expect.objectContaining({ _: ['highlight', '.btn'] }));
   });
 
+  it('passes >> chained selector through to engine', async () => {
+    const ctx = makeCtx();
+    await processLine(ctx, 'click ".nav >> button"');
+    const call = ctx.conn.run.mock.calls[0][0];
+    expect(call._[0]).toBe('click');
+    expect(call._[1]).toBe('.nav >> button');
+  });
+
   it('auto-resolves text to run-code for click', async () => {
     const ctx = makeCtx();
     await processLine(ctx, 'click "Submit"');

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@playwright-repl/core",
-  "version": "0.7.5",
+  "version": "0.7.6",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/core/src/engine.ts
+++ b/packages/core/src/engine.ts
@@ -253,6 +253,35 @@ export class Engine {
       args = { _: ['run-code', `async (page) => { await ${locExpr}.highlight(); return "Highlighted"; }`] };
     }
 
+    // ── >> chaining → run-code translation ──
+    const LOCATOR_ACTIONS: Record<string, string> = {
+      click: 'click', dblclick: 'dblclick', hover: 'hover',
+      check: 'check', uncheck: 'uncheck',
+      fill: 'fill', select: 'selectOption',
+    };
+    if (LOCATOR_ACTIONS[args._[0]] && args._.some(a => a.includes('>>'))) {
+      const action = LOCATOR_ACTIONS[args._[0]];
+      const positional = args._.slice(1);
+
+      // Find last >> — everything up to the token after it is the selector,
+      // everything after that is the action argument (e.g., value for fill).
+      let lastChainIdx = -1;
+      for (let i = 0; i < positional.length; i++) {
+        if (positional[i] === '>>' || positional[i].includes('>>')) lastChainIdx = i;
+      }
+      const selectorEnd = positional[lastChainIdx] !== '>>' && positional[lastChainIdx]?.includes('>>')
+        ? lastChainIdx     // >> inside quoted token like ".nav >> button"
+        : lastChainIdx + 1;
+      const selector = positional.slice(0, selectorEnd + 1).join(' ');
+      const rest = positional.slice(selectorEnd + 1).join(' ');
+
+      const locExpr = `page.locator(${JSON.stringify(selector)})`;
+      const actionCall = rest
+        ? `${locExpr}.${action}(${JSON.stringify(rest)})`
+        : `${locExpr}.${action}()`;
+      args = { _: ['run-code', `async (page) => { await ${actionCall}; return "Done"; }`] };
+    }
+
     const deps = this._deps || loadDeps();
     const command = deps.commands[args._[0]];
     if (!command)

--- a/packages/core/src/extension-server.ts
+++ b/packages/core/src/extension-server.ts
@@ -183,7 +183,7 @@ function resolveArgs(args: ParsedArgs): ParsedArgs {
     click: actionByText as PageScriptFn, dblclick: actionByText as PageScriptFn, hover: actionByText as PageScriptFn,
     fill: fillByText as PageScriptFn, select: selectByText as PageScriptFn, check: checkByText as PageScriptFn, uncheck: uncheckByText as PageScriptFn,
   };
-  if (textFns[cmdName] && args._[1] && !/^e\d+$/.test(args._[1])) {
+  if (textFns[cmdName] && args._[1] && !/^e\d+$/.test(args._[1]) && !args._.some(a => a.includes('>>'))) {
     const textArg = args._[1];
     const extraArgs = args._.slice(2);
     const fn = textFns[cmdName];

--- a/packages/core/test/engine.test.ts
+++ b/packages/core/test/engine.test.ts
@@ -269,6 +269,74 @@ describe('Engine', () => {
     });
   });
 
+  // ─── >> chaining ────────────────────────────────────────────────────────
+
+  describe('>> chaining', () => {
+    beforeEach(async () => {
+      await engine.start({});
+      mocks.callTool.mockResolvedValue({
+        content: [{ type: 'text', text: 'Done' }],
+        isError: false,
+      });
+    });
+
+    it('translates click with quoted >> selector', async () => {
+      await engine.run({ _: ['click', '.nav >> button'] });
+      expect(mocks.callTool).toHaveBeenCalledWith(
+        'browser_run_code',
+        expect.objectContaining({ code: expect.stringContaining('page.locator(".nav >> button").click()') }),
+      );
+    });
+
+    it('translates click with unquoted >> selector', async () => {
+      await engine.run({ _: ['click', '.nav', '>>', 'button'] });
+      expect(mocks.callTool).toHaveBeenCalledWith(
+        'browser_run_code',
+        expect.objectContaining({ code: expect.stringContaining('page.locator(".nav >> button").click()') }),
+      );
+    });
+
+    it('translates hover with >> selector', async () => {
+      await engine.run({ _: ['hover', '.menu', '>>', '.item'] });
+      expect(mocks.callTool).toHaveBeenCalledWith(
+        'browser_run_code',
+        expect.objectContaining({ code: expect.stringContaining('page.locator(".menu >> .item").hover()') }),
+      );
+    });
+
+    it('translates fill with quoted >> selector and value', async () => {
+      await engine.run({ _: ['fill', '.form >> input', 'hello'] });
+      expect(mocks.callTool).toHaveBeenCalledWith(
+        'browser_run_code',
+        expect.objectContaining({ code: expect.stringContaining('page.locator(".form >> input").fill("hello")') }),
+      );
+    });
+
+    it('translates fill with unquoted >> selector and value', async () => {
+      await engine.run({ _: ['fill', '.form', '>>', 'input', 'hello'] });
+      expect(mocks.callTool).toHaveBeenCalledWith(
+        'browser_run_code',
+        expect.objectContaining({ code: expect.stringContaining('page.locator(".form >> input").fill("hello")') }),
+      );
+    });
+
+    it('translates select with >> selector and value', async () => {
+      await engine.run({ _: ['select', '.form >> select', 'opt'] });
+      expect(mocks.callTool).toHaveBeenCalledWith(
+        'browser_run_code',
+        expect.objectContaining({ code: expect.stringContaining('page.locator(".form >> select").selectOption("opt")') }),
+      );
+    });
+
+    it('does not trigger for commands without >>', async () => {
+      await engine.run({ _: ['click', 'e5'] });
+      expect(mocks.callTool).toHaveBeenCalledWith(
+        'browser_click',
+        expect.objectContaining({ ref: 'e5' }),
+      );
+    });
+  });
+
   // ─── close ──────────────────────────────────────────────────────────────
 
   describe('close', () => {


### PR DESCRIPTION
## Summary

- Adds `>>` chaining support for interaction commands: `click ".nav >> button"` translates to `page.locator(".nav >> button").click()`
- Supports both quoted and unquoted syntax
- Works with: click, dblclick, hover, check, uncheck, fill, select
- `highlight` already supported `>>` via its CSS selector detection

## Changes

| File | Change |
|---|---|
| `packages/core/src/engine.ts` | `>>` detection + run-code translation in `run()` |
| `packages/core/src/extension-server.ts` | Skip text-locator resolution for `>>` args |
| `packages/cli/src/repl.ts` | Skip text-locator resolution for `>>` args |
| `packages/core/test/engine.test.ts` | 7 chaining tests (quoted, unquoted, fill, select, hover, no-trigger) |
| `packages/cli/test/repl-processline.test.ts` | CLI passthrough test |

## Test plan

- [x] `npm test` — all 449 tests pass
- [x] `click ".nav >> button"` translates correctly
- [x] `fill ".form >> input" "hello"` passes value correctly
- [x] Commands without `>>` are unaffected

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)