### PR TITLE
feat: record tab-select when switching tabs during recording (v0.7.16)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## v0.7.16 — Tab Switch Recording
+
+**2026-03-04**
+
+### Features
+
+- **Tab switch recording**: Switching Chrome tabs during a recording session now automatically records a `tab-select N` command. The panel resolves the Playwright tab index by calling `tab-list` on the server (which sets the tab as current), parsing the `(current)` marker, and appending the command to the editor.
+
+### Tests
+
+- 3 new unit tests for `onActivated` handler in `background.test.ts` (sends `pw-tab-activated` with URL, skips when not recording, skips when tab has no URL)
+- 5 new browser component tests for `pw-tab-activated` handling in `Toolbar.browser.test.tsx` (calls `tab-list` with correct URL, records `tab-select 0`, records `tab-select 2`, no-op when no `(current)` marker, no-op on server error)
+
+---
+
 ## v0.7.15 — Popup Window Mode + Tab Switcher
 
 **2026-03-04**

--- a/package-lock.json
+++ b/package-lock.json
@@ -4616,10 +4616,10 @@
     },
     "packages/cli": {
       "name": "playwright-repl",
-      "version": "0.7.15",
+      "version": "0.7.16",
       "license": "MIT",
       "dependencies": {
-        "@playwright-repl/core": "0.7.15",
+        "@playwright-repl/core": "0.7.16",
         "playwright": "1.59.0-alpha-2026-02-21"
       },
       "bin": {
@@ -4634,7 +4634,7 @@
     },
     "packages/core": {
       "name": "@playwright-repl/core",
-      "version": "0.7.15",
+      "version": "0.7.16",
       "dependencies": {
         "minimist": "^1.2.8"
       },
@@ -4661,7 +4661,7 @@
     },
     "packages/extension": {
       "name": "@playwright-repl/extension",
-      "version": "0.7.15",
+      "version": "0.7.16",
       "dependencies": {
         "@codemirror/autocomplete": "^6.20.1",
         "@codemirror/commands": "^6.10.2",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "playwright-repl",
-  "version": "0.7.15",
+  "version": "0.7.16",
   "description": "Interactive REPL for Playwright browser automation — keyword-driven testing from your terminal",
   "type": "module",
   "bin": {
@@ -38,7 +38,7 @@
     "node": ">=20.0.0"
   },
   "dependencies": {
-    "@playwright-repl/core": "0.7.15",
+    "@playwright-repl/core": "0.7.16",
     "playwright": "1.59.0-alpha-2026-02-21"
   },
   "devDependencies": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@playwright-repl/core",
-  "version": "0.7.15",
+  "version": "0.7.16",
   "type": "module",
   "main": "./dist/index.js",
   "exports": {

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@playwright-repl/extension",
-  "version": "0.7.15",
+  "version": "0.7.16",
   "private": true,
   "description": "Chrome DevTools panel extension for Playwright REPL",
   "type": "module",

--- a/packages/extension/public/manifest.json
+++ b/packages/extension/public/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Playwright REPL",
-  "version": "0.7.0",
+  "version": "0.7.16",
   "description": "A side panel for Playwright-style browser automation commands.",
   "permissions": [
     "activeTab",

--- a/packages/extension/src/background.ts
+++ b/packages/extension/src/background.ts
@@ -85,13 +85,10 @@ chrome.tabs.onActivated.addListener((activeInfo: chrome.tabs.TabActiveInfo) => {
   if (recordingTabId === null) return;
   recordingTabId = activeInfo.tabId;
   injectRecorder(activeInfo.tabId).catch(() => {});
-  // Notify panel about tab switch
+  // Notify panel to record tab-select N (panel resolves index via tab-list)
   chrome.tabs.get(activeInfo.tabId, (tab) => {
-    if (chrome.runtime.lastError) return;
-    chrome.runtime.sendMessage({
-      type: "pw-recorded-command",
-      command: "# tab: " + (tab.title || tab.url || "unknown"),
-    }).catch(() => {});
+    if (chrome.runtime.lastError || !tab.url) return;
+    chrome.runtime.sendMessage({ type: "pw-tab-activated", url: tab.url }).catch(() => {});
   });
 });
 

--- a/packages/extension/src/panel/components/Toolbar.tsx
+++ b/packages/extension/src/panel/components/Toolbar.tsx
@@ -2,18 +2,18 @@ import { useRef, useMemo, useState, useEffect } from 'react';
 import type { PanelState, Action } from "@/reducer";
 import type { RecordedMessage } from '@/types';
 import { exportToPlaywright } from '@/lib/converter';
-import { checkHealth, setServerPort } from '@/lib/server';
+import { checkHealth, setServerPort, executeCommand } from '@/lib/server';
 import { runAndDispatch } from '@/lib/run';
 import { getServerPort } from '@/lib/server';
 import { SunIcon, MoonIcon, FolderOpenIcon, SaveIcon, RecordIcon, StopIcon, ExportIcon } from './Icons';
 
 interface ToolbarProps extends Pick<PanelState, 'editorContent' | 'fileName' | 'stepLine'> {
     dispatch: React.Dispatch<Action>,
-    attachedTabUrl: string | undefined,
-    onTabChange: (url: string) => void,
+    attachedTabUrl?: string,
+    onTabChange?: (url: string) => void,
 };
 
-function Toolbar({ editorContent, fileName, stepLine, dispatch, attachedTabUrl, onTabChange }: ToolbarProps) {
+function Toolbar({ editorContent, fileName, stepLine, dispatch, attachedTabUrl, onTabChange = () => {} }: ToolbarProps) {
     const fileInputRef = useRef<HTMLInputElement>(null);
     const [isRecording, setIsRecording] = useState(false);
     const [isConnected, setIsConnected] = useState(false);
@@ -160,6 +160,18 @@ function Toolbar({ editorContent, fileName, stepLine, dispatch, attachedTabUrl, 
             if (msg.type === "pw-recorded-command" && msg.command) {
                 dispatch({ type: 'ADD_LINE', line: { text: msg.command, type: 'command' } });
                 dispatch({ type: 'APPEND_EDITOR_CONTENT', command: msg.command });
+            }
+            if (msg.type === "pw-tab-activated" && msg.url) {
+                // Pass the new tab URL as activeTabUrl so the server auto-selects it in Playwright,
+                // then parse the (current) index from tab-list output to record tab-select N
+                executeCommand('tab-list', msg.url).then(result => {
+                    const match = result.text.match(/^- (\d+): \(current\)/m);
+                    if (match) {
+                        const cmd = `tab-select ${match[1]}`;
+                        dispatch({ type: 'ADD_LINE', line: { text: cmd, type: 'command' } });
+                        dispatch({ type: 'APPEND_EDITOR_CONTENT', command: cmd });
+                    }
+                }).catch(() => {});
             }
         };
         if (!chrome.runtime?.onMessage) return;

--- a/packages/extension/src/panel/types.ts
+++ b/packages/extension/src/panel/types.ts
@@ -10,4 +10,6 @@ export type CommandResult = {
     image?: string
 }
 
-export type RecordedMessage = { type: 'pw-recorded-command'; command: string };
+export type RecordedMessage =
+    | { type: 'pw-recorded-command'; command: string }
+    | { type: 'pw-tab-activated'; url: string };

--- a/packages/extension/test/background.test.ts
+++ b/packages/extension/test/background.test.ts
@@ -360,4 +360,54 @@ describe("background.js recording handlers", () => {
       files: ["content/recorder.js"],
     });
   });
+
+  // ─── onActivated (tab switch during recording) ─────────────────────────
+
+  describe("onActivated (tab switch during recording)", () => {
+    it("sends pw-tab-activated with URL when recording is active", async () => {
+      await startRecording(42);
+
+      (chrome.tabs as any).get = vi.fn().mockImplementation((_id: number, cb: (tab: chrome.tabs.Tab) => void) => {
+        cb({ id: 43, url: "https://google.com" } as chrome.tabs.Tab);
+      });
+
+      const onActivatedListener = ((chrome.tabs.onActivated as any).addListener as Mock).mock.calls[0][0];
+      onActivatedListener({ tabId: 43 });
+
+      await vi.waitFor(() => {
+        expect(rtSendMessage).toHaveBeenCalledWith({ type: "pw-tab-activated", url: "https://google.com" });
+      });
+    });
+
+    it("does nothing when not recording", async () => {
+      // recordingTabId is null — startRecording not called
+      (chrome.tabs as any).get = vi.fn().mockImplementation((_id: number, cb: (tab: chrome.tabs.Tab) => void) => {
+        cb({ id: 43, url: "https://google.com" } as chrome.tabs.Tab);
+      });
+
+      const onActivatedListener = ((chrome.tabs.onActivated as any).addListener as Mock).mock.calls[0][0];
+      onActivatedListener({ tabId: 43 });
+
+      await vi.advanceTimersByTimeAsync(50);
+      expect(rtSendMessage).not.toHaveBeenCalledWith(
+        expect.objectContaining({ type: "pw-tab-activated" }),
+      );
+    });
+
+    it("skips sending when tab has no URL", async () => {
+      await startRecording(42);
+
+      (chrome.tabs as any).get = vi.fn().mockImplementation((_id: number, cb: (tab: chrome.tabs.Tab) => void) => {
+        cb({ id: 43 } as chrome.tabs.Tab);
+      });
+
+      const onActivatedListener = ((chrome.tabs.onActivated as any).addListener as Mock).mock.calls[0][0];
+      onActivatedListener({ tabId: 43 });
+
+      await vi.advanceTimersByTimeAsync(50);
+      expect(rtSendMessage).not.toHaveBeenCalledWith(
+        expect.objectContaining({ type: "pw-tab-activated" }),
+      );
+    });
+  });
 });

--- a/packages/extension/test/components/Toolbar.browser.test.tsx
+++ b/packages/extension/test/components/Toolbar.browser.test.tsx
@@ -929,5 +929,94 @@ test('recorded session', async ({ page }) => {
     });
   });
 
+  // ─── Tab recording (pw-tab-activated) ───────────────────────────────────
+
+  describe('tab recording', () => {
+    it('calls executeCommand with tab-list and the activated tab URL', async () => {
+      vi.mocked(executeCommand).mockResolvedValue({ text: '- 0: (current) [Google](https://google.com)', isError: false });
+
+      const dispatch = vi.fn();
+      await render(<Toolbar editorContent='' fileName='' stepLine={-1} dispatch={dispatch} />);
+
+      const listener = (window.chrome.runtime.onMessage.addListener as ReturnType<typeof vi.fn>).mock.calls[0][0];
+      listener({ type: 'pw-tab-activated', url: 'https://google.com' });
+
+      await vi.waitFor(() => {
+        expect(executeCommand).toHaveBeenCalledWith('tab-list', 'https://google.com');
+      });
+    });
+
+    it('records tab-select 0 when current tab is at index 0', async () => {
+      vi.mocked(executeCommand).mockResolvedValue({ text: '- 0: (current) [Google](https://google.com)', isError: false });
+
+      const dispatch = vi.fn();
+      await render(<Toolbar editorContent='' fileName='' stepLine={-1} dispatch={dispatch} />);
+
+      const listener = (window.chrome.runtime.onMessage.addListener as ReturnType<typeof vi.fn>).mock.calls[0][0];
+      listener({ type: 'pw-tab-activated', url: 'https://google.com' });
+
+      await vi.waitFor(() => {
+        expect(dispatch).toHaveBeenCalledWith({ type: 'ADD_LINE', line: { text: 'tab-select 0', type: 'command' } });
+        expect(dispatch).toHaveBeenCalledWith({ type: 'APPEND_EDITOR_CONTENT', command: 'tab-select 0' });
+      });
+    });
+
+    it('records tab-select 2 when current tab is at index 2', async () => {
+      const tabListText = [
+        '- 0:  [Tab 1](https://tab1.com)',
+        '- 1:  [Tab 2](https://tab2.com)',
+        '- 2: (current) [Tab 3](https://tab3.com)',
+      ].join('\n');
+
+      vi.mocked(executeCommand).mockResolvedValue({ text: tabListText, isError: false });
+
+      const dispatch = vi.fn();
+      await render(<Toolbar editorContent='' fileName='' stepLine={-1} dispatch={dispatch} />);
+
+      const listener = (window.chrome.runtime.onMessage.addListener as ReturnType<typeof vi.fn>).mock.calls[0][0];
+      listener({ type: 'pw-tab-activated', url: 'https://tab3.com' });
+
+      await vi.waitFor(() => {
+        expect(dispatch).toHaveBeenCalledWith({ type: 'ADD_LINE', line: { text: 'tab-select 2', type: 'command' } });
+        expect(dispatch).toHaveBeenCalledWith({ type: 'APPEND_EDITOR_CONTENT', command: 'tab-select 2' });
+      });
+    });
+
+    it('does not record when tab-list output has no (current) marker', async () => {
+      vi.mocked(executeCommand).mockResolvedValue({ text: '- 0:  [Tab 1](https://tab1.com)', isError: false });
+
+      const dispatch = vi.fn();
+      await render(<Toolbar editorContent='' fileName='' stepLine={-1} dispatch={dispatch} />);
+
+      const listener = (window.chrome.runtime.onMessage.addListener as ReturnType<typeof vi.fn>).mock.calls[0][0];
+      dispatch.mockClear();
+      listener({ type: 'pw-tab-activated', url: 'https://tab1.com' });
+
+      // Wait for the executeCommand promise to resolve
+      await vi.waitFor(() => {
+        expect(executeCommand).toHaveBeenCalledWith('tab-list', 'https://tab1.com');
+      });
+      expect(dispatch).not.toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'APPEND_EDITOR_CONTENT' }),
+      );
+    });
+
+    it('does not throw when executeCommand rejects', async () => {
+      vi.mocked(executeCommand).mockRejectedValue(new Error('Server error'));
+
+      const dispatch = vi.fn();
+      await render(<Toolbar editorContent='' fileName='' stepLine={-1} dispatch={dispatch} />);
+
+      const listener = (window.chrome.runtime.onMessage.addListener as ReturnType<typeof vi.fn>).mock.calls[0][0];
+      dispatch.mockClear();
+
+      expect(() => listener({ type: 'pw-tab-activated', url: 'https://example.com' })).not.toThrow();
+
+      await new Promise(r => setTimeout(r, 50));
+      expect(dispatch).not.toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'APPEND_EDITOR_CONTENT' }),
+      );
+    });
+  });
 
 })


### PR DESCRIPTION
## Summary

- When the user switches Chrome tabs during a recording session, the panel now automatically records a `tab-select N` command
- Background sends `pw-tab-activated` with the new tab URL; Toolbar resolves the Playwright index by calling `tab-list` (which also switches Playwright's active tab via `activeTabUrl`), parses the `(current)` marker, and appends the command to the editor
- `RecordedMessage` union type in `types.ts` extended with `pw-tab-activated`
- Bumped all packages to v0.7.16 and synced `manifest.json` version

## Test plan

- [x] 3 new unit tests in `background.test.ts` — `onActivated` sends `pw-tab-activated` with URL, skips when not recording, skips when tab has no URL
- [x] 5 new browser component tests in `Toolbar.browser.test.tsx` — calls `tab-list` with correct URL, records `tab-select 0`, records `tab-select 2`, no-op when no `(current)` marker, no-op on server error
- [x] Manual: start recording, switch tabs in Chrome, verify `tab-select N` appears in editor

🤖 Generated with [Claude Code](https://claude.com/claude-code)