### PR TITLE
feat: popup window mode and tab switcher (v0.7.15)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## v0.7.15 — Popup Window Mode + Tab Switcher
+
+**2026-03-04**
+
+### Features
+
+- **Popup window mode**: Right-click the extension icon → Options to choose "Side Panel" or "Popup Window". In popup mode, clicking the icon opens a standalone 450×700 popup with the REPL panel attached to the current tab (closes [#34](https://github.com/stevez/playwright-repl/issues/34))
+- **Tab switcher**: Toolbar dropdown lets you re-attach the panel to any open browser tab — works in both side panel and popup modes
+- **Preferences page**: New Options UI (right-click icon → Options) saves the open-as preference via `chrome.storage.local`
+
+### Improvements
+
+- **URL normalization in tab switching**: `selectPageByUrl` strips query params and hash fragments before comparing URLs, fixing mismatches caused by Chrome's internal params (e.g. `?zx=...&no_sw_cr=1`)
+- **`/select-tab` HTTP endpoint**: New `CommandServer` endpoint lets the panel notify the engine when the active tab changes
+
+### Tests
+
+- 7 new unit tests for `Engine.selectPageByUrl` (exact match, query params, trailing slash, hash, multi-page index, no-op)
+- 4 new unit tests for `POST /select-tab` in `CommandServer` (200 response, deduplication, URL change)
+- 5 new browser component tests for the Toolbar tab switcher
+
+---
+
 ## v0.7.14 — Focus Fix + Command Timeout
 
 **2026-03-03**

--- a/README.md
+++ b/README.md
@@ -26,16 +26,16 @@ Key features:
 Both CLI and Extension are frontends to the Engine. Neither directly accesses Chrome.
 
 ```
-┌──────────────┐     ┌──────────────┐
-│   CLI (REPL) │     │  Extension   │
-│  packages/cli│     │  (Side Panel)│
-└──────┬───────┘     └──────┬───────┘
-       │                    │ fetch POST /run
-       │                    ▼
-       │              ┌─────────────┐
-       └──────────────►   Engine    │
-                      │ (in-process)│
-                      └──────┬──────┘
+┌──────────────┐     ┌───────────────────────┐
+│   CLI (REPL) │     │       Extension        │
+│  packages/cli│     │  (Side Panel / Popup)  │
+└──────┬───────┘     └──────────┬─────────────┘
+       │                        │ fetch POST /run
+       │                        ▼
+       │              ┌─────────────────┐
+       └──────────────►     Engine      │
+                      │  (in-process)   │
+                      └──────┬──────────┘
                              │ CDP
                              ▼
                       ┌─────────────┐
@@ -88,12 +88,14 @@ pw> verify-text "1 item left"
 # 1. Start in extension mode (launches Chrome with extension loaded)
 playwright-repl --extension
 
-# 2. Open any website → click the side panel icon → "Playwright REPL" panel
+# 2. Click the extension icon to open the "Playwright REPL" side panel
 
 # 3. Type commands in the panel — same syntax as CLI
 ```
 
-The extension side panel includes a REPL input, script editor, visual recorder, and export to Playwright tests.
+The extension panel includes a REPL input, script editor, visual recorder, and export to Playwright tests.
+
+**Open as popup window:** Right-click the extension icon → **Options** → select "Popup Window". Click the icon and the REPL opens as a standalone 450×700 window attached to the current tab. Use the **tab switcher** in the toolbar to re-attach to a different tab at any time.
 
 ## Install
 
@@ -385,14 +387,17 @@ pw> run-code const u = await page.url(); const t = await page.title(); return {u
 
 ## Extension Features
 
-### Side Panel
+### Side Panel and Popup Window
 
-The extension adds a "Playwright REPL" side panel in Chrome with:
+The extension opens as a Chrome **side panel** by default. To switch to a standalone **popup window**, right-click the extension icon → **Options** and choose "Open as Popup Window". Your preference is saved and applied every time you click the icon.
+
+The panel UI is the same in both modes:
 
 - **REPL input** — type commands at the bottom, results appear in the console pane
 - **Script editor** — write multi-line `.pw` scripts with line numbers, run all or step through
 - **Visual recorder** — click Record, interact with the page, recorded commands appear automatically
 - **Export** — convert `.pw` commands to Playwright TypeScript test code
+- **Tab switcher** — toolbar dropdown lets you re-attach the panel to any open browser tab without reopening
 - **Light/dark themes** — matches your DevTools theme
 
 ### Recording in Extension

--- a/package-lock.json
+++ b/package-lock.json
@@ -4616,10 +4616,10 @@
     },
     "packages/cli": {
       "name": "playwright-repl",
-      "version": "0.7.14",
+      "version": "0.7.15",
       "license": "MIT",
       "dependencies": {
-        "@playwright-repl/core": "0.7.13",
+        "@playwright-repl/core": "0.7.15",
         "playwright": "1.59.0-alpha-2026-02-21"
       },
       "bin": {
@@ -4632,20 +4632,9 @@
         "node": ">=20.0.0"
       }
     },
-    "packages/cli/node_modules/@playwright-repl/core": {
-      "version": "0.7.13",
-      "resolved": "https://registry.npmjs.org/@playwright-repl/core/-/core-0.7.13.tgz",
-      "integrity": "sha512-15KydSTKxXsiuWgm9zIHa4JTKClPApwMwzZhYC8dsAio/j4Xebc+ODdp+b/iOMdHmrVoVHOGYbkWXfbMRvpUhg==",
-      "dependencies": {
-        "minimist": "^1.2.8"
-      },
-      "peerDependencies": {
-        "playwright": ">=1.59.0-alpha-2026-02-21"
-      }
-    },
     "packages/core": {
       "name": "@playwright-repl/core",
-      "version": "0.7.14",
+      "version": "0.7.15",
       "dependencies": {
         "minimist": "^1.2.8"
       },
@@ -4672,7 +4661,7 @@
     },
     "packages/extension": {
       "name": "@playwright-repl/extension",
-      "version": "0.7.14",
+      "version": "0.7.15",
       "dependencies": {
         "@codemirror/autocomplete": "^6.20.1",
         "@codemirror/commands": "^6.10.2",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "playwright-repl",
-  "version": "0.7.14",
+  "version": "0.7.15",
   "description": "Interactive REPL for Playwright browser automation — keyword-driven testing from your terminal",
   "type": "module",
   "bin": {
@@ -38,7 +38,7 @@
     "node": ">=20.0.0"
   },
   "dependencies": {
-    "@playwright-repl/core": "0.7.13",
+    "@playwright-repl/core": "0.7.15",
     "playwright": "1.59.0-alpha-2026-02-21"
   },
   "devDependencies": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@playwright-repl/core",
-  "version": "0.7.14",
+  "version": "0.7.15",
   "type": "module",
   "main": "./dist/index.js",
   "exports": {

--- a/packages/core/src/engine.ts
+++ b/packages/core/src/engine.ts
@@ -275,7 +275,12 @@ export class Engine {
   async selectPageByUrl(targetUrl: string): Promise<void> {
     if (!this._browserContext || !this._backend || !targetUrl) return;
     const pages = this._browserContext.pages();
-    const normalize = (u: string) => u.replace(/\/+$/, '');
+    const normalize = (u: string) => {
+      try {
+        const p = new URL(u);
+        return (p.origin + p.pathname).replace(/\/+$/, '');
+      } catch { return u.replace(/\/+$/, ''); }
+    };
     const target = normalize(targetUrl);
     for (let i = 0; i < pages.length; i++) {
       if (normalize(pages[i].url()) === target) {

--- a/packages/core/src/extension-server.ts
+++ b/packages/core/src/extension-server.ts
@@ -30,6 +30,7 @@ export class CommandServer {
   private _engine: EngineInterface;
   private _server: Server | null = null;
   private _port: number | null = null;
+  private _lastActiveUrl: string | null = null;
 
   constructor(engine: EngineInterface) {
     this._engine = engine;
@@ -79,6 +80,25 @@ export class CommandServer {
       return;
     }
 
+    // Tab selection endpoint — eagerly switches Playwright's active page
+    if (req.method === 'POST' && urlPath === '/select-tab') {
+      try {
+        const body = await readBody(req);
+        const { url } = JSON.parse(body);
+        console.log(`[select-tab] ${url || 'no-url'}`);
+        if (url && url !== this._lastActiveUrl) {
+          await withTimeout(this._engine.selectPageByUrl(url), 5000).catch(() => {});
+          this._lastActiveUrl = url;
+        }
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ ok: true }));
+      } catch {
+        res.writeHead(500);
+        res.end('{}');
+      }
+      return;
+    }
+
     // Panel command endpoint
     if (req.method === 'POST' && urlPath === '/run') {
       try {
@@ -86,9 +106,10 @@ export class CommandServer {
         const { raw, activeTabUrl } = JSON.parse(body);
         console.log(`[server] ${raw} | ${activeTabUrl || 'no-url'}`);
 
-        // Auto-select the tab matching the panel's active tab.
-        if (activeTabUrl) {
+        // Auto-select the tab matching the panel's active tab (only when it changes).
+        if (activeTabUrl && activeTabUrl !== this._lastActiveUrl) {
           await withTimeout(this._engine.selectPageByUrl(activeTabUrl), 5000).catch(() => {});
+          this._lastActiveUrl = activeTabUrl;
         }
 
         let args = parseInput(raw);

--- a/packages/core/test/engine.test.ts
+++ b/packages/core/test/engine.test.ts
@@ -337,6 +337,74 @@ describe('Engine', () => {
     });
   });
 
+  // ─── selectPageByUrl ────────────────────────────────────────────────────
+
+  describe('selectPageByUrl', () => {
+    beforeEach(async () => {
+      mocks.browserContext.pages = vi.fn().mockReturnValue([]);
+      mocks.callTool.mockResolvedValue({ content: [{ type: 'text', text: 'ok' }], isError: false });
+      await engine.start({});
+    });
+
+    it('selects page with exact URL match', async () => {
+      mocks.browserContext.pages.mockReturnValue([
+        { url: () => 'https://example.com' },
+        { url: () => 'https://google.com' },
+      ]);
+      await engine.selectPageByUrl('https://example.com');
+      expect(mocks.callTool).toHaveBeenCalledWith('browser_tabs', { action: 'select', index: 0 });
+    });
+
+    it('strips query params when matching', async () => {
+      mocks.browserContext.pages.mockReturnValue([
+        { url: () => 'https://www.google.com/' },
+      ]);
+      await engine.selectPageByUrl('https://www.google.com/?zx=123&no_sw_cr=1');
+      expect(mocks.callTool).toHaveBeenCalledWith('browser_tabs', { action: 'select', index: 0 });
+    });
+
+    it('strips trailing slash when matching', async () => {
+      mocks.browserContext.pages.mockReturnValue([
+        { url: () => 'https://example.com/' },
+      ]);
+      await engine.selectPageByUrl('https://example.com');
+      expect(mocks.callTool).toHaveBeenCalledWith('browser_tabs', { action: 'select', index: 0 });
+    });
+
+    it('strips hash fragment when matching', async () => {
+      mocks.browserContext.pages.mockReturnValue([
+        { url: () => 'https://example.com/page' },
+      ]);
+      await engine.selectPageByUrl('https://example.com/page#section');
+      expect(mocks.callTool).toHaveBeenCalledWith('browser_tabs', { action: 'select', index: 0 });
+    });
+
+    it('selects the correct index when multiple pages', async () => {
+      mocks.browserContext.pages.mockReturnValue([
+        { url: () => 'https://example.com' },
+        { url: () => 'https://google.com' },
+        { url: () => 'https://github.com' },
+      ]);
+      await engine.selectPageByUrl('https://github.com');
+      expect(mocks.callTool).toHaveBeenCalledWith('browser_tabs', { action: 'select', index: 2 });
+    });
+
+    it('does nothing when URL does not match any page', async () => {
+      mocks.browserContext.pages.mockReturnValue([
+        { url: () => 'https://example.com' },
+      ]);
+      await engine.selectPageByUrl('https://other.com');
+      expect(mocks.callTool).not.toHaveBeenCalled();
+    });
+
+    it('is a no-op when engine not started', async () => {
+      const { deps } = createMockDeps();
+      const fresh = new Engine(deps);
+      await fresh.selectPageByUrl('https://example.com'); // Should not throw
+      expect(mocks.callTool).not.toHaveBeenCalled();
+    });
+  });
+
   // ─── close ──────────────────────────────────────────────────────────────
 
   describe('close', () => {

--- a/packages/core/test/extension-server.test.ts
+++ b/packages/core/test/extension-server.test.ts
@@ -7,6 +7,7 @@ import { CommandServer } from '../src/extension-server.js';
 function createMockEngine() {
   return {
     run: vi.fn().mockResolvedValue({ text: 'Clicked', isError: false }),
+    selectPageByUrl: vi.fn().mockResolvedValue(undefined),
     connected: true,
   };
 }
@@ -125,6 +126,62 @@ describe('CommandServer', () => {
       expect(res.status).toBe(200);
       const data = await res.json();
       expect(data.status).toBe('ok');
+    });
+  });
+
+  describe('POST /select-tab', () => {
+    it('returns 200 with ok: true', async () => {
+      await server.start(0);
+
+      const res = await fetch(`http://127.0.0.1:${server.port}/select-tab`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ url: 'https://example.com' }),
+      });
+
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data.ok).toBe(true);
+    });
+
+    it('calls selectPageByUrl with the given URL', async () => {
+      await server.start(0);
+
+      await fetch(`http://127.0.0.1:${server.port}/select-tab`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ url: 'https://example.com' }),
+      });
+
+      expect(engine.selectPageByUrl).toHaveBeenCalledWith('https://example.com');
+    });
+
+    it('deduplicates — does not call selectPageByUrl twice for the same URL', async () => {
+      await server.start(0);
+      const opts = { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ url: 'https://example.com' }) };
+
+      await fetch(`http://127.0.0.1:${server.port}/select-tab`, opts);
+      await fetch(`http://127.0.0.1:${server.port}/select-tab`, opts);
+
+      expect(engine.selectPageByUrl).toHaveBeenCalledTimes(1);
+    });
+
+    it('calls selectPageByUrl again when URL changes', async () => {
+      await server.start(0);
+
+      await fetch(`http://127.0.0.1:${server.port}/select-tab`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ url: 'https://example.com' }),
+      });
+      await fetch(`http://127.0.0.1:${server.port}/select-tab`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ url: 'https://google.com' }),
+      });
+
+      expect(engine.selectPageByUrl).toHaveBeenCalledTimes(2);
+      expect(engine.selectPageByUrl).toHaveBeenLastCalledWith('https://google.com');
     });
   });
 

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@playwright-repl/extension",
-  "version": "0.7.14",
+  "version": "0.7.15",
   "private": true,
   "description": "Chrome DevTools panel extension for Playwright REPL",
   "type": "module",

