### PR TITLE
feat: add run_script MCP tool with pw/javascript language support

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -18,9 +18,9 @@
 ## Big Ideas
 
 - [ ] **Script test runner** ([#70](https://github.com/stevez/playwright-repl/issues/70)) — "Run all" button streams pass/fail per `await` statement with CM6 gutter decorations.
-- [ ] **AI test generation** ([#71](https://github.com/stevez/playwright-repl/issues/71)) — Natural language → `expect()` assertions via Claude API + snapshot context.
+- [x] **AI test generation** ([#71](https://github.com/stevez/playwright-repl/issues/71)) — Works today via MCP: Claude calls `snapshot` then generates `expect()` assertions using its own reasoning. No dedicated tool needed.
 - [x] **AI browser agent** ([#72](https://github.com/stevez/playwright-repl/issues/72)) — Claude operates the browser step-by-step via `swDebugEval` pipeline. Shipped as `@playwright-repl/mcp` in v0.13.0.
-- [ ] **MCP `run_script` tool** ([#114](https://github.com/stevez/playwright-repl/issues/114)) — Add a second MCP tool that accepts a multi-line `.pw` script, runs each line sequentially, and returns combined results. Useful for replaying known `.pw` files without per-step round trips. Single `run_command` remains preferred for AI agents (observe-and-adapt per step).
+- [x] **MCP `run_script` tool** ([#114](https://github.com/stevez/playwright-repl/issues/114)) — `run_script(script, language)` runs `.pw` scripts line-by-line or JS blocks as a single eval. Extension owns the execution logic via WebSocket `type: 'script'` message.
 - [x] **Step debugger** ([#73](https://github.com/stevez/playwright-repl/issues/73)) — Step through scripts line by line with CM6 highlighting and a variables panel.
 
 ## Medium Priority
@@ -34,7 +34,7 @@
 - [x] **Fix failing recording component tab**
 - [ ] **Editor context menu** ([#74](https://github.com/stevez/playwright-repl/issues/74)) — Right-click: Run line, Copy, Export to TypeScript.
 - [ ] **Record into editor (dual mode)** ([#75](https://github.com/stevez/playwright-repl/issues/75)) — Live incremental recording in `.pw` and `JS` modes.
-- [ ] **Capture locator** ([#76](https://github.com/stevez/playwright-repl/issues/76)) — "Pick element" mode captures `getByRole(...)`/`getByText(...)` locator strings.
+- [x] **Capture locator** ([#76](https://github.com/stevez/playwright-repl/issues/76)) — Uses playwright-crx recorder's built-in Pick locator button; converts internal selector to `getByRole(...)`/`getByText(...)` etc. and shows in console.
 - [ ] **Extract shared `resolveArgs`** ([#77](https://github.com/stevez/playwright-repl/issues/77)) — Dedup verify/text-locator logic between `extension-server.ts` and `repl.ts`.
 - [ ] **Failed commands not recorded** ([#78](https://github.com/stevez/playwright-repl/issues/78)) — CLI `session.record(line)` skips failed commands.
 - [ ] **History write errors silently swallowed** ([#79](https://github.com/stevez/playwright-repl/issues/79)) — `catch {}` hides disk-full/permission errors.

--- a/packages/core/src/bridge-server.ts
+++ b/packages/core/src/bridge-server.ts
@@ -35,7 +35,16 @@ export class BridgeServer {
         const id = Math.random().toString(36).slice(2);
         return new Promise((resolve) => {
             this.pending.set(id, resolve);
-            this.socket!.send(JSON.stringify({ id, command }));
+            this.socket!.send(JSON.stringify({ id, command, type: 'command' }));
+        });
+    }
+
+    async runScript(script: string, language: 'pw' | 'javascript' = 'pw'): Promise<EngineResult> {
+        if (!this.connected) return { text: 'Extension not connected', isError: true };
+        const id = Math.random().toString(36).slice(2);
+        return new Promise((resolve) => {
+            this.pending.set(id, resolve);
+            this.socket!.send(JSON.stringify({ id, command: script, type: 'script', language }));
         });
     }
 

--- a/packages/extension/src/panel/App.tsx
+++ b/packages/extension/src/panel/App.tsx
@@ -43,10 +43,25 @@ function App() {
       try {
         ws = new WebSocket(`ws://localhost:${port}`);
         ws.onmessage = async (e) => {
-          const msg = JSON.parse(e.data as string) as { id: string; command: string };
-          const result = await executeCommand(msg.command).catch((err: unknown) => ({
-            text: String(err), isError: true,
-          }));
+          const msg = JSON.parse(e.data as string) as { id: string; command: string; type?: 'command' | 'script'; language?: 'pw' | 'javascript' };
+          let result: { text: string; isError: boolean; image?: string };
+          if (msg.type === 'script') {
+            if (msg.language !== 'javascript') {
+              const lines = msg.command.split('\n').map(l => l.trim()).filter(l => l && !l.startsWith('#'));
+              const output: string[] = [];
+              let isError = false;
+              for (const line of lines) {
+                const r = await executeCommand(line).catch((err: unknown) => ({ text: String(err), isError: true }));
+                output.push(`${r.isError ? '✗' : '✓'} ${line}${r.text ? `\n  ${r.text}` : ''}`);
+                if (r.isError) { isError = true; break; }
+              }
+              result = { text: output.join('\n'), isError };
+            } else {
+              result = await executeCommand(msg.command).catch((err: unknown) => ({ text: String(err), isError: true }));
+            }
+          } else {
+            result = await executeCommand(msg.command).catch((err: unknown) => ({ text: String(err), isError: true }));
+          }
           if (ws?.readyState === WebSocket.OPEN) {
             ws.send(JSON.stringify({ id: msg.id, ...result }));
           }

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -78,5 +78,37 @@ server.registerTool(
     }
 );
 
+const RUN_SCRIPT_DESCRIPTION = `\
+Run a multi-line script, returning combined pass/fail results.
+Useful for replaying a known script without per-step round trips.
+Prefer run_command for AI-driven exploration where you need to observe and adapt after each step.
+
+language='pw': each line is a .pw keyword command, run sequentially. Lines starting with # are skipped. Stops on first error.
+language='javascript': the entire script is run as a single JavaScript/Playwright block.`;
+
+server.registerTool(
+    'run_script',
+    {
+        description: RUN_SCRIPT_DESCRIPTION,
+        inputSchema: {
+            script: z.string().describe('The script to execute'),
+            language: z.enum(['pw', 'javascript']).describe("'pw' for keyword commands (one per line), 'javascript' for a JS/Playwright block"),
+        },
+    },
+    async ({ script, language }) => {
+        if (!srv.connected) {
+            return {
+                content: [{ type: 'text' as const, text: 'Browser not connected. Open Chrome with the playwright-repl extension — it connects automatically.' }],
+                isError: true,
+            };
+        }
+        const result = await srv.runScript(script, language);
+        return {
+            content: [{ type: 'text' as const, text: result.text || 'Done' }],
+            isError: result.isError,
+        };
+    }
+);
+
 const transport = new StdioServerTransport();
 await server.connect(transport);


### PR DESCRIPTION
## Summary

- Adds `run_script(script, language)` as a second MCP tool alongside `run_command`
- `language='pw'`: extension splits script by line, runs each as a `.pw` keyword command with per-line `✓`/`✗` output
- `language='javascript'`: extension runs the entire script as a single JS/Playwright block via `swDebugEval`
- `BridgeServer.runScript()` sends `{ type: 'script', language }` over WebSocket — extension owns the execution logic
- `run_command` sends `{ type: 'command' }` — clean protocol separation between single-step and batch execution
- Prefer `run_command` for AI-driven exploration (observe-and-adapt); use `run_script` for replaying known scripts

## Test plan

- [ ] `run_script` with `language='pw'`: pass a multi-line `.pw` script, verify each line runs and output shows `✓`/`✗` per line
- [ ] `run_script` with `language='javascript'`: pass a multi-line JS block (e.g. `await page.goto(...)\nawait expect(page).toHaveTitle(...)`) — verify it runs as one unit
- [ ] `run_command` still works as before (single command, single result)
- [ ] Error in a `.pw` script stops execution at the failed line

Closes #114

🤖 Generated with [Claude Code](https://claude.com/claude-code)