### PR TITLE
feat: generate-test MCP prompt template + v0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## v0.14.0 — AI Test Generation
+
+**2026-03-09**
+
+### New: `run_script` MCP tool
+
+- **Batch script execution**: `run_script` sends multi-line scripts to the extension in a single call. Supports two languages:
+  - `language="pw"` — splits by line, runs each keyword command sequentially, returns ✓/✗ per line
+  - `language="javascript"` — runs the entire block as one `swDebugEval` call (for `await page.*`, `expect()`, etc.)
+
+### New: `generate-test` MCP prompt
+
+- **AI-driven test generation**: `/generate-test` prompt template in Claude Desktop and Claude Code. Provide a test scenario description (and optional URL), and the AI navigates the page, takes snapshots, writes Playwright assertions, runs them via `run_script`, and iterates until all pass. Works with both natural language steps and pasted `.pw` scripts.
+
+### Features
+
+- **Pick locator**: Click elements in the page to insert their locator into the editor. ([#121](https://github.com/stevez/playwright-repl/pull/121))
+- **JS mode assertion recording**: Recording in JS mode now correctly generates `expect()` assertions. ([#121](https://github.com/stevez/playwright-repl/pull/121))
+
+### Internal
+
+- Consolidated `commands.ts` and `page-scripts.ts` into `src/panel/lib/`.
+
+---
+
 ## v0.13.0 — MCP Server + Dramaturg
 
 **2026-03-09**

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "playwright-repl",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "Interactive REPL for Playwright browser automation — keyword-driven testing from your terminal",
   "type": "module",
   "bin": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@playwright-repl/core",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "type": "module",
   "main": "./dist/index.js",
   "exports": {

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@playwright-repl/extension",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "private": true,
   "description": "Chrome DevTools panel extension for Playwright REPL",
   "type": "module",

--- a/packages/extension/public/manifest.json
+++ b/packages/extension/public/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Dramaturg",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "Playwright automation console inside Chrome — keyword commands, Playwright API, and JavaScript in one side panel.",
   "permissions": [
     "activeTab",

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -20,7 +20,7 @@ It consists of two parts working together: **Dramaturg** (a Chrome extension tha
 
 | | `@playwright-repl/mcp` | Playwright MCP | Playwriter |
 |---|:---:|:---:|:---:|
-| MCP tools exposed | **1** `run_command` | ~70 tools | **1** `execute` |
+| MCP tools exposed | **2** (`run_command` + `run_script`) | ~70 tools | **1** `execute` |
 | Uses your real session | ✅ | ❌ | ✅ |
 | Playwright runs inside browser | ✅ | ❌ | ❌ |
 | `expect()` assertions | ✅ | ❌ | ❌ |
@@ -146,6 +146,46 @@ document.title
 window.location.href
 document.querySelectorAll('a').length
 ```
+
+## Tool: `run_script`
+
+Batch execution for multi-line scripts. Two language modes:
+
+### Keyword script (`language="pw"`)
+
+Splits by line, runs each command sequentially, returns ✓/✗ per line:
+
+```
+goto https://demo.playwright.dev/todomvc/
+fill "What needs to be done?" "Buy groceries"
+press Enter
+verify-text "Buy groceries"
+```
+
+### JavaScript (`language="javascript"`)
+
+Runs the entire block as one evaluation — use for Playwright API with assertions:
+
+```js
+await page.goto('https://demo.playwright.dev/todomvc/');
+await page.getByPlaceholder('What needs to be done?').fill('Buy groceries');
+await page.keyboard.press('Enter');
+await expect(page.getByText('Buy groceries')).toBeVisible();
+```
+
+## Prompt: `generate-test`
+
+A prompt template that guides the AI to generate a passing Playwright test from a described scenario.
+
+**Args:**
+- `steps` (required) — describe the test scenario, e.g. "log in with email/password, verify the dashboard loads". Also accepts pasted `.pw` scripts.
+- `url` (optional) — URL to navigate to first.
+
+**In Claude Desktop:** click "+" → select `generate-test` → fill in the form → send.
+
+**In Claude Code:** `/mcp__playwright-repl__generate-test`
+
+The AI navigates the page, takes snapshots, writes Playwright assertions, runs them via `run_script(language="javascript")`, and iterates until all pass.
 
 ## Tips for AI agents
 

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@playwright-repl/mcp",
-    "version": "0.13.0",
+    "version": "0.14.0",
     "type": "module",
     "bin": {
         "playwright-repl-mcp": "./dist/index.js"

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -110,5 +110,50 @@ server.registerTool(
     }
 );
 
+
+const GENERATE_TEST_PROMPT = (steps: string, url?: string) => `\
+Generate a passing Playwright test for the following scenario:
+${steps}
+
+Workflow:
+1. ${url ? `Navigate to ${url} using run_command('goto ${url}').` : 'Navigate to the target URL using run_command.'}
+2. Take a snapshot using run_command('snapshot') to understand the page structure.
+3. Interact with the page as needed (click, fill, press) using run_command.
+4. After each interaction, take another snapshot to verify the state before asserting.
+5. Write assertions using \`expect\`.
+
+Example pattern:
+  await page.goto('https://example.com');
+  await expect(page).toHaveTitle('Example', { exact: true });
+  await expect(page.getByRole('heading', { name: 'Welcome' })).toBeVisible();
+  await page.getByRole('link', { name: 'Get started', exact: true }).click();
+  await expect(page.getByRole('heading', { name: 'Installation' })).toBeVisible();
+
+Code constraints:
+- Use only \`page\` and \`expect\` — available as globals, do NOT import them
+- Plain \`await\` statements only — no \`import\`, no \`test()\` wrapper, no \`describe()\`
+- Use \`exact: true\` when a locator text might match multiple elements
+
+Once you have the code, run it with run_script(language="javascript").
+If any assertion fails, read the error, fix the code, and run again until all pass.
+Show the final passing code.`;
+
+server.registerPrompt(
+  'generate-test',
+  {
+    description: 'Generate a passing Playwright test from a described scenario',
+    argsSchema: {
+      steps: z.string().describe('Describe the test scenario, e.g. "log in with email/password, verify the dashboard loads"'),
+      url: z.string().optional().describe('URL to navigate to first (optional)'),
+    },
+  },
+  ({ steps, url }) => ({
+    messages: [{
+      role: 'user' as const,
+      content: { type: 'text' as const, text: GENERATE_TEST_PROMPT(steps, url) },
+    }],
+  })
+);
+
 const transport = new StdioServerTransport();
 await server.connect(transport);


### PR DESCRIPTION
## Summary

- **`generate-test` prompt template**: AI generates passing Playwright tests from described scenarios or pasted `.pw` scripts. User provides `steps` (and optional `url`), AI navigates, snapshots, writes assertions, runs via `run_script(language="javascript")`, and iterates until all pass.
- **v0.14.0**: Bump all packages, update CHANGELOG and MCP README with `run_script` tool + `generate-test` prompt docs.

## Test plan

- [x] Tested `generate-test` prompt in Claude Desktop with natural language steps (Playwright homepage)
- [x] Tested with pasted `.pw` script (todomvc add-todos example)
- [x] Build passes

Closes #123

🤖 Generated with [Claude Code](https://claude.com/claude-code)