--- a/packages/extension/public/manifest.json
+++ b/packages/extension/public/manifest.json
@@ -8,8 +8,14 @@
     "tabs",
     "sidePanel",
     "scripting",
-    "webNavigation"
+    "webNavigation",
+    "storage",
+    "windows"
   ],
+  "options_ui": {
+    "page": "preferences/preferences.html",
+    "open_in_tab": false
+  },
   "host_permissions": [
     "<all_urls>"
   ],

--- a/packages/extension/src/background.ts
+++ b/packages/extension/src/background.ts
@@ -1,6 +1,32 @@
-// background.js — Opens side panel when extension icon is clicked + recording handlers.
-chrome.sidePanel.setPanelBehavior({ openPanelOnActionClick: true });
 
+import { loadSettings } from './panel/lib/settings';
+import type { PwReplSettings } from './panel/lib/settings';
+
+// Disable auto-open so action.onClicked fires (Chrome persists this across reloads)
+chrome.sidePanel.setPanelBehavior({ openPanelOnActionClick: false }).catch(() => {});
+
+let cachedSettings: PwReplSettings = { openAs: 'sidepanel'};
+loadSettings().then(s => cachedSettings = s ).catch(()=> {});
+
+chrome.storage.onChanged.addListener((changes, area) => {
+  if (area === 'local' && changes.openAs) {
+    cachedSettings.openAs = changes.openAs.newValue;
+  }
+});
+
+chrome.action.onClicked.addListener(async (tab) => {
+  if (cachedSettings.openAs === 'sidepanel') {
+    await chrome.sidePanel.open({ windowId: tab.windowId! });
+  } else {
+    const tabId = tab.id;
+    await chrome.windows.create({
+      url: chrome.runtime.getURL('panel/panel.html') + (tabId ? `?tabId=${tabId}` : ''),
+      type: 'popup',
+      width: 450,
+      height: 700,
+    });
+  }
+});
 // ─── Recording State ───────────────────────────────────────────────────────
 
 let recordingTabId: number | null = null;

