### PR TITLE
fix: improve recording quality and runtime locator fallbacks

### DIFF
--- a/packages/extension/src/page-scripts.ts
+++ b/packages/extension/src/page-scripts.ts
@@ -110,6 +110,9 @@ export async function actionByText(page, text, action, nth) {
   let loc = page.getByText(text, { exact: true });
   if (await loc.count() === 0) loc = page.getByRole('button', { name: text });
   if (await loc.count() === 0) loc = page.getByRole('link', { name: text });
+  if (await loc.count() === 0) loc = page.getByRole('textbox', { name: text });
+  if (await loc.count() === 0) loc = page.getByRole('combobox', { name: text });
+  if (await loc.count() === 0) loc = page.getByPlaceholder(text);
   if (await loc.count() === 0) loc = page.getByText(text);
   if (nth !== undefined) loc = loc.filter({ visible: true }).nth(nth);
   await loc[action]();
@@ -279,9 +282,15 @@ export async function pressKey(page, target, key) {
     return 'Pressed ' + target;
   }
   const isRef = /^e\d+$/.test(target);
-  const loc = isRef
-    ? page.locator('aria-ref=' + target)
-    : page.getByText(target, { exact: true });
+  if (isRef) {
+    await page.locator('aria-ref=' + target).press(key);
+    return 'Pressed ' + key;
+  }
+  let loc = page.getByText(target, { exact: true });
+  if (await loc.count() === 0) loc = page.getByRole('textbox', { name: target });
+  if (await loc.count() === 0) loc = page.getByRole('combobox', { name: target });
+  if (await loc.count() === 0) loc = page.getByPlaceholder(target);
+  if (await loc.count() === 0) loc = page.getByText(target);
   await loc.press(key);
   return 'Pressed ' + key;
 }

--- a/packages/extension/src/panel/components/Toolbar.tsx
+++ b/packages/extension/src/panel/components/Toolbar.tsx
@@ -12,6 +12,7 @@ interface ToolbarProps extends Pick<PanelState, 'editorContent' | 'fileName' | '
 function Toolbar({ editorContent, fileName, stepLine, attachedUrl, isAttaching, dispatch }: ToolbarProps) {
     const fileInputRef = useRef<HTMLInputElement>(null);
     const recorderPortRef = useRef<chrome.runtime.Port | null>(null);
+    const prevActionCountRef = useRef(0);
     const [isRecording, setIsRecording] = useState(false);
     const [isDarkMode, setIsDarkMode] = useState(() => localStorage.getItem("theme") === 'dark');
     const [availableTabs, setAvailableTabs] = useState<chrome.tabs.Tab[]>([]);
@@ -127,6 +128,15 @@ function Toolbar({ editorContent, fileName, stepLine, attachedUrl, isAttaching, 
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const source = sources.find((s: any) => s.id === 'jsonl') || sources[0];
         if (!source?.actions?.length) return;
+        const newActions = (source.actions as string[]).slice(prevActionCountRef.current);
+        prevActionCountRef.current = source.actions.length;
+        for (const a of newActions) {
+            try {
+                dispatch({ type: 'ADD_LINE', line: { text: JSON.stringify(JSON.parse(a), null, 2), type: 'code-block' } });
+            } catch {
+                dispatch({ type: 'ADD_LINE', line: { text: a, type: 'info' } });
+            }
+        }
         const replLines = (source.actions as string[])
             .map((a: string) => jsonlToRepl(a, false))
             .filter(Boolean) as string[];
@@ -162,6 +172,7 @@ function Toolbar({ editorContent, fileName, stepLine, attachedUrl, isAttaching, 
         }
 
         setIsRecording(true);
+        prevActionCountRef.current = 0;
 
         if (result.url && result.url !== 'about:blank') {
             dispatch({ type: 'APPEND_EDITOR_CONTENT', command: `goto "${result.url}"` });

--- a/packages/extension/src/panel/lib/codemirror-setup.ts
+++ b/packages/extension/src/panel/lib/codemirror-setup.ts
@@ -108,7 +108,7 @@ const resultGutter = gutter({
     markers(view) {
         const results = view.state.field(lineResultsField);
         const markers: any[] = [];
-        for (let i = 0; i < results.length; i++) {
+        for (let i = 0; i < results.length && i < view.state.doc.lines; i++) {
             if (results[i]) {
                 const line = view.state.doc.line(i + 1);
                 markers.push(new ResultMarker(results[i]!).range(line.from));

--- a/packages/extension/src/panel/lib/converter.ts
+++ b/packages/extension/src/panel/lib/converter.ts
@@ -232,9 +232,12 @@ export function jsonlToRepl(jsonStr: string, isFirst: boolean): string | null {
         return '# tab closed';
 
       case 'click':
+        // Skip focus-clicks on inputs — they're noise before fill/press
+        if (kind === 'role' && (body === 'textbox' || body === 'combobox')) return null;
         if (text) return `click ${q(text)}${nth}`;
-        // CSS fallback: quote the full selector (contains >> so chainAction picks it up)
-        if (kind === 'default' && a.selector) return `click ${q(a.selector)}`;
+        // CSS fallback: skip top-level noise (html/body clicks are "click outside" events)
+        if (kind === 'default' && a.selector && !['html', 'body'].includes(a.selector.trim()))
+          return `click ${q(a.selector)}`;
         return null;
 
       case 'fill':


### PR DESCRIPTION
## Summary
- Skip `click` on `textbox`/`combobox` role in converter — clicking to focus before fill is recorder noise
- Filter `click html`/`click body` — click-outside events are noise
- JSONL debug output in console pane now shows only **new** actions per update (delta), not the full cumulative list on every keystroke
- `actionByText` and `pressKey` add `getByRole('textbox'/'combobox', { name })` and `getByPlaceholder` fallbacks so recorded commands like `click "What needs to be done?"` and `press "What needs to be done?" Enter` run correctly
- Fix `resultGutter` crash: `Invalid line number N in 1-line document` when `lineResults` has more entries than the current document's line count

## Test plan
- [ ] Record on TodoMVC — verify no `click "What needs to be done?"` in output
- [ ] Run `fill "What needs to be done?" "reading"` + `press "What needs to be done?" Enter` — verify both work
- [ ] Run a recording with multiple commands — verify no CodeMirror crash after run

🤖 Generated with [Claude Code](https://claude.com/claude-code)