### PR TITLE
fix: align multi-line console entry

### DIFF
--- a/packages/extension/src/panel/components/Console/ConsoleEntry.tsx
+++ b/packages/extension/src/panel/components/Console/ConsoleEntry.tsx
@@ -3,35 +3,28 @@ import type { ConsoleEntry as Entry } from './types';
 
 export function ConsoleEntry({ entry }: { entry: Entry }) {
     return (
-        <div className="py-0.5 pb-1 border-b border-(--border-primary) last:border-b-0" data-status={entry.status}>
-
-            {/* Input line(s) */}
-            {entry.input.split('\n').map((line, i) => (
-                <div key={i} className="flex items-baseline gap-1">
-                    <span className="text-(--color-prompt) shrink-0">{i === 0 ? '>' : ' '}</span>
-                    <span className="flex-1 text-(--color-command)">{line}</span>
-                </div>
-            ))}
-
-            {/* Result */}
-            {entry.status === 'pending' && (
-                <div className="pl-4 text-(--text-dim)">…</div>
-            )}
-
-            {entry.status === 'done' && (
-                <div className="pl-4 pt-0.5">
-                    {entry.value !== undefined ? (
-                        <ObjectTree data={entry.value} />
-                    ) : (
-                        <span className="text-(--color-success)">{entry.text}</span>
-                    )}
-                </div>
-            )}
-
-            {entry.status === 'error' && (
-                <div className="pl-4 pt-0.5 text-(--color-error)">{entry.errorText}</div>
-            )}
-
+        <div className="flex items-start gap-1 py-0.5 pb-1 border-b border-(--border-primary) last:border-b-0" data-status={entry.status}>
+            <span className="text-(--color-prompt) shrink-0">{'>'}</span>
+            <div className="flex-1 min-w-0">
+                {entry.input.split('\n').map((line, i) => (
+                    <div key={i} className="text-(--color-command)">{line}</div>
+                ))}
+                {entry.status === 'pending' && (
+                    <div className="text-(--text-dim) pt-0.5">…</div>
+                )}
+                {entry.status === 'done' && (
+                    <div className="pt-0.5">
+                        {entry.value !== undefined ? (
+                            <ObjectTree data={entry.value} />
+                        ) : (
+                            <span className="text-(--color-success)">{entry.text}</span>
+                        )}
+                    </div>
+                )}
+                {entry.status === 'error' && (
+                    <div className="pt-0.5 text-(--color-error)">{entry.errorText}</div>
+                )}
+            </div>
         </div>
     );
 }


### PR DESCRIPTION
## Summary

- Replace per-line `>`/` ` prefix approach with a single outer flex row
- `>` sits on the left as a fixed-width column; all content (code lines + result) stacks in the right column
- Code continuation lines and result output are now naturally left-aligned with each other
- Matches the live input area layout exactly

## Before

Each input line had its own flex row with `>` or ` ` prefix. `' '` (space) doesn't always render at the same width as `>`, causing code lines and result to mis-align.

## After

```
> a = 1+1;    ← all on same horizontal baseline
  b = 5;
  a + b;
  7            ← result aligns with code, no extra pl-4 offset
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)