--- a/packages/extension/src/panel/App.tsx
+++ b/packages/extension/src/panel/App.tsx
@@ -1,4 +1,4 @@
-import { useReducer, useRef, useEffect } from 'react'
+import { useReducer, useRef, useEffect, useState } from 'react'
 import Toolbar from './components/Toolbar'
 import CodeMirrorEditorPane from "./components/CodeMirrorEditorPane"
 import Splitter from './components/Splitter'
@@ -6,23 +6,56 @@ import ConsolePane from './components/ConsolePane'
 import CommandInput, { CommandInputHandle } from './components/CommandInput'
 import { panelReducer, initialState } from './reducer'
 import { runAndDispatch, setTabUrl } from './lib/run'
+import { selectTab } from './lib/server'
 
 function App() {
   const [state, dispatch ] = useReducer(panelReducer, initialState)
   const editorPaneRef = useRef<HTMLDivElement>(null)
   const cmdInputRef = useRef<CommandInputHandle>(null)
+  const [attachedTabUrl, setAttachedTabUrl] = useState<string | undefined>();
 
   useEffect(() => {
     if (!chrome.tabs?.onActivated) return;
+    // In popup mode (?tabId=X), stay attached to the original tab — don't follow Chrome tab switches.
+    const isPopup = new URLSearchParams(window.location.search).has('tabId');
+    if (isPopup) return;
     const onActivated = (info: chrome.tabs.TabActiveInfo) => {
-      chrome.tabs.get(info.tabId, (tab) => setTabUrl(tab?.url));
+      chrome.tabs.get(info.tabId, (tab) => {
+        const url = tab?.url;
+        if (!url || url.startsWith('chrome://') || url.startsWith('chrome-extension://') || url.startsWith('about:')) return;
+        setTabUrl(url);
+        setAttachedTabUrl(url);
+        selectTab(url);
+      });
     };
     chrome.tabs.onActivated.addListener(onActivated);
     return () => chrome.tabs.onActivated.removeListener(onActivated);
   }, []);
 
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const tabId = params.get('tabId');
+    if (tabId) {
+      // Popup mode — attach to the tab passed in the URL
+      chrome.tabs.get(Number(tabId), (tab) => {
+        if (chrome.runtime.lastError || !tab?.url) return;
+        setTabUrl(tab.url);
+        setAttachedTabUrl(tab.url);
+      });
+    } else {
+      // Side panel mode — initialize from the currently active tab
+      chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
+        const url = tabs[0]?.url;
+        if (!url || url.startsWith('chrome://') || url.startsWith('chrome-extension://') || url.startsWith('about:')) return;
+        setTabUrl(url);
+        setAttachedTabUrl(url);
+      });
+    }
+  }, []);
+
   async function handleSubmit(command: string) {
     await runAndDispatch(command, dispatch);
+    window.focus();
     cmdInputRef.current?.focus();
   }
 
