### PR TITLE
feat: replace toolbar text labels with SVG icons

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -12,7 +12,7 @@
 - [x] **CLI `clear` command** — Add `clear` to the CLI REPL to clear terminal output, matching the extension behavior. ([#15](https://github.com/stevez/playwright-repl/issues/15))
 - [x] **Chaining selectors with `>>`** — When args contain `>>`, use `page.locator(<chained>)` instead of ref-based lookup. ([#16](https://github.com/stevez/playwright-repl/issues/16))
 - [ ] **Upgrade editor to CodeMirror 6** — Replace plain `<textarea>` in `EditorPane.tsx` with CodeMirror 6 (~30KB gzipped). Gains: syntax highlighting, proper selections, undo/redo, search. Potential custom `.pw` syntax mode later.
-- [ ] **Toolbar icons** — Replace text buttons (Open, Save, Export) with SVG icons in `Toolbar.tsx`, similar to existing sun/moon toggle in `Icons.tsx`.
+- [x] **Toolbar icons** — Replace text buttons (Open, Save, Export) with SVG icons in `Toolbar.tsx`, similar to existing sun/moon toggle in `Icons.tsx`.
 - [ ] **Editor context menu** — Right-click menu in the editor with: Run line, Copy, Export to TypeScript, Copy to clipboard.
 - [ ] **Capture locator** — "Pick element" mode: user clicks on the page, extension captures a Playwright locator string (`getByRole(...)`, `getByText(...)`) via `chrome.scripting.executeScript` overlay, similar to recorder.
 - [ ] **Extract shared `resolveArgs`** — The verify-command translation, text-locator resolution, and run-code auto-wrap logic is duplicated between `extension-server.ts` and `repl.ts`. Extract to a shared `core` utility.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## v0.7.7 — Toolbar Icons
+
+**2026-03-01**
+
+### Improvements
+
+- **Toolbar icons**: Replaced text labels (Open, Save, Record/Stop, Export) with SVG icons for a cleaner, more compact toolbar
+- Added `FolderOpenIcon`, `SaveIcon`, `RecordIcon`, `StopIcon`, `ExportIcon` components
+- Adjusted button padding and centering for icon-only buttons
+
 ## v0.7.6 — Chaining Selectors with >>
 
 **2026-03-01**

--- a/packages/extension/e2e/panel/panel.test.ts
+++ b/packages/extension/e2e/panel/panel.test.ts
@@ -185,9 +185,8 @@ test('record button toggles to Stop when recording starts', async ({ panelPage }
 
   // Click to start recording
   await btn.click();
-  await expect(btn).toContainText('Stop');
-  const hasRecording = await btn.evaluate(el => el.classList.contains('recording'));
-  expect(hasRecording).toBe(true);
+  await expect(btn).toHaveAttribute('title', 'Stop recording');
+  await expect(btn).toHaveClass(/recording/);
 });
 
 test('record button toggles back to Record when stopped', async ({ panelPage }) => {
@@ -204,9 +203,9 @@ test('record button toggles back to Record when stopped', async ({ panelPage }) 
 
   // Start then stop
   await btn.click();
-  await expect(btn).toContainText('Stop');
+  await expect(btn).toHaveAttribute('title', 'Stop recording');
   await btn.click();
-  await expect(btn).toContainText('Record');
+  await expect(btn).toHaveAttribute('title', 'Start Recording');
   const hasRecording = await btn.evaluate(el => el.classList.contains('recording'));
   expect(hasRecording).toBe(false);
 });

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@playwright-repl/extension",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "private": true,
   "description": "Chrome DevTools panel extension for Playwright REPL",
   "type": "module",

--- a/packages/extension/src/panel/components/Icons.tsx
+++ b/packages/extension/src/panel/components/Icons.tsx
@@ -21,3 +21,47 @@ export function MoonIcon({ size = 16 }: { size?: number }) {
     </svg>
   );
 }
+
+export function FolderOpenIcon({ size = 16 }: { size?: number }) {
+  return (
+    <svg viewBox="0 0 24 24" width={size} height={size} stroke="currentColor" fill="none" strokeWidth="2">
+      <path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z" />
+    </svg>
+  );
+}
+
+export function SaveIcon({ size = 16 }: { size?: number }) {
+  return (
+    <svg viewBox="0 0 24 24" width={size} height={size} stroke="currentColor" fill="none" strokeWidth="2">
+      <path d="M19 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11l5 5v11a2 2 0 0 1-2 2z" />
+      <polyline points="17 21 17 13 7 13 7 21" />
+      <polyline points="7 3 7 8 15 8" />
+    </svg>
+  );
+}
+
+export function RecordIcon({ size = 16 }: { size?: number }) {
+  return (
+    <svg viewBox="0 0 24 24" width={size} height={size} stroke="currentColor" fill="currentColor" strokeWidth="2">
+      <circle cx="12" cy="12" r="7" />
+    </svg>
+  );
+}
+
+export function StopIcon({ size = 16 }: { size?: number }) {
+  return (
+    <svg viewBox="0 0 24 24" width={size} height={size} stroke="currentColor" fill="currentColor" strokeWidth="2">
+      <rect x="6" y="6" width="12" height="12" rx="1" />
+    </svg>
+  );
+}
+
+export function ExportIcon({ size = 16 }: { size?: number }) {
+  return (
+    <svg viewBox="0 0 24 24" width={size} height={size} stroke="currentColor" fill="none" strokeWidth="2">
+      <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+      <polyline points="17 8 12 3 7 8" />
+      <line x1="12" y1="3" x2="12" y2="15" />
+    </svg>
+  );
+}

--- a/packages/extension/src/panel/components/Toolbar.tsx
+++ b/packages/extension/src/panel/components/Toolbar.tsx
@@ -5,7 +5,7 @@ import { exportToPlaywright } from '@/lib/converter';
 import { checkHealth, setServerPort } from '@/lib/server';
 import { runAndDispatch } from '@/lib/run';
 import { getServerPort } from '@/lib/server';
-import { SunIcon, MoonIcon } from './Icons';
+import { SunIcon, MoonIcon, FolderOpenIcon, SaveIcon, RecordIcon, StopIcon, ExportIcon } from './Icons';
 
 interface ToolbarProps extends Pick<PanelState, 'editorContent' | 'fileName' | 'stepLine'> {
     dispatch: React.Dispatch<Action>
@@ -200,8 +200,8 @@ function Toolbar({ editorContent, fileName, stepLine, dispatch }: ToolbarProps) 
                     style={{ display: 'none' }}
                     onChange={handleFileChange}
                 />
-                <button id="open-btn" title="Open .pw file" onClick={handleFileOpen}>Open</button>
-                <button id="save-btn" title="Save as .pw file" disabled={!editorContent.trim()} onClick={handleSave}>Save</button>
+                <button id="open-btn" title="Open .pw file" onClick={handleFileOpen}><FolderOpenIcon /></button>
+                <button id="save-btn" title="Save as .pw file" disabled={!editorContent.trim()} onClick={handleSave}><SaveIcon /></button>
                 <span className="w-[1px] h-[18px] bg-(--color-toolbar-sep) mx-1"></span>
                 <button
                     id="record-btn"
@@ -209,11 +209,11 @@ function Toolbar({ editorContent, fileName, stepLine, dispatch }: ToolbarProps) 
                     title={isRecording ? "Stop recording" : "Start Recording"}
                     onClick={handleRecord}
                 >
-                    {isRecording ? '⏹ Stop' : '⏺ Record'}
+                    {isRecording ? <StopIcon /> : <RecordIcon />}
                 </button>
                 <button id="run-btn" title="Run script (Ctrl+Enter)" disabled={!editorContent.trim() || !isConnected} onClick={handleRun}>&#9654;</button>
                 <button id="step-btn" title="Step: run next line" disabled={!editorContent.trim() || !isConnected} onClick={handleStep}>&#9655;</button>
-                <button id="export-btn" title="Export as Playwright test" disabled={!editorContent.trim()} onClick={handleExport}>Export</button>
+                <button id="export-btn" title="Export as Playwright test" disabled={!editorContent.trim()} onClick={handleExport}><ExportIcon /></button>
                 <button onClick={() => setIsDarkMode(prev => !prev)} title={isDarkMode ? 'Switch to light mode' : 'Switch to dark mode'}>
                     {isDarkMode ? <SunIcon /> : <MoonIcon />}
                 </button>

--- a/packages/extension/src/panel/panel.css
+++ b/packages/extension/src/panel/panel.css
@@ -113,10 +113,13 @@ html, body {
   color: var(--text-default);
   border: 1px solid var(--border-button);
   border-radius: 4px;
-  padding: 4px 10px;
+  padding: 4px 6px;
   font-family: inherit;
   font-size: 11px;
   cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
 }
 
 #toolbar button:hover {


### PR DESCRIPTION
## Summary

- Replace text labels (Open, Save, Record/Stop, Export) with stroke-based SVG icons in the extension toolbar
- Add `FolderOpenIcon`, `SaveIcon`, `RecordIcon`, `StopIcon`, `ExportIcon` to `Icons.tsx`
- Adjust button padding (`4px 6px`) and add flexbox centering for icon-only buttons

## Test plan

- [x] All 449 tests pass (`npm test`)
- [x] Extension builds (`npm run build`)
- [ ] Visual: load extension in Chrome, verify icons render in light and dark mode
- [ ] Hover tooltips still display full descriptions

🤖 Generated with [Claude Code](https://claude.com/claude-code)