### PR TITLE
fix: upgrade to @playwright-repl/playwright-crx@0.15.1 (SW fix)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ packages/*/dist/
 *.tsbuildinfo
 test-results/
 __screenshots__/
+.yalc/
+yalc.lock

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -26,6 +26,9 @@
 - [ ] **Fix skipped autocomplete keyboard test** — `test/components/CommandInput.browser.test.tsx`: "should accept autocomplete item on Enter when dropdown is open" is skipped. After `waitForVisible`, subsequent `userEvent.keyboard` events don't reach CM6's autocomplete handler (CDP focus vs JS focus mismatch). Needs investigation into vitest-browser keyboard dispatch and CM6 completion state.
 - [ ] **Improve test coverage after playwright-crx migration** — Coverage dropped significantly after migrating from HTTP server to playwright-crx: `commands.ts` and `page-scripts.ts` are at 0%, `App.tsx` at 0%, `Toolbar.tsx` at 0% in unit tests. Add: (1) unit tests for `commands.ts` and `page-scripts.ts`; (2) component test for `App.tsx` (auto-attach on mount, tab switch listener); (3) E2E tests for attach status indicator (shows connected after panel loads) and port-based recording JSONL → editor pipeline. Also recover the 2 dropped E2E panel tests: "shows attached status" and "recorded commands appear in editor".
 
+- [ ] **Fix failing recording component tab** — Recording via the record button fails to capture interactions on the component tab. Investigate why the recorder port/JSONL pipeline doesn't pick up actions on that tab and restore correct recording behaviour.
+- [ ] **Auto-attach fails when only one tab open** — On fresh panel load with only one tab (e.g. `chrome://extensions`), the extension shows "Not attached". Adding a second regular tab (e.g. github.com) makes it work. Likely `getActiveTabId()` returns a chrome:// tab which is rejected, and there's no fallback to retry on next tab. Investigate and add a retry or clearer error.
+
 ## Low Priority
 
 - [ ] **Recorder: merge fill + Enter into `fill --submit`** — When recording, absorb `press Enter` after a `fill` into a single `fill "loc" "value" --submit` command. The `--submit` flag already exists in the engine. Change is in `recorder.ts` `handleKeydown`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1126,6 +1126,20 @@
       "resolved": "packages/extension",
       "link": true
     },
+    "node_modules/@playwright-repl/playwright-crx": {
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/@playwright-repl/playwright-crx/-/playwright-crx-0.15.1.tgz",
+      "integrity": "sha512-G2FqdxYKWEEj9M9Qjfu1eW67eSGTJpwfvLj6fEOx0rcsgRU6Tsum2VK1NXVT6vorHVJF1il+dg4D+LNy/BaE0Q==",
+      "license": "Apache-2.0",
+      "workspaces": [
+        "examples/recorder-crx",
+        "examples/todomvc-crx",
+        "tests"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@playwright/test": {
       "version": "1.59.0-alpha-2026-02-21",
       "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.0-alpha-2026-02-21.tgz",
@@ -3877,20 +3891,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/playwright-crx": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/playwright-crx/-/playwright-crx-0.15.0.tgz",
-      "integrity": "sha512-yIz2AchvFOKj+oiGz5AAonMCPK5l6ttt4Xijd7Ggjm6D4OUNdVg+R2dnAnKIoBnvjoOBihlL1lyQVYPswV4Xow==",
-      "license": "Apache-2.0",
-      "workspaces": [
-        "examples/recorder-crx",
-        "examples/todomvc-crx",
-        "tests"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/playwright-repl": {
       "resolved": "packages/cli",
       "link": true
@@ -4683,8 +4683,8 @@
         "@codemirror/search": "^6.6.0",
         "@codemirror/state": "^6.5.4",
         "@codemirror/view": "^6.39.16",
+        "@playwright-repl/playwright-crx": "0.15.1",
         "codemirror": "^6.0.2",
-        "playwright-crx": "^0.15.0",
         "react": "^19.2.4",
         "react-dom": "^19.2.4"
       },
@@ -4708,6 +4708,19 @@
         "vitest": "^4.0.18",
         "vitest-browser-react": "^2.0.5",
         "vitest-chrome": "^0.1.0"
+      }
+    },
+    "packages/extension/.yalc/playwright-crx": {
+      "version": "0.15.1",
+      "extraneous": true,
+      "license": "Apache-2.0",
+      "workspaces": [
+        "examples/recorder-crx",
+        "examples/todomvc-crx",
+        "tests"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "packages/extension/node_modules/@types/chrome": {

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -39,7 +39,6 @@
     "vitest-chrome": "^0.1.0"
   },
   "dependencies": {
-    "playwright-crx": "^0.15.0",
     "@codemirror/autocomplete": "^6.20.1",
     "@codemirror/commands": "^6.10.2",
     "@codemirror/language": "^6.12.2",
@@ -47,6 +46,7 @@
     "@codemirror/state": "^6.5.4",
     "@codemirror/view": "^6.39.16",
     "codemirror": "^6.0.2",
+    "@playwright-repl/playwright-crx": "0.15.1",
     "react": "^19.2.4",
     "react-dom": "^19.2.4"
   }

--- a/packages/extension/src/background.ts
+++ b/packages/extension/src/background.ts
@@ -1,6 +1,6 @@
-import { crx } from 'playwright-crx';
-import type { CrxApplication } from 'playwright-crx';
-import type { Page } from 'playwright-crx/test';
+import { crx } from '@playwright-repl/playwright-crx';
+import type { CrxApplication } from '@playwright-repl/playwright-crx';
+import type { Page } from '@playwright-repl/playwright-crx/test';
 import { parseReplCommand } from './commands';
 import type { TabOperation } from './commands';
 import { loadSettings } from './panel/lib/settings';

--- a/packages/extension/test/background.test.ts
+++ b/packages/extension/test/background.test.ts
@@ -6,7 +6,7 @@ let mockPage: any;
 let mockCrxApp: any;
 let parseReplCommandMock: ReturnType<typeof vi.fn>;
 
-vi.mock('playwright-crx', () => {
+vi.mock('@playwright-repl/playwright-crx', () => {
   mockPage = { url: vi.fn().mockReturnValue('https://example.com') };
   const mockContext = { pages: vi.fn().mockReturnValue([mockPage]) };
   mockCrxApp = {
@@ -53,7 +53,7 @@ describe("background.ts message handlers", () => {
     };
 
     // Override factory for this test
-    const { crx } = await import('playwright-crx');
+    const { crx } = await import('@playwright-repl/playwright-crx');
     (crx.start as ReturnType<typeof vi.fn>).mockResolvedValue(mockCrxApp);
 
     // Re-import parseReplCommand mock reference
@@ -103,7 +103,7 @@ describe("background.ts message handlers", () => {
   // ─── attach ───────────────────────────────────────────────────────────────
 
   it("attach starts crxApp and attaches to tab", async () => {
-    const { crx } = await import('playwright-crx');
+    const { crx } = await import('@playwright-repl/playwright-crx');
     const result = await sendMessage({ type: 'attach', tabId: 42 });
     expect(crx.start).toHaveBeenCalled();
     expect(mockCrxApp.attach).toHaveBeenCalledWith(42);
@@ -230,7 +230,7 @@ describe("background.ts message handlers", () => {
   });
 
   it("record-start returns ok:false when crx.start throws", async () => {
-    const { crx } = await import('playwright-crx');
+    const { crx } = await import('@playwright-repl/playwright-crx');
     (crx.start as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('crx init failed'));
     const result = await sendMessage({ type: 'record-start' });
     expect(result.ok).toBe(false);

--- a/packages/extension/test/components/Toolbar.browser.test.tsx
+++ b/packages/extension/test/components/Toolbar.browser.test.tsx
@@ -56,7 +56,7 @@ describe('Toolbar component tests', () => {
       onMessage: { addListener: vi.fn() },
       onDisconnect: { addListener: vi.fn() },
       disconnect: vi.fn(),
-    });
+    } as unknown as chrome.runtime.Port);
   });
 
   afterEach(() => {
@@ -396,7 +396,7 @@ describe('Toolbar component tests', () => {
       onMessage: { addListener: vi.fn() },
       onDisconnect: { addListener: vi.fn() },
       disconnect: vi.fn(),
-    };
+    } as unknown as chrome.runtime.Port;
     vi.mocked(connectWithRetry).mockResolvedValue(mockPort);
 
     const screen = await renderToolbar();
@@ -461,7 +461,7 @@ describe('Toolbar component tests', () => {
       },
       onDisconnect: { addListener: vi.fn() },
       disconnect: vi.fn(),
-    };
+    } as unknown as chrome.runtime.Port;
     vi.mocked(connectWithRetry).mockResolvedValue(mockPort);
 
     const dispatch = vi.fn();

--- a/packages/extension/test/reducer.test.ts
+++ b/packages/extension/test/reducer.test.ts
@@ -102,7 +102,7 @@ describe('Reducer tests', () => {
    })
 
    it('should remain the same state for the invalid event', () => {
-     const newState = panelReducer(initialState, {type: 'invalid_event'});
+     const newState = panelReducer(initialState, {type: 'invalid_event'} as never);
      expect(newState).toEqual(initialState);
    })
 


### PR DESCRIPTION
## Summary

- Replaces `playwright-crx@0.15.0` (npm) with `@playwright-repl/playwright-crx@0.15.1` — a scoped fork that includes the service worker auto-attach fix (issue #104), resolving `goto` timeouts on SW-enabled sites like playwright.dev and Gmail
- Updates all imports in `background.ts` and test files to the new scoped package name
- Fixes TypeScript mock type casts in Toolbar and reducer tests
- Adds two new backlog items (recording tab issue, auto-attach single-tab issue)

## Test plan

- [x] `npm run build` passes in `packages/extension`
- [x] `npm run typecheck` passes with no errors
- [x] Extension loads in Chrome and auto-attaches to active tab
- [x] `goto https://playwright.dev/` no longer times out
- [x] `goto https://github.com` works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)