@@ -34,6 +67,8 @@ function App() {
         fileName={state.fileName}
         stepLine={state.stepLine}
         dispatch={dispatch}
+        attachedTabUrl={attachedTabUrl}
+        onTabChange={(url: string) => { setTabUrl(url); setAttachedTabUrl(url); selectTab(url).then(() => window.focus()); }}
       />
 
       {/* Editor pane */}

--- a/packages/extension/src/panel/components/Icons.tsx
+++ b/packages/extension/src/panel/components/Icons.tsx
@@ -65,3 +65,13 @@ export function ExportIcon({ size = 16 }: { size?: number }) {
     </svg>
   );
 }
+
+export function TabsIcon() {
+  return (
+    <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
+      <rect x="1" y="4" width="14" height="10" rx="1.5"/>
+      <path d="M1 7h14"/>
+      <rect x="3" y="1" width="6" height="4" rx="1"/>
+    </svg>
+  );
+}

--- a/packages/extension/src/panel/components/Toolbar.tsx
+++ b/packages/extension/src/panel/components/Toolbar.tsx
@@ -8,10 +8,12 @@ import { getServerPort } from '@/lib/server';
 import { SunIcon, MoonIcon, FolderOpenIcon, SaveIcon, RecordIcon, StopIcon, ExportIcon } from './Icons';
 
 interface ToolbarProps extends Pick<PanelState, 'editorContent' | 'fileName' | 'stepLine'> {
-    dispatch: React.Dispatch<Action>
+    dispatch: React.Dispatch<Action>,
+    attachedTabUrl: string | undefined,
+    onTabChange: (url: string) => void,
 };
 
