### PR TITLE
feat: add verify-visible and verify-value assertion commands

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -33,6 +33,7 @@
 
 - [ ] **Recorder: merge fill + Enter into `fill --submit`** — When recording, absorb `press Enter` after a `fill` into a single `fill "loc" "value" --submit` command. The `--submit` flag already exists in the engine. Change is in `recorder.ts` `handleKeydown`.
 - [x] **`highlight` command** — `highlight <locator>` as shortcut for `page.locator(<locator>).highlight()`. Useful for visualizing non-unique locator matches. ([#14](https://github.com/stevez/playwright-repl/issues/14))
+- [ ] **Migrate monorepo to pnpm** — Replace npm workspaces with pnpm. Use `workspace:*` protocol for internal dependencies so version bumps no longer require updating dep versions in each package. Migration: `pnpm import`, delete `package-lock.json`, update CI/scripts to use `pnpm`.
 - [ ] **Improve README structure** — Consider splitting README into per-package docs (`packages/cli/README.md`, `packages/extension/README.md`) with a concise root README linking to both.
 - [x] **Convert to TypeScript** — All packages migrated to TypeScript.
 - [x] **Extension server (Phase 8)** — `playwright-repl --extension` starts HTTP server; extension connects as thin CDP relay.

--- a/packages/extension/src/commands.ts
+++ b/packages/extension/src/commands.ts
@@ -11,6 +11,7 @@
 import {
   verifyText, verifyElement, verifyValue, verifyList,
   verifyTitle, verifyUrl, verifyNoText, verifyNoElement,
+  verifyVisible, verifyInputValue,
   actionByText, fillByText, selectByText, checkByText, uncheckByText,
   highlightByText, highlightBySelector, chainAction, goBack, goForward,
   gotoUrl, reloadPage, waitMs, getTitle, getUrl,
@@ -92,6 +93,7 @@ const ALIASES: Record<string, string> = {
   'v':    'verify',
   'vt':   'verify-text',
   've':   'verify-element',
+  'vvis': 'verify-visible',
   'vv':   'verify-value',
   'vl':   'verify-list',
 };
@@ -220,9 +222,12 @@ function resolveArgs(args: ParsedArgs): ParsedArgs | DirectExecution | TabOperat
   }
 
   // ── Legacy verify-* commands ────────────────────────────────
+  const TEXT_VERIFY_CMDS = new Set(['verify-text', 'verify-no-text', 'verify-title', 'verify-url']);
+  const ELEMENT_VERIFY_CMDS = new Set(['verify-element', 'verify-no-element', 'verify-visible']);
   const verifyFns: Record<string, PageScriptFn> = {
     'verify-text': verifyText as PageScriptFn,
     'verify-element': verifyElement as PageScriptFn,
+    'verify-visible': verifyVisible as PageScriptFn,
     'verify-value': verifyValue as PageScriptFn,
     'verify-list': verifyList as PageScriptFn,
     'verify-title': verifyTitle as PageScriptFn,
@@ -233,11 +238,15 @@ function resolveArgs(args: ParsedArgs): ParsedArgs | DirectExecution | TabOperat
   if (verifyFns[cmdName]) {
     const pos = args._.slice(1);
     const fn = verifyFns[cmdName];
-    if (cmdName === 'verify-text' || cmdName === 'verify-no-text' || cmdName === 'verify-title' || cmdName === 'verify-url') {
+    if (TEXT_VERIFY_CMDS.has(cmdName)) {
       const text = pos.join(' ');
       if (text) return { fn, fnArgs: [text] };
-    } else if (cmdName === 'verify-no-element' || cmdName === 'verify-element') {
+    } else if (ELEMENT_VERIFY_CMDS.has(cmdName)) {
       if (pos[0] && pos.length >= 2) return { fn, fnArgs: [pos[0], pos.slice(1).join(' ')] };
+    } else if (cmdName === 'verify-value' && pos[0] && pos.length >= 2) {
+      const isRef = /^e\d+$/.test(pos[0]);
+      const valueFn = isRef ? (verifyValue as PageScriptFn) : (verifyInputValue as PageScriptFn);
+      return { fn: valueFn, fnArgs: [pos[0], pos.slice(1).join(' ')] };
     } else if (pos[0] && pos.length >= 2) {
       const rest = cmdName === 'verify-list' ? pos.slice(1) : pos.slice(1).join(' ');
       return { fn, fnArgs: [pos[0], rest] };

--- a/packages/extension/src/page-scripts.ts
+++ b/packages/extension/src/page-scripts.ts
@@ -59,6 +59,51 @@ export async function verifyNoElement(page, role, name) {
     throw new Error('Element still exists: ' + role + ' "' + name + '"');
 }
 
+export async function verifyVisible(page, role, name) {
+  if (!(await page.getByRole(role, { name }).isVisible()))
+    throw new Error('Element not visible: ' + role + ' "' + name + '"');
+}
+
+export async function verifyInputValue(page, label, expected) {
+  let loc = page.getByLabel(label);
+  if (await loc.count() === 0) loc = page.getByRole('spinbutton', { name: label });
+  if (await loc.count() === 0) loc = page.getByRole('textbox', { name: label });
+  if (await loc.count() === 0) loc = page.getByRole('combobox', { name: label });
+
+  if (await loc.count() > 0) {
+    const el = loc.first();
+    const inputType = await el.evaluate(e => e instanceof HTMLInputElement ? e.type : '');
+    if (inputType === 'checkbox') {
+      const isChecked = await el.isChecked();
+      const expectChecked = ['checked', 'true', 'yes', '1'].includes(expected.toLowerCase());
+      if (isChecked !== expectChecked)
+        throw new Error('Expected "' + label + '" to be ' + expected + ', but was ' + (isChecked ? 'checked' : 'unchecked'));
+      return;
+    }
+    const value = await el.inputValue();
+    if (String(value) !== String(expected))
+      throw new Error('Expected "' + expected + '", got "' + value + '" for "' + label + '"');
+    return;
+  }
+
+  // Radio group: find a role=group labeled <label>, then check which radio is selected
+  const group = page.getByRole('group', { name: label });
+  if (await group.count() > 0) {
+    const checkedRadio = group.locator('input[type=radio]:checked');
+    if (await checkedRadio.count() === 0)
+      throw new Error('No radio button selected in group "' + label + '"');
+    const value = await checkedRadio.evaluate(e => {
+      const lbl = document.querySelector('label[for="' + e.id + '"]');
+      return lbl ? lbl.textContent.trim() : e.value;
+    });
+    if (value !== expected)
+      throw new Error('Expected "' + expected + '" selected, got "' + value + '" in group "' + label + '"');
+    return;
+  }
+
+  throw new Error('Element not found for label: ' + label);
+}
+
 // ─── Text locator actions ───────────────────────────────────────────────────
 
 export async function actionByText(page, text, action, nth) {

--- a/packages/extension/src/panel/lib/commands.ts
+++ b/packages/extension/src/panel/lib/commands.ts
@@ -60,12 +60,14 @@ export const COMMANDS: Record<string, CommandInfo> = {
     'unroute':              { desc: 'Remove route' },
     'upload':               { desc: 'Upload a file' },
     'verify':               { desc: 'Assert page state (title, url, text, element, value, list)' },
-    'verify-element':       { desc: 'Verify element exists' },
+    'verify-element':       { desc: 'Verify element exists by role' },
     'verify-no-element':    { desc: 'Verify element not exists' },
     'verify-no-text':       { desc: 'Verify text not visible' },
     'verify-text':          { desc: 'Verify text visible' },
     'verify-title':         { desc: 'Verify page title' },
     'verify-url':           { desc: 'Verify page URL' },
+    'verify-value':         { desc: 'Verify input / checkbox / radio value' },
+    'verify-visible':       { desc: 'Verify element is visible by role' },
 };
 
 // Aliases from parser.ts (core package not available in extension bundle)
@@ -74,7 +76,7 @@ export const ALIASES = [
   'c', 'dc', 't', 'f', 'h', 'p', 'sel', 'chk', 'unchk',
   'hl', 's', 'snap', 'ss', 'e', 'con', 'net',
   'tl', 'tn', 'tc', 'ts',
-  'v', 'vt', 've', 'vv', 'vl',
+  'v', 'vt', 've', 'vvis', 'vv', 'vl',
   'q', 'ls',
 ];
 

--- a/packages/extension/src/panel/lib/converter.ts
+++ b/packages/extension/src/panel/lib/converter.ts
@@ -139,6 +139,14 @@ export function pwToPlaywright(cmd: string): string | null {
       if (args.length < 2) return null;
       return `await expect(page.getByRole(${JSON.stringify(args[0])}, { name: ${JSON.stringify(args.slice(1).join(' '))} })).not.toBeVisible();`;
     }
+    case "verify-visible": {
+      if (args.length < 2) return null;
+      return `await expect(page.getByRole(${JSON.stringify(args[0])}, { name: ${JSON.stringify(args.slice(1).join(' '))} })).toBeVisible();`;
+    }
+    case "verify-value": {
+      if (args.length < 2) return null;
+      return `await expect(page.getByLabel(${JSON.stringify(args[0])})).toHaveValue(${JSON.stringify(args[1])});`;
+    }
     case "verify-url": {
       if (!args[0]) return null;
       return `await expect(page).toHaveURL(/${args[0].replace(/[.*+?^${}()|[\]\\/]/g, '\\$&')}/);`;
@@ -263,18 +271,19 @@ export function jsonlToRepl(jsonStr: string, isFirst: boolean): string | null {
       // ─── Assertions ───────────────────────────────────────────
       case 'assertVisible':
         if (!text) return null;
-        if (kind === 'role' && body) return `verify element ${body} ${q(text)}`;
+        if (kind === 'role' && body) return `verify-visible ${body} ${q(text)}`;
         return `verify text ${q(text)}`;
 
       case 'assertText':
         return a.text ? `verify text ${q(a.text)}` : null;
 
       case 'assertValue':
-        if (text && a.value != null) return `# verify value "${a.value}" in ${q(text)} — use snapshot ref`;
+        if (text && a.value != null) return `verify-value ${q(text)} ${q(String(a.value))}`;
         return null;
 
       case 'assertChecked':
-        return `# assertChecked — not yet supported`;
+        if (!text) return null;
+        return `verify-value ${q(text)} ${q(a.checked ? 'checked' : 'unchecked')}`;
 
       default:
         return `# ${a.name} (unsupported)`;

--- a/packages/extension/test/lib/commands.test.ts
+++ b/packages/extension/test/lib/commands.test.ts
@@ -1,0 +1,196 @@
+import { describe, it, expect, vi, beforeAll } from "vitest";
+
+// ─── Mock page-scripts so we can assert which fn was resolved ─────────────────
+
+const verifyVisibleMock = vi.fn();
+const verifyInputValueMock = vi.fn();
+const verifyValueMock = vi.fn();
+const verifyTextMock = vi.fn();
+const verifyElementMock = vi.fn();
+const verifyNoTextMock = vi.fn();
+const verifyNoElementMock = vi.fn();
+const verifyTitleMock = vi.fn();
+const verifyUrlMock = vi.fn();
+const verifyListMock = vi.fn();
+const gotoUrlMock = vi.fn();
+const actionByTextMock = vi.fn();
+const fillByTextMock = vi.fn();
+const takeSnapshotMock = vi.fn();
+
+vi.mock("../../src/page-scripts", () => ({
+  verifyVisible: verifyVisibleMock,
+  verifyInputValue: verifyInputValueMock,
+  verifyValue: verifyValueMock,
+  verifyText: verifyTextMock,
+  verifyElement: verifyElementMock,
+  verifyNoText: verifyNoTextMock,
+  verifyNoElement: verifyNoElementMock,
+  verifyTitle: verifyTitleMock,
+  verifyUrl: verifyUrlMock,
+  verifyList: verifyListMock,
+  gotoUrl: gotoUrlMock,
+  actionByText: actionByTextMock,
+  fillByText: fillByTextMock,
+  takeSnapshot: takeSnapshotMock,
+  selectByText: vi.fn(),
+  checkByText: vi.fn(),
+  uncheckByText: vi.fn(),
+  highlightByText: vi.fn(),
+  highlightBySelector: vi.fn(),
+  chainAction: vi.fn(),
+  goBack: vi.fn(),
+  goForward: vi.fn(),
+  reloadPage: vi.fn(),
+  waitMs: vi.fn(),
+  getTitle: vi.fn(),
+  getUrl: vi.fn(),
+  evalCode: vi.fn(),
+  runCode: vi.fn(),
+  takeScreenshot: vi.fn(),
+  refAction: vi.fn(),
+  pressKey: vi.fn(),
+  typeText: vi.fn(),
+  localStorageGet: vi.fn(), localStorageSet: vi.fn(), localStorageDelete: vi.fn(),
+  localStorageClear: vi.fn(), localStorageList: vi.fn(),
+  sessionStorageGet: vi.fn(), sessionStorageSet: vi.fn(), sessionStorageDelete: vi.fn(),
+  sessionStorageClear: vi.fn(), sessionStorageList: vi.fn(),
+  cookieList: vi.fn(), cookieGet: vi.fn(), cookieClear: vi.fn(),
+}));
+
+let parseReplCommand: (input: string) => any;
+
+beforeAll(async () => {
+  const mod = await import("../../src/commands");
+  parseReplCommand = mod.parseReplCommand;
+});
+
+// ─── helpers ──────────────────────────────────────────────────────────────────
+
+function direct(input: string) {
+  const result = parseReplCommand(input);
+  expect(result).toHaveProperty("fn");
+  expect(result).toHaveProperty("fnArgs");
+  return result as { fn: unknown; fnArgs: unknown[] };
+}
+
+function isError(input: string) {
+  const result = parseReplCommand(input);
+  expect(result).toHaveProperty("error");
+  return result as { error: string };
+}
+
+// ─── verify-visible ───────────────────────────────────────────────────────────
+
+describe("verify-visible", () => {
+  it("resolves to verifyVisible with role and name", () => {
+    const { fn, fnArgs } = direct('verify-visible button "Submit"');
+    expect(fn).toBe(verifyVisibleMock);
+    expect(fnArgs).toEqual(["button", "Submit"]);
+  });
+
+  it("resolves multi-word name", () => {
+    const { fn, fnArgs } = direct('verify-visible heading "Getting Started"');
+    expect(fn).toBe(verifyVisibleMock);
+    expect(fnArgs).toEqual(["heading", "Getting Started"]);
+  });
+
+  it("vvis alias resolves to verifyVisible", () => {
+    const { fn, fnArgs } = direct('vvis link "Learn more"');
+    expect(fn).toBe(verifyVisibleMock);
+    expect(fnArgs).toEqual(["link", "Learn more"]);
+  });
+
+  it("returns error when missing name arg", () => {
+    isError("verify-visible button");
+  });
+
+  it("returns error when empty", () => {
+    isError("verify-visible");
+  });
+});
+
+// ─── verify-value (label-based) ───────────────────────────────────────────────
+
+describe("verify-value — label-based", () => {
+  it("resolves to verifyInputValue for plain label", () => {
+    const { fn, fnArgs } = direct('verify-value "Email" "user@example.com"');
+    expect(fn).toBe(verifyInputValueMock);
+    expect(fnArgs).toEqual(["Email", "user@example.com"]);
+  });
+
+  it("resolves to verifyInputValue for checkbox checked", () => {
+    const { fn, fnArgs } = direct('verify-value "Accept terms" "checked"');
+    expect(fn).toBe(verifyInputValueMock);
+    expect(fnArgs).toEqual(["Accept terms", "checked"]);
+  });
+
+  it("resolves to verifyInputValue for checkbox unchecked", () => {
+    const { fn, fnArgs } = direct('verify-value "Newsletter" "unchecked"');
+    expect(fn).toBe(verifyInputValueMock);
+    expect(fnArgs).toEqual(["Newsletter", "unchecked"]);
+  });
+
+  it("resolves to verifyInputValue for radio group", () => {
+    const { fn, fnArgs } = direct('verify-value "Gender" "Female"');
+    expect(fn).toBe(verifyInputValueMock);
+    expect(fnArgs).toEqual(["Gender", "Female"]);
+  });
+});
+
+// ─── verify-value (ref-based) ─────────────────────────────────────────────────
+
+describe("verify-value — ref-based", () => {
+  it("resolves to verifyValue when first arg is a ref", () => {
+    const { fn, fnArgs } = direct('verify-value e5 "hello"');
+    expect(fn).toBe(verifyValueMock);
+    expect(fnArgs).toEqual(["e5", "hello"]);
+  });
+
+  it("resolves to verifyValue for ref e12", () => {
+    const { fn, fnArgs } = direct('verify-value e12 "world"');
+    expect(fn).toBe(verifyValueMock);
+    expect(fnArgs).toEqual(["e12", "world"]);
+  });
+});
+
+// ─── verify-visible vs verify-element distinction ─────────────────────────────
+
+describe("verify-visible vs verify-element", () => {
+  it("verify-element resolves to verifyElement (count-based)", () => {
+    const { fn } = direct('verify-element button "Submit"');
+    expect(fn).toBe(verifyElementMock);
+  });
+
+  it("verify-visible resolves to verifyVisible (isVisible-based)", () => {
+    const { fn } = direct('verify-visible button "Submit"');
+    expect(fn).toBe(verifyVisibleMock);
+  });
+});
+
+// ─── existing verify commands unaffected ─────────────────────────────────────
+
+describe("existing verify commands", () => {
+  it("verify-text resolves to verifyText", () => {
+    const { fn, fnArgs } = direct('verify-text "Hello"');
+    expect(fn).toBe(verifyTextMock);
+    expect(fnArgs).toEqual(["Hello"]);
+  });
+
+  it("verify-no-text resolves to verifyNoText", () => {
+    const { fn, fnArgs } = direct('verify-no-text "Gone"');
+    expect(fn).toBe(verifyNoTextMock);
+    expect(fnArgs).toEqual(["Gone"]);
+  });
+
+  it("verify text (unified) resolves to verifyText", () => {
+    const { fn, fnArgs } = direct('verify text "Welcome"');
+    expect(fn).toBe(verifyTextMock);
+    expect(fnArgs).toEqual(["Welcome"]);
+  });
+
+  it("verify-url resolves to verifyUrl", () => {
+    const { fn, fnArgs } = direct('verify-url "dashboard"');
+    expect(fn).toBe(verifyUrlMock);
+    expect(fnArgs).toEqual(["dashboard"]);
+  });
+});

--- a/packages/extension/test/lib/converter.test.ts
+++ b/packages/extension/test/lib/converter.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { tokenize, pwToPlaywright } from "@/lib/converter.js";
+import { tokenize, pwToPlaywright, jsonlToRepl } from "@/lib/converter.js";
 
 describe("tokenize", () => {
   it("tokenizes simple words", () => {
@@ -339,8 +339,143 @@ describe("pwToPlaywright", () => {
     expect(pwToPlaywright("verify-title")).toBeNull();
   });
 
+  // verify-visible
+  it("converts verify-visible to toBeVisible with role", () => {
+    expect(pwToPlaywright('verify-visible button "Submit"')).toBe(
+      'await expect(page.getByRole("button", { name: "Submit" })).toBeVisible();'
+    );
+  });
+
+  it("converts verify-visible heading", () => {
+    expect(pwToPlaywright('verify-visible heading "Dashboard"')).toBe(
+      'await expect(page.getByRole("heading", { name: "Dashboard" })).toBeVisible();'
+    );
+  });
+
+  it("returns null for verify-visible without args", () => {
+    expect(pwToPlaywright("verify-visible")).toBeNull();
+  });
+
+  // verify-value
+  it("converts verify-value to toHaveValue", () => {
+    expect(pwToPlaywright('verify-value "Email" "user@example.com"')).toBe(
+      'await expect(page.getByLabel("Email")).toHaveValue("user@example.com");'
+    );
+  });
+
+  it("converts verify-value for numeric input", () => {
+    expect(pwToPlaywright('verify-value "Quantity" "3"')).toBe(
+      'await expect(page.getByLabel("Quantity")).toHaveValue("3");'
+    );
+  });
+
+  it("returns null for verify-value without args", () => {
+    expect(pwToPlaywright("verify-value")).toBeNull();
+  });
+
   // unknown
   it("converts unknown command to comment", () => {
     expect(pwToPlaywright("foobar")).toBe("// unknown command: foobar");
+  });
+});
+
+// ─── helpers ─────────────────────────────────────────────────────────────────
+
+function jsonl(obj: object): string {
+  return JSON.stringify(obj);
+}
+
+function roleLocator(role: string, name: string) {
+  return { kind: "role", body: role, options: { name } };
+}
+
+function labelLocator(label: string) {
+  return { kind: "label", body: label, options: {} };
+}
+
+function textLocator(text: string) {
+  return { kind: "text", body: text, options: {} };
+}
+
+// ─── jsonlToRepl ─────────────────────────────────────────────────────────────
+
+describe("jsonlToRepl", () => {
+  // assertVisible
+  it("converts assertVisible with role locator to verify-visible", () => {
+    const action = jsonl({ name: "assertVisible", selector: "button", signals: [], locator: roleLocator("button", "Submit") });
+    expect(jsonlToRepl(action, false)).toBe('verify-visible button "Submit"');
+  });
+
+  it("converts assertVisible with text locator to verify text", () => {
+    const action = jsonl({ name: "assertVisible", selector: "text=Welcome", signals: [], locator: textLocator("Welcome") });
+    expect(jsonlToRepl(action, false)).toBe('verify text "Welcome"');
+  });
+
+  it("returns null for assertVisible with no text", () => {
+    const action = jsonl({ name: "assertVisible", selector: ".foo", signals: [], locator: { kind: "default", body: ".foo" } });
+    expect(jsonlToRepl(action, false)).toBeNull();
+  });
+
+  // assertText
+  it("converts assertText to verify text", () => {
+    const action = jsonl({ name: "assertText", selector: "text=Hello", text: "Hello", substring: true, signals: [], locator: textLocator("Hello") });
+    expect(jsonlToRepl(action, false)).toBe('verify text "Hello"');
+  });
+
+  it("returns null for assertText with no text field", () => {
+    const action = jsonl({ name: "assertText", selector: "text=", text: "", substring: true, signals: [] });
+    expect(jsonlToRepl(action, false)).toBeNull();
+  });
+
+  // assertValue
+  it("converts assertValue with label locator to verify-value", () => {
+    const action = jsonl({ name: "assertValue", selector: "input", value: "user@example.com", signals: [], locator: labelLocator("Email") });
+    expect(jsonlToRepl(action, false)).toBe('verify-value "Email" "user@example.com"');
+  });
+
+  it("converts assertValue with role locator to verify-value", () => {
+    const action = jsonl({ name: "assertValue", selector: "input", value: "5", signals: [], locator: roleLocator("spinbutton", "Quantity") });
+    expect(jsonlToRepl(action, false)).toBe('verify-value "Quantity" "5"');
+  });
+
+  it("returns null for assertValue with no text", () => {
+    const action = jsonl({ name: "assertValue", selector: "input", value: "5", signals: [], locator: { kind: "default", body: "input" } });
+    expect(jsonlToRepl(action, false)).toBeNull();
+  });
+
+  // assertChecked
+  it("converts assertChecked checked=true to verify-value checked", () => {
+    const action = jsonl({ name: "assertChecked", selector: "input", checked: true, signals: [], locator: labelLocator("Accept terms") });
+    expect(jsonlToRepl(action, false)).toBe('verify-value "Accept terms" "checked"');
+  });
+
+  it("converts assertChecked checked=false to verify-value unchecked", () => {
+    const action = jsonl({ name: "assertChecked", selector: "input", checked: false, signals: [], locator: labelLocator("Newsletter") });
+    expect(jsonlToRepl(action, false)).toBe('verify-value "Newsletter" "unchecked"');
+  });
+
+  it("returns null for assertChecked with no text", () => {
+    const action = jsonl({ name: "assertChecked", selector: "input", checked: true, signals: [], locator: { kind: "default", body: "input" } });
+    expect(jsonlToRepl(action, false)).toBeNull();
+  });
+
+  // other actions
+  it("converts click with role locator", () => {
+    const action = jsonl({ name: "click", selector: "button", button: "left", modifiers: 0, clickCount: 1, signals: [], locator: roleLocator("button", "Submit") });
+    expect(jsonlToRepl(action, false)).toBe('click "Submit"');
+  });
+
+  it("converts navigate (not first) to goto", () => {
+    const action = jsonl({ name: "navigate", url: "https://example.com", signals: [] });
+    expect(jsonlToRepl(action, false)).toBe('goto "https://example.com"');
+  });
+
+  it("skips navigate when isFirst=true", () => {
+    const action = jsonl({ name: "navigate", url: "https://example.com", signals: [] });
+    expect(jsonlToRepl(action, true)).toBeNull();
+  });
+
+  it("returns null for invalid JSON", () => {
+    expect(jsonlToRepl("not json", false)).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary
- `verify-visible <role> "<name>"`: checks element visibility via `isVisible()` — more correct than `verify-element` which only checks `count()`
- `verify-value "<label>" "<value>"`: checks input/checkbox/radio values via label-based locators; falls back to ref-based for `eN` refs
- Full JSONL roundtrip: `assertVisible`, `assertText`, `assertValue`, `assertChecked` all convert correctly to/from REPL commands
- Export: `verify-visible` → `toBeVisible()`, `verify-value` → `toHaveValue()`

## Test plan
- [ ] Unit tests for `converter.ts` (`jsonlToRepl`) and `commands.ts` (`parseReplCommand`) — all passing
- [ ] Record assertions in TodoMVC, verify commands generated correctly
- [ ] Run `verify-visible heading "Title"`, `verify-value "Email" "user@example.com"` in REPL

Closes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)