### PR TITLE
feat: expose page, crxApp, activeTabId, expect on globalThis after attach

### DIFF
--- a/packages/extension/src/background.ts
+++ b/packages/extension/src/background.ts
@@ -78,6 +78,7 @@ async function attachToTab(tabId: number): Promise<{ ok: boolean; url?: string; 
       }
     }
     activeTabId = tabId;
+    Object.assign(globalThis, { page: currentPage, crxApp, activeTabId, expect });
     return { ok: true, url: currentPage.url() };
   } catch (e) {
     activeTabId = null;


### PR DESCRIPTION
## Summary

- After `attachToTab` succeeds, assigns `{ page, crxApp, activeTabId, expect }` to `globalThis` in the service worker
- Enables direct use from the background service worker DevTools console (`chrome://extensions` → service worker → Inspect):
  ```js
  await page.title()
  await page.locator('h1').textContent()
  await expect(page).toHaveTitle(/foo/)
  ```
- Mirrors `playwright-repl-crx` background.ts behaviour; adds `expect` which crx doesn't have

## Test plan
- [ ] Open extension → panel auto-attaches
- [ ] Open `chrome://extensions` → Find the extension → Click "service worker" to open DevTools
- [ ] In console: `await page.title()` → returns current page title
- [ ] In console: `await expect(page).toHaveTitle(/.*/)` → resolves without error
- [ ] Unit tests: 157 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)