-function Toolbar({ editorContent, fileName, stepLine, dispatch }: ToolbarProps) {
+function Toolbar({ editorContent, fileName, stepLine, dispatch, attachedTabUrl, onTabChange }: ToolbarProps) {
     const fileInputRef = useRef<HTMLInputElement>(null);
     const [isRecording, setIsRecording] = useState(false);
     const [isConnected, setIsConnected] = useState(false);
@@ -21,6 +23,19 @@ function Toolbar({ editorContent, fileName, stepLine, dispatch }: ToolbarProps) 
     const [isDarkMode, setIsDarkMode] = useState(()=> localStorage.getItem("theme") === 'dark');
 
     const lines = useMemo(() => editorContent.split('\n'), [editorContent]);
+;
+    const [availableTabs, setAvailableTabs] = useState<chrome.tabs.Tab[]>([]);
+
+    async function loadTabs() {
+        if (!chrome.tabs?.query) return;
+        const tabs = await chrome.tabs.query({});
+        setAvailableTabs(tabs.filter(t =>
+            t?.url &&
+            !t.url.startsWith('chrome://') &&
+            !t.url.startsWith('chrome-extension://') &&
+            !t.url.startsWith('about:')
+        ));
+    }
 
     function handleFileChange(event: React.ChangeEvent<HTMLInputElement>) {
         const file = event.target.files?.[0];
@@ -195,6 +210,10 @@ function Toolbar({ editorContent, fileName, stepLine, dispatch }: ToolbarProps) 
         localStorage.setItem('theme', isDarkMode ? 'dark' : 'light');
     }, [isDarkMode]);
 
+    useEffect(() => {
+        loadTabs();
+    }, []);
+
     return (
         <div id="toolbar" className="flex flex-wrap gap-1 justify-between items-center py-1 px-2 bg-(--bg-toolbar) border-b border-solid border-(--border-primary) shrink-0">
             <div id="toolbar-left" className="flex flex-wrap gap-1 items-center">
@@ -225,6 +244,16 @@ function Toolbar({ editorContent, fileName, stepLine, dispatch }: ToolbarProps) 
                 </button>
             </div>
             <div id="toolbar-right" className="flex items-center">
+                <select
+                    value={attachedTabUrl ?? ''}
+                    title="Switch tab"
+                    onFocus={loadTabs}
+                    onChange={e => onTabChange(e.target.value)}
+                >
+                    {availableTabs.map(tab => (
+                        <option key={tab.id} value={tab.url}>{new URL(tab.url!).hostname}</option>
+                    ))}
+                </select>
                 <span id="file-info" className="text-(--text-dim) text-[11px]">{fileName}</span>
                 <span className="w-[1px] h-[18px] bg-(--color-toolbar-sep) mx-1"></span>
                 <span

--- a/packages/extension/src/panel/lib/server.ts
+++ b/packages/extension/src/panel/lib/server.ts
@@ -39,3 +39,13 @@ export async function checkHealth(): Promise<{status: string, version: string, b
     const res = await fetch(`${getServerUrl()}/health`);
     return res.json();
 }
+
+export async function selectTab(url: string): Promise<void> {
+    console.log('[selectTab] sending', url);
+    const res = await fetch(`${getServerUrl()}/select-tab`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ url }),
+    }).catch((e) => { console.error('[selectTab] fetch failed', e); return null; });
+    console.log('[selectTab] response', res?.status);
+}

