### PR TITLE
feat: console input flows inline with entries

### DIFF
--- a/packages/extension/src/panel/components/Console/ConsoleOutput.tsx
+++ b/packages/extension/src/panel/components/Console/ConsoleOutput.tsx
@@ -1,20 +1,12 @@
-import { useEffect, useRef } from 'react';
 import { ConsoleEntry } from './ConsoleEntry';
 import type { ConsoleEntry as Entry } from './types';
 
 export function ConsoleOutput({ entries }: { entries: Entry[] }) {
-    const bottomRef = useRef<HTMLDivElement>(null);
-
-    useEffect(() => {
-        bottomRef.current?.scrollIntoView({ behavior: 'instant' });
-    }, [entries]);
-
     return (
-        <div className="flex-1 overflow-y-auto py-1 px-2">
+        <>
             {entries.map(e => (
                 <ConsoleEntry key={e.id} entry={e} />
             ))}
-            <div ref={bottomRef} />
-        </div>
+        </>
     );
 }

--- a/packages/extension/src/panel/components/Console/index.tsx
+++ b/packages/extension/src/panel/components/Console/index.tsx
@@ -1,4 +1,4 @@
-import { useImperativeHandle, useRef, Ref } from 'react';
+import { useImperativeHandle, useRef, useEffect, Ref } from 'react';
 import { useConsole } from './useConsole';
 import { ConsoleOutput } from './ConsoleOutput';
 import { ConsoleInput, type ConsoleInputHandle } from './ConsoleInput';
@@ -13,15 +13,23 @@ interface Props extends ConsoleProps {
 export function Console({ executors, className, ref }: Props) {
     const { entries, execute, clear } = useConsole(executors);
     const inputRef = useRef<ConsoleInputHandle>(null);
+    const bottomRef = useRef<HTMLDivElement>(null);
 
     useImperativeHandle(ref, () => ({ clear }));
 
+    useEffect(() => {
+        bottomRef.current?.scrollIntoView({ behavior: 'instant' });
+    }, [entries]);
+
     return (
         <div className={`flex flex-col flex-1 min-h-20 overflow-hidden ${className ?? ''}`} data-testid="console-pane">
-            <ConsoleOutput entries={entries} />
-            <div className="flex items-start gap-1 border-t border-(--border-primary) py-1 px-2">
-                <span className="text-(--color-prompt) shrink-0">&gt;</span>
-                <ConsoleInput ref={inputRef} onSubmit={execute} onClear={clear} />
+            <div className="flex-1 overflow-y-auto py-1 px-2">
+                <ConsoleOutput entries={entries} />
+                <div className="flex items-start gap-1 py-0.5">
+                    <span className="text-(--color-prompt) shrink-0">&gt;</span>
+                    <ConsoleInput ref={inputRef} onSubmit={execute} onClear={clear} />
+                </div>
+                <div ref={bottomRef} />
             </div>
         </div>
     );


### PR DESCRIPTION
## Summary

- Input row is now inside the single scrollable container, flowing after the last entry (Chrome DevTools style)
- Removed the fixed-at-bottom input with its `border-t` separator
- Auto-scroll anchor placed after the input row — new entries keep the input visible
- `ConsoleOutput` simplified to a pure list renderer; scroll ownership moved to `Console`

## Test plan

- [ ] Type an expression and submit — input appears inline below the result, scroll follows
- [ ] Many entries — scroll auto-follows to keep input visible
- [ ] Ctrl+L clears entries and input stays at top of scroll area

🤖 Generated with [Claude Code](https://claude.com/claude-code)