### PR TITLE
feat: add sandbox iframe for run-code command execution

### DIFF
--- a/packages/extension/e2e/commands/commands.test.ts
+++ b/packages/extension/e2e/commands/commands.test.ts
@@ -1,33 +1,37 @@
 /**
  * Command integration tests — exercises the full stack:
- * real Engine + CommandServer + Playwright browser.
+ * real extension + playwright-crx via chrome.runtime.sendMessage.
  *
- * Each test sends commands via HTTP POST /run and asserts on actual results.
+ * Commands are sent directly to the background service worker via sendCommand().
+ * run-code tests use sendViaUI() since that command routes through the sandbox iframe.
  */
 
-import { test, expect } from './fixtures.js';
+import { test, expect, sendCommand, sendViaUI } from './fixtures.js';
 
-// ─── Test URLs ──────────────────────────────────────────────────────────────
-// Use Playwright-hosted sites to avoid Cloudflare bot protection in CI.
 const TEST_URL = 'https://demo.playwright.dev/todomvc/';
 const SECOND_URL = 'https://playwright.dev/';
 
-// ─── Helper ─────────────────────────────────────────────────────────────────
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+/**
+ * Navigate to a URL and clear storage so previous test runs don't leave stale
+ * state (e.g. TodoMVC persists todos in localStorage).
+ */
+async function gotoFresh(panelPage: Parameters<typeof sendCommand>[0], url: string) {
+  await sendCommand(panelPage, `goto ${url}`);
+  await sendCommand(panelPage, 'eval localStorage.clear()');
+  await sendCommand(panelPage, 'eval sessionStorage.clear()');
+  await sendCommand(panelPage, `goto ${url}`);
+}
 
 /**
  * Extract an element ref (e.g. "e5") from snapshot text by matching a label.
- * Handles formats like:
- *   - link "Learn more" [ref=e6]       → label before ref
- *   - textbox "Name" [ref=e2]          → label before ref
- *   - combobox [ref=e2]:               → type before ref (no label)
  */
 function findRef(snapshotText: string, labelPattern: string): string {
-  // Try: label appears before [ref=eN] on same line
   const re1 = new RegExp(`${labelPattern}.*\\[ref=(e\\d+)\\]`, 'i');
   const m1 = snapshotText.match(re1);
   if (m1) return m1[1];
 
-  // Try: [ref=eN] appears before label on same line
   const re2 = new RegExp(`\\[ref=(e\\d+)\\].*${labelPattern}`, 'i');
   const m2 = snapshotText.match(re2);
   if (m2) return m2[1];
@@ -35,368 +39,389 @@ function findRef(snapshotText: string, labelPattern: string): string {
   throw new Error(`No ref found for "${labelPattern}" in snapshot:\n${snapshotText}`);
 }
 
-// ─── Navigation ─────────────────────────────────────────────────────────────
-
-test('goto navigates to a URL', async ({ run }) => {
-  const result = await run(`goto ${TEST_URL}`);
-  expect(result.isError).toBeFalsy();
-  expect(result.text).toContain(TEST_URL);
-});
-
-test('goto with alias g', async ({ run }) => {
-  const result = await run(`g ${TEST_URL}`);
-  expect(result.isError).toBeFalsy();
-  expect(result.text).toContain(TEST_URL);
-});
-
-test('go-back navigates to previous page', async ({ run }) => {
-  await run(`goto ${TEST_URL}`);
-  await run(`goto ${SECOND_URL}`);
-  const result = await run('go-back');
-  expect(result.isError).toBeFalsy();
-  expect(result.text).toContain(TEST_URL);
-});
-
-test('go-forward navigates to next page', async ({ run }) => {
-  await run(`goto ${TEST_URL}`);
-  await run(`goto ${SECOND_URL}`);
-  await run('go-back');
-  const result = await run('go-forward');
-  expect(result.isError).toBeFalsy();
-  expect(result.text).toContain(SECOND_URL);
-});
-
-// ─── Snapshot ───────────────────────────────────────────────────────────────
-
-test('snapshot returns accessibility tree with refs', async ({ run }) => {
-  await run(`goto ${TEST_URL}`);
-  const result = await run('snapshot');
-  expect(result.isError).toBeFalsy();
-  expect(result.text).toContain('todos');
-  expect(result.text).toMatch(/\[ref=e\d+\]/);
-});
-
-test('snapshot with alias s', async ({ run }) => {
-  await run(`goto ${TEST_URL}`);
-  const result = await run('s');
-  expect(result.isError).toBeFalsy();
-  expect(result.text).toContain('todos');
-  expect(result.text).toMatch(/\[ref=e\d+\]/);
-});
-
-// ─── Click ──────────────────────────────────────────────────────────────────
-
-test('click an element by ref', async ({ run }) => {
-  await run(`goto ${TEST_URL}`);
-  const snap = await run('snapshot');
-  const ref = findRef(snap.text, 'TodoMVC');
-  const result = await run(`click ${ref}`);
-  expect(result.isError).toBeFalsy();
-  expect(result.text).toContain('Page URL');
-});
-
-// ─── Fill ───────────────────────────────────────────────────────────────────
-
-test('fill an input field', async ({ run }) => {
-  await run('goto https://demo.playwright.dev/todomvc/');
-  const result = await run('fill "What needs to be done" "Buy groceries"');
-  expect(result.isError).toBeFalsy();
-});
-
-// ─── Press ──────────────────────────────────────────────────────────────────
-
-test('press a keyboard key', async ({ run }) => {
-  await run(`goto ${TEST_URL}`);
-  const result = await run('press Tab');
-  expect(result.isError).toBeFalsy();
-});
-
-// ─── Select ─────────────────────────────────────────────────────────────────
-
-test('select a dropdown option', async ({ run }) => {
-  await run('goto https://the-internet.herokuapp.com/dropdown');
-  const snap = await run('snapshot');
-  const ref = findRef(snap.text, 'combobox');
-  const result = await run(`select ${ref} "Option 1"`);
-  expect(result.isError).toBeFalsy();
-});
-
-// ─── Eval ───────────────────────────────────────────────────────────────────
-
-test('eval executes JavaScript', async ({ run }) => {
-  await run(`goto ${TEST_URL}`);
-  const result = await run('eval document.title');
-  expect(result.isError).toBeFalsy();
-  expect(result.text).toContain('TodoMVC');
-});
-
-// ─── Screenshot ─────────────────────────────────────────────────────────────
-
-test('screenshot captures the page', async ({ run }) => {
-  await run(`goto ${TEST_URL}`);
-  const result = await run('screenshot');
-  expect(result.isError).toBeFalsy();
-  expect(result.text).toContain('.png');
-  expect(result.image).toMatch(/^data:image\/png;base64,/);
-});
-
-// ─── Check / Uncheck ────────────────────────────────────────────────────────
-
-test('check a todo item', async ({ run }) => {
-  await run('goto https://demo.playwright.dev/todomvc/');
-  await run('fill "What needs to be done" "Buy groceries"');
-  await run('press Enter');
-  const result = await run('check "Buy groceries"');
-  expect(result.isError).toBeFalsy();
-});
-
-test('uncheck a todo item', async ({ run }) => {
-  await run('goto https://demo.playwright.dev/todomvc/');
-  await run('fill "What needs to be done" "Clean house"');
-  await run('press Enter');
-  await run('check "Clean house"');
-  const result = await run('uncheck "Clean house"');
-  expect(result.isError).toBeFalsy();
-});
-
-// ─── Hover ──────────────────────────────────────────────────────────────────
-
-test('hover over an element', async ({ run }) => {
-  await run(`goto ${TEST_URL}`);
-  const result = await run('hover "todos"');
-  expect(result.isError).toBeFalsy();
-});
-
-// ─── Run-code ───────────────────────────────────────────────────────────────
-
-test('run-code simple expression returns result', async ({ run }) => {
-  await run(`goto ${TEST_URL}`);
-  const result = await run('run-code page.title()');
-  expect(result.isError).toBeFalsy();
-  expect(result.text).toContain('### Result');
-  expect(result.text).toContain('TodoMVC');
-  expect(result.text).toContain('return await page.title()');
-});
-
-test('run-code multi-statement with semicolons', async ({ run }) => {
-  await run(`goto ${TEST_URL}`);
-  const result = await run('run-code const t = await page.title(); return t');
-  expect(result.isError).toBeFalsy();
-  expect(result.text).toContain('### Result');
-  expect(result.text).toContain('TodoMVC');
-  expect(result.text).toContain('const t = await page.title(); return t');
-});
-
-test('run-code with await statement', async ({ run }) => {
-  await run(`goto ${TEST_URL}`);
-  const result = await run('run-code await page.waitForTimeout(100)');
-  expect(result.isError).toBeFalsy();
-  expect(result.text).toContain('await page.waitForTimeout(100)');
-});
-
-test('run-code with async function passes through unchanged', async ({ run }) => {
-  await run(`goto ${TEST_URL}`);
-  const result = await run('run-code async (page) => { const t = await page.title(); return t }');
-  expect(result.isError).toBeFalsy();
-  expect(result.text).toContain('### Result');
-  expect(result.text).toContain('TodoMVC');
-  expect(result.text).toContain('const t = await page.title(); return t');
-});
-
-// ─── Verify commands ────────────────────────────────────────────────────────
-
-test('verify-text passes when text exists', async ({ run }) => {
-  await run(`goto ${TEST_URL}`);
-  const result = await run('verify-text "todos"');
-  expect(result.isError).toBeFalsy();
-});
-
-test('verify-text fails when text is missing', async ({ run }) => {
-  await run(`goto ${TEST_URL}`);
-  const result = await run('verify-text "nonexistent text xyz"');
-  expect(result.isError).toBe(true);
-  expect(result.text).toContain('Text not found');
-});
-
-test('verify-element passes when element exists', async ({ run }) => {
-  await run(`goto ${TEST_URL}`);
-  const result = await run('verify-element heading "todos"');
-  expect(result.isError).toBeFalsy();
-});
-
-// ─── Unified verify command ─────────────────────────────────────────────────
-
-test('verify title passes when title matches', async ({ run }) => {
-  await run(`goto ${TEST_URL}`);
-  const result = await run('verify title "TodoMVC"');
-  expect(result.isError).toBeFalsy();
-});
-
-test('verify title fails when title does not match', async ({ run }) => {
-  await run(`goto ${TEST_URL}`);
-  const result = await run('verify title "Nonexistent Title XYZ"');
-  expect(result.isError).toBe(true);
-  expect(result.text).toContain('does not contain');
-});
-
-test('verify url passes when URL matches', async ({ run }) => {
-  await run(`goto ${TEST_URL}`);
-  const result = await run('verify url "todomvc"');
-  expect(result.isError).toBeFalsy();
-});
-
-test('verify url fails when URL does not match', async ({ run }) => {
-  await run(`goto ${TEST_URL}`);
-  const result = await run('verify url "nonexistent-path"');
-  expect(result.isError).toBe(true);
-  expect(result.text).toContain('does not contain');
-});
-
-test('verify text passes when text is visible', async ({ run }) => {
-  await run(`goto ${TEST_URL}`);
-  const result = await run('verify text "todos"');
-  expect(result.isError).toBeFalsy();
-});
-
-test('verify text fails when text is not visible', async ({ run }) => {
-  await run(`goto ${TEST_URL}`);
-  const result = await run('verify text "nonexistent text xyz"');
-  expect(result.isError).toBe(true);
-  expect(result.text).toContain('Text not found');
-});
-
-test('verify no-text passes when text is absent', async ({ run }) => {
-  await run(`goto ${TEST_URL}`);
-  const result = await run('verify no-text "nonexistent text xyz"');
-  expect(result.isError).toBeFalsy();
-});
-
-test('verify element passes when element exists', async ({ run }) => {
-  await run(`goto ${TEST_URL}`);
-  const result = await run('verify element heading "todos"');
-  expect(result.isError).toBeFalsy();
-});
-
-test('verify no-element passes when element is absent', async ({ run }) => {
-  await run(`goto ${TEST_URL}`);
-  const result = await run('verify no-element button "Nonexistent XYZ"');
-  expect(result.isError).toBeFalsy();
-});
-
-test('v alias routes to verify', async ({ run }) => {
-  await run(`goto ${TEST_URL}`);
-  const result = await run('v title "TodoMVC"');
-  expect(result.isError).toBeFalsy();
-});
-
-// ─── Aliases ────────────────────────────────────────────────────────────────
-
-test('alias c for click', async ({ run }) => {
-  await run(`goto ${TEST_URL}`);
-  const snap = await run('s');
-  const ref = findRef(snap.text, 'TodoMVC');
-  const result = await run(`c ${ref}`);
-  expect(result.isError).toBeFalsy();
-});
-
-// ─── Tab commands ────────────────────────────────────────────────────────────
-
 /**
- * Count tab entries in tab-list output.
- * Format: "- N: [Title](URL)" or "- N: (current) [Title](URL)"
+ * Count tabs in tab-list output. Format: "[tabId] title — url"
  */
 function countTabs(tabListText: string): number {
-  return tabListText.split('\n').filter(l => /^- \d+:/.test(l)).length;
+  return (tabListText.match(/\[\d+\]/g) ?? []).length;
 }
 
-test('tab-list shows open tabs', async ({ run }) => {
-  await run(`goto ${TEST_URL}`);
-  const result = await run('tab-list');
-  expect(result.isError).toBeFalsy();
-  expect(result.text).toContain('demo.playwright.dev');
-  expect(result.text).toMatch(/- 0:.*\(current\)/);
+/**
+ * Extract the tab ID for a tab whose line contains the given URL substring.
+ */
+function findTabId(tabListText: string, urlSubstring: string): number | null {
+  const line = tabListText.split('\n').find(l => l.includes(urlSubstring));
+  if (!line) return null;
+  const m = line.match(/\[(\d+)\]/);
+  return m ? parseInt(m[1]) : null;
+}
+
+// ─── Navigation ─────────────────────────────────────────────────────────────
+
+test.describe('Navigation', () => {
+  test('goto navigates to a URL', async ({ testPage: _, panelPage }) => {
+    const result = await sendCommand(panelPage, `goto ${TEST_URL}`);
+    expect(result.isError).toBeFalsy();
+    expect(result.text).toContain(TEST_URL);
+  });
+
+  test('goto with alias g', async ({ testPage: _, panelPage }) => {
+    const result = await sendCommand(panelPage, `g ${TEST_URL}`);
+    expect(result.isError).toBeFalsy();
+    expect(result.text).toContain(TEST_URL);
+  });
+
+  test('go-back navigates to previous page', async ({ testPage: _, panelPage }) => {
+    await sendCommand(panelPage, `goto ${TEST_URL}`);
+    await sendCommand(panelPage, `goto ${SECOND_URL}`);
+    const result = await sendCommand(panelPage, 'go-back');
+    expect(result.isError).toBeFalsy();
+    expect(result.text).toContain(TEST_URL);
+  });
+
+  test('go-forward navigates to next page', async ({ testPage: _, panelPage }) => {
+    await sendCommand(panelPage, `goto ${TEST_URL}`);
+    await sendCommand(panelPage, `goto ${SECOND_URL}`);
+    await sendCommand(panelPage, 'go-back');
+    const result = await sendCommand(panelPage, 'go-forward');
+    expect(result.isError).toBeFalsy();
+    expect(result.text).toContain(SECOND_URL);
+  });
 });
 
-test('tab-new opens a new tab', async ({ run }) => {
-  await run(`goto ${TEST_URL}`);
-  const before = await run('tab-list');
-  const tabsBefore = countTabs(before.text);
+// ─── Snapshot ────────────────────────────────────────────────────────────────
 
-  const result = await run('tab-new');
-  expect(result.isError).toBeFalsy();
+test.describe('Snapshot', () => {
+  test('snapshot returns accessibility tree with refs', async ({ testPage: _, panelPage }) => {
+    await sendCommand(panelPage, `goto ${TEST_URL}`);
+    const result = await sendCommand(panelPage, 'snapshot');
+    expect(result.isError).toBeFalsy();
+    expect(result.text).toContain('todos');
+    expect(result.text).toMatch(/\[ref=e\d+\]/);
+  });
 
-  const after = await run('tab-list');
-  const tabsAfter = countTabs(after.text);
-  expect(tabsAfter).toBe(tabsBefore + 1);
-  // New tab becomes current
-  expect(after.text).toMatch(/- 1:.*\(current\)/);
+  test('snapshot with alias s', async ({ testPage: _, panelPage }) => {
+    await sendCommand(panelPage, `goto ${TEST_URL}`);
+    const result = await sendCommand(panelPage, 's');
+    expect(result.isError).toBeFalsy();
+    expect(result.text).toContain('todos');
+    expect(result.text).toMatch(/\[ref=e\d+\]/);
+  });
 });
 
-test('tab-select switches to a tab by index', async ({ run }) => {
-  await run(`goto ${TEST_URL}`);
-  await run('tab-new');
-  // New tab is current — switch back to first tab
-  const result = await run('tab-select 0');
-  expect(result.isError).toBeFalsy();
+// ─── Click ───────────────────────────────────────────────────────────────────
 
-  // Verify first tab is now current
-  const list = await run('tab-list');
-  expect(list.text).toMatch(/- 0:.*\(current\).*demo\.playwright\.dev/);
+test.describe('Click', () => {
+  test('click an element by ref', async ({ testPage: _, panelPage }) => {
+    await sendCommand(panelPage, `goto ${TEST_URL}`);
+    const snap = await sendCommand(panelPage, 'snapshot');
+    const ref = findRef(snap.text, 'TodoMVC');
+    const result = await sendCommand(panelPage, `click ${ref}`);
+    expect(result.isError).toBeFalsy();
+  });
+
+  test('click by text', async ({ testPage: _, panelPage }) => {
+    await sendCommand(panelPage, `goto ${SECOND_URL}`);
+    const result = await sendCommand(panelPage, 'click "Get started"');
+    expect(result.isError).toBeFalsy();
+  });
 });
 
-test('tab-close closes the current tab', async ({ run }) => {
-  await run(`goto ${TEST_URL}`);
-  await run('tab-new');
-  const before = await run('tab-list');
-  const tabsBefore = countTabs(before.text);
+// ─── Fill ────────────────────────────────────────────────────────────────────
 
-  // Close the current tab (the new one)
-  const result = await run('tab-close');
-  expect(result.isError).toBeFalsy();
-
-  const after = await run('tab-list');
-  const tabsAfter = countTabs(after.text);
-  expect(tabsAfter).toBe(tabsBefore - 1);
+test.describe('Fill', () => {
+  test('fill an input field by text', async ({ testPage: _, panelPage }) => {
+    await sendCommand(panelPage, `goto ${TEST_URL}`);
+    const result = await sendCommand(panelPage, 'fill "What needs to be done" "Buy groceries"');
+    expect(result.isError).toBeFalsy();
+  });
 });
 
-test('tab-new then goto navigates in the new tab', async ({ run }) => {
-  await run(`goto ${TEST_URL}`);
-  await run('tab-new');
-  await run(`goto ${SECOND_URL}`);
+// ─── Press ───────────────────────────────────────────────────────────────────
 
-  const list = await run('tab-list');
-  expect(list.text).toContain('demo.playwright.dev');
-  expect(list.text).toContain('playwright.dev');
+test.describe('Press', () => {
+  test('press a keyboard key', async ({ testPage: _, panelPage }) => {
+    await sendCommand(panelPage, `goto ${TEST_URL}`);
+    const result = await sendCommand(panelPage, 'press Tab');
+    expect(result.isError).toBeFalsy();
+  });
+
+  test('press Enter submits a todo', async ({ testPage: _, panelPage }) => {
+    await sendCommand(panelPage, `goto ${TEST_URL}`);
+    await sendCommand(panelPage, 'fill "What needs to be done" "Buy groceries"');
+    const result = await sendCommand(panelPage, 'press Enter');
+    expect(result.isError).toBeFalsy();
+  });
 });
 
-test('tab aliases tl, tn, tc, ts work', async ({ run }) => {
-  await run(`goto ${TEST_URL}`);
+// ─── Eval ────────────────────────────────────────────────────────────────────
 
-  const list = await run('tl');
-  expect(list.isError).toBeFalsy();
-  expect(list.text).toContain('demo.playwright.dev');
+test.describe('Eval', () => {
+  test('eval executes JavaScript', async ({ testPage: _, panelPage }) => {
+    await sendCommand(panelPage, `goto ${TEST_URL}`);
+    const result = await sendCommand(panelPage, 'eval document.title');
+    expect(result.isError).toBeFalsy();
+    expect(result.text).toContain('TodoMVC');
+  });
 
-  const newTab = await run('tn');
-  expect(newTab.isError).toBeFalsy();
-
-  const select = await run('ts 0');
-  expect(select.isError).toBeFalsy();
-
-  const close = await run('ts 1');
-  expect(close.isError).toBeFalsy();
-  await run('tc');
+  test('eval with alias e', async ({ testPage: _, panelPage }) => {
+    await sendCommand(panelPage, `goto ${TEST_URL}`);
+    const result = await sendCommand(panelPage, 'e document.title');
+    expect(result.isError).toBeFalsy();
+    expect(result.text).toContain('TodoMVC');
+  });
 });
 
-// ─── Errors ─────────────────────────────────────────────────────────────────
+// ─── Screenshot ──────────────────────────────────────────────────────────────
 
-test('unknown command returns error', async ({ run }) => {
-  const result = await run('nonexistent');
-  expect(result.isError).toBe(true);
-  expect(result.text).toContain('Unknown command');
+test.describe('Screenshot', () => {
+  test('screenshot captures the page', async ({ testPage: _, panelPage }) => {
+    await sendCommand(panelPage, `goto ${TEST_URL}`);
+    const result = await sendCommand(panelPage, 'screenshot');
+    expect(result.isError).toBeFalsy();
+    expect(result.image).toMatch(/^data:image\/(jpeg|png);base64,/);
+  });
 });
 
-test('invalid ref returns error', async ({ run }) => {
-  await run(`goto ${TEST_URL}`);
-  const result = await run('click e9999');
-  expect(result.isError).toBe(true);
+// ─── Check / Uncheck ─────────────────────────────────────────────────────────
+
+test.describe('Check / Uncheck', () => {
+  test('check a todo item', async ({ testPage: _, panelPage }) => {
+    await gotoFresh(panelPage, TEST_URL);
+    await sendCommand(panelPage, 'fill "What needs to be done" "Buy groceries"');
+    await sendCommand(panelPage, 'press Enter');
+    const result = await sendCommand(panelPage, 'check "Buy groceries"');
+    expect(result.isError).toBeFalsy();
+  });
+
+  test('uncheck a todo item', async ({ testPage: _, panelPage }) => {
+    await gotoFresh(panelPage, TEST_URL);
+    await sendCommand(panelPage, 'fill "What needs to be done" "Clean house"');
+    await sendCommand(panelPage, 'press Enter');
+    await sendCommand(panelPage, 'check "Clean house"');
+    const result = await sendCommand(panelPage, 'uncheck "Clean house"');
+    expect(result.isError).toBeFalsy();
+  });
+});
+
+// ─── Hover ───────────────────────────────────────────────────────────────────
+
+test.describe('Hover', () => {
+  test('hover over an element', async ({ testPage: _, panelPage }) => {
+    await sendCommand(panelPage, `goto ${TEST_URL}`);
+    const result = await sendCommand(panelPage, 'hover "todos"');
+    expect(result.isError).toBeFalsy();
+  });
+});
+
+// ─── Verify ──────────────────────────────────────────────────────────────────
+
+test.describe('Verify', () => {
+  test('verify-text passes when text exists', async ({ testPage: _, panelPage }) => {
+    await sendCommand(panelPage, `goto ${TEST_URL}`);
+    const result = await sendCommand(panelPage, 'verify-text "todos"');
+    expect(result.isError).toBeFalsy();
+  });
+
+  test('verify-text fails when text is missing', async ({ testPage: _, panelPage }) => {
+    await sendCommand(panelPage, `goto ${TEST_URL}`);
+    const result = await sendCommand(panelPage, 'verify-text "nonexistent text xyz"');
+    expect(result.isError).toBe(true);
+    expect(result.text).toContain('Text not found');
+  });
+
+  test('verify-element passes when element exists', async ({ testPage: _, panelPage }) => {
+    await sendCommand(panelPage, `goto ${TEST_URL}`);
+    const result = await sendCommand(panelPage, 'verify-element heading "todos"');
+    expect(result.isError).toBeFalsy();
+  });
+
+  test('verify title passes when title matches', async ({ testPage: _, panelPage }) => {
+    await sendCommand(panelPage, `goto ${TEST_URL}`);
+    const result = await sendCommand(panelPage, 'verify title "TodoMVC"');
+    expect(result.isError).toBeFalsy();
+  });
+
+  test('verify title fails when title does not match', async ({ testPage: _, panelPage }) => {
+    await sendCommand(panelPage, `goto ${TEST_URL}`);
+    const result = await sendCommand(panelPage, 'verify title "Nonexistent Title XYZ"');
+    expect(result.isError).toBe(true);
+    expect(result.text).toContain('does not contain');
+  });
+
+  test('verify url passes when URL matches', async ({ testPage: _, panelPage }) => {
+    await sendCommand(panelPage, `goto ${TEST_URL}`);
+    const result = await sendCommand(panelPage, 'verify url "todomvc"');
+    expect(result.isError).toBeFalsy();
+  });
+
+  test('verify url fails when URL does not match', async ({ testPage: _, panelPage }) => {
+    await sendCommand(panelPage, `goto ${TEST_URL}`);
+    const result = await sendCommand(panelPage, 'verify url "nonexistent-path"');
+    expect(result.isError).toBe(true);
+    expect(result.text).toContain('does not contain');
+  });
+
+  test('verify text passes when text is visible', async ({ testPage: _, panelPage }) => {
+    await sendCommand(panelPage, `goto ${TEST_URL}`);
+    const result = await sendCommand(panelPage, 'verify text "todos"');
+    expect(result.isError).toBeFalsy();
+  });
+
+  test('verify text fails when text is not visible', async ({ testPage: _, panelPage }) => {
+    await sendCommand(panelPage, `goto ${TEST_URL}`);
+    const result = await sendCommand(panelPage, 'verify text "nonexistent text xyz"');
+    expect(result.isError).toBe(true);
+    expect(result.text).toContain('Text not found');
+  });
+
+  test('verify no-text passes when text is absent', async ({ testPage: _, panelPage }) => {
+    await sendCommand(panelPage, `goto ${TEST_URL}`);
+    const result = await sendCommand(panelPage, 'verify no-text "nonexistent text xyz"');
+    expect(result.isError).toBeFalsy();
+  });
+
+  test('verify element passes when element exists', async ({ testPage: _, panelPage }) => {
+    await sendCommand(panelPage, `goto ${TEST_URL}`);
+    const result = await sendCommand(panelPage, 'verify element heading "todos"');
+    expect(result.isError).toBeFalsy();
+  });
+
+  test('verify no-element passes when element is absent', async ({ testPage: _, panelPage }) => {
+    await sendCommand(panelPage, `goto ${TEST_URL}`);
+    const result = await sendCommand(panelPage, 'verify no-element button "Nonexistent XYZ"');
+    expect(result.isError).toBeFalsy();
+  });
+
+  test('v alias routes to verify', async ({ testPage: _, panelPage }) => {
+    await sendCommand(panelPage, `goto ${TEST_URL}`);
+    const result = await sendCommand(panelPage, 'v title "TodoMVC"');
+    expect(result.isError).toBeFalsy();
+  });
+});
+
+// ─── Aliases ─────────────────────────────────────────────────────────────────
+
+test.describe('Aliases', () => {
+  test('alias c for click', async ({ testPage: _, panelPage }) => {
+    await sendCommand(panelPage, `goto ${TEST_URL}`);
+    const snap = await sendCommand(panelPage, 's');
+    const ref = findRef(snap.text, 'TodoMVC');
+    const result = await sendCommand(panelPage, `c ${ref}`);
+    expect(result.isError).toBeFalsy();
+  });
+});
+
+// ─── Tab commands ─────────────────────────────────────────────────────────────
+
+test.describe('Tab commands', () => {
+  test('tab-list shows open tabs', async ({ testPage: _, panelPage }) => {
+    await sendCommand(panelPage, `goto ${TEST_URL}`);
+    const result = await sendCommand(panelPage, 'tab-list');
+    expect(result.isError).toBeFalsy();
+    expect(result.text).toContain('demo.playwright.dev');
+  });
+
+  test('tab-new opens a new tab', async ({ testPage: _, panelPage }) => {
+    await sendCommand(panelPage, `goto ${TEST_URL}`);
+    const before = await sendCommand(panelPage, 'tab-list');
+    const tabsBefore = countTabs(before.text);
+
+    const result = await sendCommand(panelPage, 'tab-new');
+    expect(result.isError).toBeFalsy();
+
+    const after = await sendCommand(panelPage, 'tab-list');
+    expect(countTabs(after.text)).toBe(tabsBefore + 1);
+  });
+
+  test('tab-select switches to a tab by id', async ({ testPage: _, panelPage }) => {
+    await sendCommand(panelPage, `goto ${TEST_URL}`);
+    await sendCommand(panelPage, 'tab-new');
+
+    const list = await sendCommand(panelPage, 'tab-list');
+    const tabId = findTabId(list.text, 'demo.playwright.dev');
+    expect(tabId).not.toBeNull();
+
+    const result = await sendCommand(panelPage, `tab-select ${tabId}`);
+    expect(result.isError).toBeFalsy();
+  });
+
+  test('tab-close closes a tab', async ({ testPage: _, panelPage }) => {
+    await sendCommand(panelPage, `goto ${TEST_URL}`);
+    await sendCommand(panelPage, 'tab-new');
+    const before = await sendCommand(panelPage, 'tab-list');
+    const tabsBefore = countTabs(before.text);
+
+    const blankId = findTabId(before.text, 'about:blank');
+    if (blankId) {
+      const result = await sendCommand(panelPage, `tab-close ${blankId}`);
+      expect(result.isError).toBeFalsy();
+    }
+
+    const after = await sendCommand(panelPage, 'tab-list');
+    expect(countTabs(after.text)).toBe(tabsBefore - 1);
+  });
+
+  test('tab aliases tl, tn work', async ({ testPage: _, panelPage }) => {
+    const list = await sendCommand(panelPage, 'tl');
+    expect(list.isError).toBeFalsy();
+
+    const newTab = await sendCommand(panelPage, 'tn');
+    expect(newTab.isError).toBeFalsy();
+  });
+});
+
+// ─── Errors ──────────────────────────────────────────────────────────────────
+
+test.describe('Errors', () => {
+  test('unknown command returns error', async ({ panelPage }) => {
+    const result = await sendCommand(panelPage, 'nonexistent');
+    expect(result.isError).toBe(true);
+    expect(result.text).toContain('Unknown command');
+  });
+
+  test('invalid ref returns error', async ({ testPage: _, panelPage }) => {
+    await sendCommand(panelPage, `goto ${TEST_URL}`);
+    const result = await sendCommand(panelPage, 'click e9999');
+    expect(result.isError).toBe(true);
+  });
+});
+
+// ─── run-code ────────────────────────────────────────────────────────────────
+// run-code routes through the sandbox iframe inside the panel, so these tests
+// drive the UI directly instead of using sendCommand.
+
+test.describe('run-code', () => {
+  test('returns page title', async ({ testPage: _, panelPage }) => {
+    await sendCommand(panelPage, `goto ${SECOND_URL}`);
+    const result = await sendViaUI(panelPage, 'run-code await page.title()');
+    expect(result.isError).toBe(false);
+    expect(result.text).toContain('Playwright');
+  });
+
+  test('executes chained locator calls', async ({ testPage: _, panelPage }) => {
+    await sendCommand(panelPage, `goto ${SECOND_URL}`);
+    const result = await sendViaUI(panelPage, "run-code await page.locator('text=Get started').click()");
+    expect(result.isError).toBe(false);
+    expect(result.text).toBe('Done');
+  });
+
+  test('returns Done for void actions', async ({ testPage: _, panelPage }) => {
+    await sendCommand(panelPage, `goto ${TEST_URL}`);
+    const result = await sendViaUI(panelPage, "run-code await page.click('.header')");
+    expect(result.isError).toBe(false);
+    expect(result.text).toBe('Done');
+  });
+
+  test('goto does not hang', async ({ testPage: _, panelPage }) => {
+    const result = await sendViaUI(panelPage, `run-code await page.goto('${TEST_URL}')`);
+    expect(result.isError).toBe(false);
+    expect(result.text).toBe('Done');
+  });
+
+  test('reports errors from failed calls', async ({ testPage: _, panelPage }) => {
+    await sendCommand(panelPage, `goto ${TEST_URL}`);
+    const result = await sendViaUI(panelPage, "run-code await page.locator('.nonexistent-xyz').click({ timeout: 1000 })");
+    expect(result.isError).toBe(true);
+  });
 });

--- a/packages/extension/e2e/commands/fixtures.ts
+++ b/packages/extension/e2e/commands/fixtures.ts
@@ -1,50 +1,126 @@
 /**
  * Command integration test fixtures.
  *
- * Launches a real Engine + CommandServer, sends commands via HTTP,
- * and asserts on actual Playwright browser behavior.
+ * Launches Chromium with the real extension loaded. Commands are sent via
+ * chrome.runtime.sendMessage to the background service worker (playwright-crx),
+ * with no Engine or CommandServer involved.
  */
 
-import { test as base } from '@playwright/test';
-import { Engine, CommandServer } from '@playwright-repl/core';
+import { test as base, chromium, type BrowserContext, type Page, type Worker } from '@playwright/test';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
-type EngineContext = { engine: Engine; server: CommandServer; port: number };
-type RunResult = { text: string; isError: boolean; image?: string };
-type RunFn = (command: string) => Promise<RunResult>;
+export { expect } from '@playwright/test';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const EXTENSION_PATH = path.resolve(__dirname, '../../dist');
+
+type ExtensionContext = { context: BrowserContext; extensionId: string; sw: Worker };
 
 export const test = base.extend<
-  { run: RunFn },
-  { engineContext: EngineContext }
+  { panelPage: Page; testPage: Page },
+  { extensionContext: ExtensionContext }
 >({
-  // Worker-scoped: one Engine + CommandServer per worker
-  engineContext: [async ({}, use) => {
-    const engine = new Engine();
-    await engine.start({ browser: 'chromium', headed: false });
+  // Worker-scoped: browser launched once, reused across all tests in a worker
+  extensionContext: [async ({}, use) => {
+    const context = await chromium.launchPersistentContext('', {
+      channel: 'chromium',
+      headless: !process.env.HEADED,
+      args: [
+        `--disable-extensions-except=${EXTENSION_PATH}`,
+        `--load-extension=${EXTENSION_PATH}`,
+        '--no-first-run',
+        '--no-default-browser-check',
+      ],
+    });
 
-    const server = new CommandServer(engine);
-    await server.start(0); // OS-assigned port
+    // Navigate the initial blank tab to a real page so auto-attach never sees about:blank
+    const [initialPage] = context.pages();
+    if (initialPage) await initialPage.goto('https://httpbin.org');
 
-    await use({ engine, server, port: server.port as number });
+    let sw = context.serviceWorkers()[0];
+    if (!sw) sw = await context.waitForEvent('serviceworker');
+    const extensionId = sw.url().split('/')[2];
 
-    await server.close();
-    await engine.close();
+    await use({ context, extensionId, sw });
+    await context.close();
   }, { scope: 'worker' }],
 
-  // Test-scoped: run() helper sends commands to the real server
-  run: async ({ engineContext }, use) => {
-    const { port } = engineContext;
+  // Test-scoped: fresh panel page per test
+  panelPage: async ({ extensionContext }, use) => {
+    const { context, extensionId } = extensionContext;
+    const page = await context.newPage();
+    await page.goto(`chrome-extension://${extensionId}/panel/panel.html`);
+    await page.waitForSelector('[data-testid="command-input"]', { timeout: 10000 });
+    await use(page);
+    await page.close();
+  },
 
-    const run = async (command: string): Promise<RunResult> => {
-      const res = await fetch(`http://localhost:${port}/run`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ raw: command }),
-      });
-      return res.json();
-    };
+  // Test-scoped: target page navigated to playwright.dev, attached to extension
+  testPage: async ({ extensionContext, panelPage }, use) => {
+    const { context } = extensionContext;
+    const page = await context.newPage();
+    await page.goto('https://playwright.dev');
 
-    await use(run);
+    // Bring to front so it's the active tab for chrome.tabs.query
+    await page.bringToFront();
+
+    // Attach the extension to the active tab
+    await panelPage.evaluate(() =>
+      new Promise(resolve =>
+        chrome.tabs.query({ active: true, lastFocusedWindow: true }, ([tab]) =>
+          tab?.id
+            ? chrome.runtime.sendMessage({ type: 'attach', tabId: tab.id }, resolve)
+            : resolve({ ok: false })
+        )
+      )
+    );
+
+    await use(page);
+    await page.close();
   },
 });
 
-export { expect } from '@playwright/test';
+/**
+ * Send a REPL command via chrome.runtime.sendMessage from the panel context.
+ * Bypasses the UI — goes directly to the background service worker.
+ */
+export async function sendCommand(
+  panelPage: Page,
+  command: string,
+): Promise<{ text: string; isError: boolean; image?: string }> {
+  return panelPage.evaluate((cmd) =>
+    new Promise(resolve =>
+      chrome.runtime.sendMessage({ type: 'run', command: cmd }, resolve)
+    ), command
+  );
+}
+
+/**
+ * Submit a command through the panel UI (CodeMirror input → Enter).
+ * Required for run-code which routes through the sandbox iframe, not the background.
+ */
+export async function sendViaUI(
+  panelPage: Page,
+  command: string,
+): Promise<{ text: string; isError: boolean }> {
+  const resultSelector = '[data-type="success"], [data-type="error"]';
+  const prevCount = await panelPage.locator(resultSelector).count();
+
+  await panelPage.getByTestId('command-input').locator('.cm-content').click();
+  await panelPage.keyboard.type(command, { delay: 0 });
+  await panelPage.keyboard.press('Escape'); // close autocomplete
+  await panelPage.keyboard.press('Enter');
+
+  // Wait for a new result line (sandbox init + async round-trip)
+  await panelPage.waitForFunction(
+    ({ sel, n }) => document.querySelectorAll(sel).length > n,
+    { sel: resultSelector, n: prevCount },
+    { timeout: 15000 },
+  );
+
+  const last = panelPage.locator(resultSelector).last();
+  const text = (await last.textContent()) ?? '';
+  const isError = (await last.getAttribute('data-type')) === 'error';
+  return { text, isError };
+}

--- a/packages/extension/public/manifest.json
+++ b/packages/extension/public/manifest.json
@@ -29,6 +29,9 @@
   "side_panel": {
     "default_path": "panel/panel.html"
   },
+  "sandbox": {
+    "pages": ["sandbox.html"]
+  },
   "background": {
     "service_worker": "background.js",
     "type": "module"

--- a/packages/extension/public/sandbox.html
+++ b/packages/extension/public/sandbox.html
@@ -1,0 +1,85 @@
+<!DOCTYPE html>
+<html>
+<head><meta charset="utf-8"></head>
+<body>
+<script>
+(function () {
+  // Chain-based proxy: builds up [{method, args}, ...] and sends the full chain
+  // only when awaited — so page.locator('.btn').click() works without serializing Locator.
+  function createPageProxy() {
+    function makeChainProxy(chain) {
+      var promise = null;
+      function getPromise() {
+        if (!promise) {
+          promise = new Promise(function (resolve, reject) {
+            var id = Math.random().toString(36).slice(2);
+            function handler(e) {
+              if (!e.data || e.data.type !== 'page-result' || e.data.id !== id) return;
+              window.removeEventListener('message', handler);
+              if (e.data.error) reject(new Error(e.data.error));
+              else resolve(e.data.result);
+            }
+            window.addEventListener('message', handler);
+            window.parent.postMessage({ type: 'page-call', chain: chain, id: id }, '*');
+          });
+        }
+        return promise;
+      }
+      return new Proxy({}, {
+        get: function (_, prop) {
+          if (typeof prop !== 'string') return undefined;
+          if (prop === 'then') return function (res, rej) { return getPromise().then(res, rej); };
+          if (prop === 'catch') return function (rej) { return getPromise().catch(rej); };
+          if (prop === 'finally') return function (fn) { return getPromise().finally(fn); };
+          return function () {
+            var args = Array.prototype.slice.call(arguments);
+            return makeChainProxy(chain.concat([{ method: prop, args: args }]));
+          };
+        }
+      });
+    }
+    return new Proxy({}, {
+      get: function (_, method) {
+        if (typeof method !== 'string') return undefined;
+        return function () {
+          var args = Array.prototype.slice.call(arguments);
+          return makeChainProxy([{ method: method, args: args }]);
+        };
+      }
+    });
+  }
+
+  var AsyncFunction = Object.getPrototypeOf(async function () {}).constructor;
+
+  window.addEventListener('message', async function (e) {
+    if (!e.data || e.data.type !== 'run-code') return;
+    var code = e.data.code;
+    var id = e.data.id;
+    var page = createPageProxy();
+    try {
+      var trimmed = code.trim();
+      var isFnExpr = /^(async\s*)?\(|^(async\s+)?function\b/.test(trimmed);
+      var body;
+      if (isFnExpr) {
+        body = 'return (' + trimmed + ')(page)';
+      } else {
+        // Try as expression to capture return value, else run as statements
+        try {
+          new AsyncFunction('page', 'return (' + trimmed + ')');
+          body = 'return (' + trimmed + ')';
+        } catch (_) {
+          body = trimmed;
+        }
+      }
+      var fn = new AsyncFunction('page', body);
+      var result = await fn(page);
+      var text = result != null ? String(result) : 'Done';
+      window.parent.postMessage({ type: 'run-code-result', id: id, result: text }, '*');
+    } catch (err) {
+      window.parent.postMessage({ type: 'run-code-result', id: id, error: String(err) }, '*');
+    }
+  });
+})();
+</script>
+</body>
+</html>

--- a/packages/extension/src/background.ts
+++ b/packages/extension/src/background.ts
@@ -198,6 +198,31 @@ async function stopRecording(): Promise<{ ok: boolean }> {
   return { ok: true };
 }
 
+// ─── Page call (sandbox iframe → background) ─────────────────────────────────
+
+async function handlePageCall(chain: { method: string; args: unknown[] }[]): Promise<{ result?: unknown; error?: string }> {
+  const page = await ensurePage();
+  if (!page) return { error: 'Not attached to any tab. Click Attach to connect.' };
+  try {
+    let obj: any = page;
+    for (const { method, args } of chain) {
+      const fn = obj[method];
+      if (typeof fn !== 'function') return { error: `${method} is not a function` };
+      obj = await fn.apply(obj, args);
+    }
+    // Only serialize plain data — class instances (Locator, Response) return null
+    const isPlainData = obj == null || typeof obj !== 'object' || Array.isArray(obj) || Object.getPrototypeOf(obj) === Object.prototype;
+    if (!isPlainData) return { result: null };
+    try {
+      return { result: JSON.parse(JSON.stringify(obj)) };
+    } catch {
+      return { result: null };
+    }
+  } catch (e) {
+    return { error: String(e) };
+  }
+}
+
 // ─── Message Handler ─────────────────────────────────────────────────────────
 
 chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
@@ -206,4 +231,5 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
   if (msg.type === 'health')       { sendResponse({ ok: !!crxApp }); return false; }
   if (msg.type === 'record-start') { startRecording().then(sendResponse); return true; }
   if (msg.type === 'record-stop')  { stopRecording().then(sendResponse); return true; }
+  if (msg.type === 'page-call')    { handlePageCall(msg.chain).then(sendResponse); return true; }
 });

--- a/packages/extension/src/panel/lib/run.ts
+++ b/packages/extension/src/panel/lib/run.ts
@@ -4,6 +4,7 @@ import { COMMANDS } from '@/lib/commands';
 import type { CommandResult } from '@/types';
 import type { Action } from '@/reducer';
 import { getCommandHistory, clearHistory, addCommand } from '@/lib/command-history';
+import { runCodeInSandbox } from '@/lib/sandbox-runner';
 
 function runLocalCommand(command: string, dispatch: React.Dispatch<Action>): boolean {
     if (command.trim().startsWith('#')) {
@@ -43,9 +44,24 @@ export async function runAndDispatch(command: string, dispatch: React.Dispatch<A
 
     addCommand(command);
     dispatch({ type: 'COMMAND_SUBMITTED', line: { text: command, type: 'command' } });
+
+    // run-code is handled locally via sandbox iframe (bypasses background service worker)
+    const cmdName = command.trim().split(/\s+/)[0].toLowerCase();
+    if (cmdName === 'run-code') {
+        const code = command.trim().slice('run-code'.length).trim();
+        try {
+            const text = await runCodeInSandbox(code);
+            dispatch({ type: 'COMMAND_SUCCESS', line: { text, type: 'success' } });
+            return { text, isError: false };
+        } catch (e) {
+            const text = String(e);
+            dispatch({ type: 'COMMAND_SUCCESS', line: { text, type: 'error' } });
+            return { text, isError: true };
+        }
+    }
+
     try {
         const result = await executeCommand(command);
-        const cmdName = command.trim().split(/\s+/)[0];
         const text = filterResponse(result.text, cmdName);
         if (cmdName === 'snapshot') {
             dispatch({ type: 'COMMAND_SUCCESS', line: { text, type: 'snapshot' } });

--- a/packages/extension/src/panel/lib/sandbox-runner.ts
+++ b/packages/extension/src/panel/lib/sandbox-runner.ts
@@ -1,0 +1,81 @@
+/**
+ * Manages the sandboxed iframe used to execute run-code commands.
+ *
+ * The sandbox page (sandbox.html) has a relaxed CSP that allows eval/new AsyncFunction.
+ * It communicates with the panel via postMessage:
+ *
+ *   panel → sandbox:  { type: 'run-code', code, id }
+ *   sandbox → panel:  { type: 'page-call', chain: [{method, args}], id }  (chained call)
+ *   panel → sandbox:  { type: 'page-result', id, result | error }
+ *   sandbox → panel:  { type: 'run-code-result', id, result | error }
+ *
+ * Each page method call is forwarded to background.ts via chrome.runtime.sendMessage.
+ */
+
+type PendingRun = { resolve: (v: string) => void; reject: (e: Error) => void };
+
+let frame: HTMLIFrameElement | null = null;
+let frameReady: Promise<HTMLIFrameElement> | null = null;
+const pendingRuns = new Map<string, PendingRun>();
+
+function initSandbox(): Promise<HTMLIFrameElement> {
+    if (frameReady) return frameReady;
+
+    frame = document.createElement('iframe');
+    frame.src = chrome.runtime.getURL('sandbox.html');
+    frame.style.cssText = 'display:none;position:absolute;width:0;height:0;border:none;';
+    document.body.appendChild(frame);
+
+    frameReady = new Promise<HTMLIFrameElement>(resolve => {
+        frame!.addEventListener('load', () => resolve(frame!), { once: true });
+    });
+
+    window.addEventListener('message', async (e: MessageEvent) => {
+        if (!e.data) return;
+
+        // page chain call from sandbox → forward full chain to background
+        if (e.data.type === 'page-call') {
+            const { chain, id } = e.data;
+            try {
+                const response = await chrome.runtime.sendMessage({ type: 'page-call', chain });
+                if (response?.error) {
+                    frame!.contentWindow!.postMessage(
+                        { type: 'page-result', id, error: response.error },
+                        '*'
+                    );
+                } else {
+                    frame!.contentWindow!.postMessage(
+                        { type: 'page-result', id, result: response?.result ?? null },
+                        '*'
+                    );
+                }
+            } catch (err) {
+                frame!.contentWindow!.postMessage(
+                    { type: 'page-result', id, error: String(err) },
+                    '*'
+                );
+            }
+        }
+
+        // run-code completed
+        if (e.data.type === 'run-code-result') {
+            const { id, result, error } = e.data;
+            const pending = pendingRuns.get(id);
+            if (!pending) return;
+            pendingRuns.delete(id);
+            if (error) pending.reject(new Error(error));
+            else pending.resolve(result);
+        }
+    });
+
+    return frameReady;
+}
+
+export async function runCodeInSandbox(code: string): Promise<string> {
+    const f = await initSandbox();
+    const id = Math.random().toString(36).slice(2);
+    return new Promise<string>((resolve, reject) => {
+        pendingRuns.set(id, { resolve, reject });
+        f.contentWindow!.postMessage({ type: 'run-code', code, id }, '*');
+    });
+}


### PR DESCRIPTION
## Summary

- Add `public/sandbox.html`: sandboxed iframe with a chain-based `page` proxy that allows `eval`/`new AsyncFunction` (Chrome requires a sandbox page for relaxed CSP)
- Add `"sandbox"` entry to `manifest.json` so Chrome permits the iframe
- Add `src/panel/lib/sandbox-runner.ts`: initialises the hidden sandbox iframe, relays `page-call` chains to the background service worker, and resolves `run-code` results
- Update `src/panel/lib/run.ts`: intercept `run-code` commands and route them through the sandbox instead of the background service worker
- Update `src/background.ts`: add `handlePageCall()` to execute chained Playwright page method calls forwarded from the sandbox, and wire it into the message handler

**Command flow for `run-code`:**
```
panel (run.ts)
  → sandbox iframe (sandbox.html) — AsyncFunction executes user code
    → page.locator(...).click() proxy → postMessage page-call
  → sandbox-runner.ts relays → chrome.runtime.sendMessage page-call
  → background.ts handlePageCall() — walks chain on real Page object
  → result back to sandbox → run-code-result → panel
```

- Migrate `e2e/commands/` fixtures and tests from Engine+CommandServer (old HTTP architecture) to the real extension via `chrome.runtime.sendMessage`; add 5 `run-code` E2E tests that exercise the full sandbox→background→page stack

## Test plan

- [x] All 43 command E2E tests pass against the real extension (no Engine/CommandServer)
- [x] `run-code` tests: `page.title()`, chained locators, void actions, `page.goto()`, error reporting
- [x] All 77 component tests pass
- [x] All 157 unit tests pass
- [x] Build succeeds with no TypeScript errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)