--- a/packages/extension/src/panel/lib/settings.ts
+++ b/packages/extension/src/panel/lib/settings.ts
@@ -1,0 +1,14 @@
+export type PwReplSettings = {
+    openAs: 'sidepanel' | 'popup'
+};
+
+const DEFAULT: PwReplSettings = { openAs: 'sidepanel' };
+
+export async function loadSettings(): Promise<PwReplSettings> {
+    const stored = await chrome.storage.local.get(['openAs']) as Partial<PwReplSettings>;
+    return { ...DEFAULT, ...stored };
+}
+
+export async function storeSettings(s: PwReplSettings): Promise<void> {
+    await chrome.storage.local.set(s);
+}

--- a/packages/extension/src/preferences/PreferencesForm.tsx
+++ b/packages/extension/src/preferences/PreferencesForm.tsx
@@ -1,0 +1,47 @@
+import { useState, useEffect } from 'react';
+import { loadSettings, storeSettings } from '../panel/lib/settings';
+import type { PwReplSettings } from '../panel/lib/settings';
+
+export default function PreferencesForm() {
+  const [settings, setSettings] = useState<PwReplSettings>({ openAs: 'sidepanel' });
+
+  useEffect(() => {
+    loadSettings().then(setSettings);
+  }, []);
+
+  function handleChange(openAs: PwReplSettings['openAs']) {
+    const next = { ...settings, openAs };
+    setSettings(next);
+    storeSettings(next);
+  }
+
+  return (
+    <form style={{ fontFamily: 'system-ui, sans-serif', padding: '24px', maxWidth: '400px' }}>
+      <h2 style={{ marginTop: 0 }}>Playwright REPL Preferences</h2>
+      <fieldset style={{ border: 'none', padding: 0, margin: 0 }}>
+        <legend style={{ fontWeight: 600, marginBottom: '12px' }}>Open REPL as:</legend>
+        <label style={{ display: 'flex', alignItems: 'center', gap: '8px', marginBottom: '8px', cursor: 'pointer' }}>
+          <input
+            type="radio"
+            name="openAs"
+            value="sidepanel"
+            checked={settings.openAs === 'sidepanel'}
+            onChange={() => handleChange('sidepanel')}
+          />
+          Side Panel (default)
+        </label>
+        <label style={{ display: 'flex', alignItems: 'center', gap: '8px', cursor: 'pointer' }}>
+          <input
+            type="radio"
+            name="openAs"
+            value="popup"
+            checked={settings.openAs === 'popup'}
+            onChange={() => handleChange('popup')}
+          />
+          Popup Window
+        </label>
+      </fieldset>
+      <p style={{ marginTop: '16px', fontSize: '12px', color: '#888' }}>Saved automatically.</p>
+    </form>
+  );
+}

