### PR TITLE
feat: console multi-line input display

### DIFF
--- a/packages/extension/src/panel/components/Console/ConsoleEntry.tsx
+++ b/packages/extension/src/panel/components/Console/ConsoleEntry.tsx
@@ -5,11 +5,13 @@ export function ConsoleEntry({ entry }: { entry: Entry }) {
     return (
         <div className="py-0.5 pb-1 border-b border-(--border-primary) last:border-b-0" data-status={entry.status}>
 
-            {/* Input line */}
-            <div className="flex items-baseline gap-1">
-                <span className="text-(--color-prompt) shrink-0">&gt;</span>
-                <span className="flex-1 text-(--color-command)">{entry.input}</span>
-            </div>
+            {/* Input line(s) */}
+            {entry.input.split('\n').map((line, i) => (
+                <div key={i} className="flex items-baseline gap-1">
+                    <span className="text-(--color-prompt) shrink-0">{i === 0 ? '>' : ' '}</span>
+                    <span className="flex-1 text-(--color-command)">{line}</span>
+                </div>
+            ))}
 
             {/* Result */}
             {entry.status === 'pending' && (

--- a/packages/extension/src/panel/components/Console/ConsoleInput.tsx
+++ b/packages/extension/src/panel/components/Console/ConsoleInput.tsx
@@ -86,7 +86,7 @@ export function ConsoleInput({ onSubmit, onClear, ref }: Props) {
             className="flex-1 bg-transparent border-none outline-none resize-none font-[inherit] text-inherit leading-4.5 p-0 max-h-30 overflow-y-auto placeholder:text-(--text-placeholder)"
             rows={1}
             spellCheck={false}
-            placeholder="js expression, page.url(), or .pw command…"
+            placeholder="js expression, page.url(), or .pw command… (Shift+Enter for newline)"
             onKeyDown={handleKeyDown}
             onInput={handleInput}
         />


### PR DESCRIPTION
## Summary

- `ConsoleEntry` now renders multi-line inputs line by line: first line shows `>`, continuation lines show ` ` (aligned)
- `ConsoleInput` placeholder updated to mention `Shift+Enter` for inserting newlines

## Test plan

- [ ] Type a single-line expression — displays as before
- [ ] Type `const x = 1` + Shift+Enter + `x + 1` and submit — entry shows both lines with correct prefix
- [ ] Placeholder text shows the Shift+Enter hint

🤖 Generated with [Claude Code](https://claude.com/claude-code)