--- a/packages/extension/src/preferences/preferences.html
+++ b/packages/extension/src/preferences/preferences.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title>Playwright REPL - Preferences</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="preferences.tsx"></script>
+  </body>
+</html>

--- a/packages/extension/src/preferences/preferences.tsx
+++ b/packages/extension/src/preferences/preferences.tsx
@@ -1,0 +1,6 @@
+import ReactDOM from 'react-dom/client';
+import PreferencesForm from './PreferencesForm';
+
+ReactDOM.createRoot(document.querySelector('#root')!).render(
+    <PreferencesForm />
+);

--- a/packages/extension/test/components/Toolbar.browser.test.tsx
+++ b/packages/extension/test/components/Toolbar.browser.test.tsx
@@ -821,9 +821,113 @@ test('recorded session', async ({ page }) => {
     await expect.element(screen.getByText(':6781')).toBeInTheDocument();
   });
 
+  // ─── Tab switcher ────────────────────────────────────────────────────────
 
+  describe('tab switcher', () => {
+    const mockTabs = [
+      { id: 1, url: 'https://example.com', title: 'Example' },
+      { id: 2, url: 'https://google.com', title: 'Google' },
+    ];
 
+    beforeEach(() => {
+      (window.chrome.tabs.query as ReturnType<typeof vi.fn>).mockResolvedValue(mockTabs);
+    });
 
+    it('renders a tab select element', async () => {
+      const screen = await render(<Toolbar
+        editorContent=''
+        fileName=''
+        stepLine={-1}
+        dispatch={vi.fn()}
+        attachedTabUrl={undefined}
+        onTabChange={vi.fn()}
+      />);
+      const select = screen.container.querySelector('select[title="Switch tab"]');
+      expect(select).not.toBeNull();
+    });
+
+    it('shows attachedTabUrl as the selected value', async () => {
+      const screen = await render(<Toolbar
+        editorContent=''
+        fileName=''
+        stepLine={-1}
+        dispatch={vi.fn()}
+        attachedTabUrl='https://example.com'
+        onTabChange={vi.fn()}
+      />);
+      const select = screen.container.querySelector('select[title="Switch tab"]') as HTMLSelectElement;
+      expect(select.value).toBe('https://example.com');
+    });
+
+    it('loads tabs from chrome.tabs.query on focus', async () => {
+      const screen = await render(<Toolbar
+        editorContent=''
+        fileName=''
+        stepLine={-1}
+        dispatch={vi.fn()}
+        attachedTabUrl={undefined}
+        onTabChange={vi.fn()}
+      />);
+      const select = screen.container.querySelector('select[title="Switch tab"]') as HTMLSelectElement;
+      select.dispatchEvent(new FocusEvent('focus', { bubbles: true }));
+
+      await vi.waitFor(() => {
+        expect(window.chrome.tabs.query).toHaveBeenCalled();
+        const options = select.querySelectorAll('option');
+        expect(options.length).toBe(2);
+      });
+    });
+
+    it('calls onTabChange with the selected URL', async () => {
+      const onTabChange = vi.fn();
+      const screen = await render(<Toolbar
+        editorContent=''
+        fileName=''
+        stepLine={-1}
+        dispatch={vi.fn()}
+        attachedTabUrl='https://example.com'
+        onTabChange={onTabChange}
+      />);
+
+      // Focus first to load tabs
+      const select = screen.container.querySelector('select[title="Switch tab"]') as HTMLSelectElement;
+      select.dispatchEvent(new FocusEvent('focus', { bubbles: true }));
+
+      await vi.waitFor(() => {
+        expect(select.querySelectorAll('option').length).toBe(2);
+      });
+
+      await userEvent.selectOptions(select, 'https://google.com');
+      expect(onTabChange).toHaveBeenCalledWith('https://google.com');
+    });
+
+    it('filters out chrome:// and chrome-extension:// tabs', async () => {
+      (window.chrome.tabs.query as ReturnType<typeof vi.fn>).mockResolvedValue([
+        { id: 1, url: 'https://example.com', title: 'Example' },
+        { id: 2, url: 'chrome://newtab/', title: 'New Tab' },
+        { id: 3, url: 'chrome-extension://abc/panel.html', title: 'Panel' },
+        { id: 4, url: 'about:blank', title: 'Blank' },
+      ]);
+
+      const screen = await render(<Toolbar
+        editorContent=''
+        fileName=''
+        stepLine={-1}
+        dispatch={vi.fn()}
+        attachedTabUrl={undefined}
+        onTabChange={vi.fn()}
+      />);
+
+      const select = screen.container.querySelector('select[title="Switch tab"]') as HTMLSelectElement;
+      select.dispatchEvent(new FocusEvent('focus', { bubbles: true }));
+
+      await vi.waitFor(() => {
+        const options = select.querySelectorAll('option');
+        expect(options.length).toBe(1);
+        expect((options[0] as HTMLOptionElement).value).toBe('https://example.com');
+      });
+    });
+  });
 
 
 })

--- a/packages/extension/test/setup.ts
+++ b/packages/extension/test/setup.ts
@@ -13,7 +13,15 @@ if (!globalThis.chrome.scripting) {
 // vitest-chrome doesn't include chrome.sidePanel — add it manually
 if (!globalThis.chrome.sidePanel) {
   (globalThis.chrome as any).sidePanel = {
-    setPanelBehavior: () => {},
+    setPanelBehavior: () => Promise.resolve(),
+    open: () => Promise.resolve(),
+  };
+}
+
+// vitest-chrome doesn't include chrome.action — add it manually
+if (!globalThis.chrome.action) {
+  (globalThis.chrome as any).action = {
+    onClicked: { addListener: () => {} },
   };
 }
 

--- a/packages/extension/vite.config.ts
+++ b/packages/extension/vite.config.ts
@@ -22,6 +22,7 @@ export default defineConfig({
         background: resolve(__dirname, "src/background.ts"),
         "content/recorder": resolve(__dirname, "src/content/recorder.ts"),
         "panel/panel": resolve(__dirname, "src/panel/panel.html"),
+        "preferences/preferences": resolve(__dirname, "src/preferences/preferences.html"),
       },
       output: {
         entryFileNames: "[name].js",

--- a/packages/extension/vitest.config.ts
+++ b/packages/extension/vitest.config.ts
@@ -19,7 +19,7 @@ export default defineConfig({
     coverage: {
       enabled: true,
       provider: "v8",
-      include: ["src/**/*.ts"],
+      include: ["src/**/*.{ts,tsx}"],
       reporter: ["text", "html"],
     },
   },


### PR DESCRIPTION
## Summary

- **Popup window mode**: Right-click the extension icon → Options to choose "Side Panel" or "Popup Window". In popup mode, clicking the icon opens a standalone 450×700 popup attached to the current tab
- **Tab switcher**: Toolbar dropdown lets you re-attach the panel to any open browser tab without reopening — works in both side panel and popup modes
- **Preferences page**: New Options UI saves the open-as preference via `chrome.storage.local`

## Changes

- `settings.ts` — `loadSettings`/`storeSettings` using `chrome.storage.local`
- `background.ts` — reads saved preference on icon click, opens side panel or popup accordingly; pre-loads settings at startup
- `preferences/` — new Options page (React) with radio/select for open-as preference
- `App.tsx` — reads `?tabId` from URL in popup mode to attach to the correct tab
- `Toolbar.tsx` — tab switcher `<select>` dropdown, filters out `chrome://` / `about:` tabs
- `manifest.json` — adds `"storage"` permission and `"options_ui"` entry
- `vite.config.ts` — adds `preferences/preferences` entry point
- `engine.ts` / `extension-server.ts` — `selectPageByUrl` + `/select-tab` endpoint; URL normalization strips query params and hash before comparing

## Tests

- 7 unit tests for `Engine.selectPageByUrl` (exact match, query params, trailing slash, hash, multi-page index, no-op cases)
- 4 unit tests for `POST /select-tab` in `CommandServer` (200 response, calls engine, deduplication, URL change)
- 5 browser component tests for Toolbar tab switcher (renders select, shows attached URL, loads tabs on focus, calls onTabChange, filters internal tabs)

## Test plan

- [ ] Load unpacked extension in Chrome → right-click icon → Options → verify preferences page opens inline
- [ ] Set "Open as Popup Window" → click icon → verify popup opens with `?tabId=X`
- [ ] Set "Open as Side Panel" → click icon → verify side panel opens
- [ ] In popup: use tab switcher dropdown → pick a different tab → verify URL and snapshot reflect new tab
- [ ] `npm test` passes in core and extension
- [ ] E2E tests pass (`npx playwright test` in extension)

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)