### PR TITLE
feat: capture console.log/warn from JS editor scripts

### DIFF
--- a/packages/extension/e2e/commands/commands.test.ts
+++ b/packages/extension/e2e/commands/commands.test.ts
@@ -435,3 +435,29 @@ test.describe('run-code: expect()', () => {
     expect(result.text).toBe('Done');
   });
 });
+
+// ─── Console.log capture ──────────────────────────────────────────────────────
+// console.log/error/warn in run-code (swDebugEval context) should appear in the
+// output pane via Runtime.consoleAPICalled CDP events.
+
+test.describe('Console.log capture', () => {
+  test('console.log string appears in output', async ({ testPage: _, panelPage }) => {
+    await sendCommand(panelPage, `goto ${TEST_URL}`);
+    await sendViaUI(panelPage, 'run-code console.log("e2e-log-marker")');
+    await expect(panelPage.getByTestId('output')).toContainText('e2e-log-marker');
+  });
+
+  test('console.log object shows properties', async ({ testPage: _, panelPage }) => {
+    await sendCommand(panelPage, `goto ${TEST_URL}`);
+    await sendViaUI(panelPage, 'run-code console.log({testKey: "testVal"})');
+    const output = panelPage.getByTestId('output');
+    await expect(output).toContainText('testKey');
+    await expect(output).toContainText('testVal');
+  });
+
+  test('console.warn appears in output', async ({ testPage: _, panelPage }) => {
+    await sendCommand(panelPage, `goto ${TEST_URL}`);
+    await sendViaUI(panelPage, 'run-code console.warn("e2e-warn-marker")');
+    await expect(panelPage.getByTestId('output')).toContainText('e2e-warn-marker');
+  });
+});

--- a/packages/extension/src/panel/App.tsx
+++ b/packages/extension/src/panel/App.tsx
@@ -6,11 +6,22 @@ import { panelReducer, initialState } from './reducer'
 import { attachToTab, executeCommand } from './lib/bridge'
 import { Console } from './components/Console';
 import { loadSettings } from './lib/settings';
+import { onConsoleEvent } from '@/lib/sw-debugger';
 
 function App() {
   const [state, dispatch] = useReducer(panelReducer, initialState)
   const editorPaneRef = useRef<HTMLDivElement>(null)
   const editorRef = useRef<EditorHandle | null>(null);
+
+  useEffect(() => {
+    onConsoleEvent((level, args) => {
+      for (const arg of args) {
+        const type = level === 'error' ? 'error' : level === 'warn' ? 'info' : 'success';
+        dispatch({ type: 'ADD_LINE', line: { text: '', type, value: arg } });
+      }
+    });
+    return () => onConsoleEvent(null);
+  }, [dispatch]);
 
 
   async function doAttach(tabId: number) {
@@ -69,7 +80,7 @@ function App() {
         ws.onclose = () => {
           if (!unmounted) reconnectTimer = setTimeout(() => connect(port), 3000);
         };
-        ws.onerror = () => {};
+        ws.onerror = () => { };
       } catch {
         if (!unmounted) reconnectTimer = setTimeout(() => connect(port), 3000);
       }
@@ -130,17 +141,17 @@ function App() {
 
       {/* Editor pane */}
       <CodeMirrorEditorPane
-         ref={editorRef}
-         containerRef={editorPaneRef}
-         editorContent={state.editorContent}
-         editorMode={state.editorMode}
-         currentRunLine={state.currentRunLine}
-         lineResults={state.lineResults}
-         dispatch={dispatch}
+        ref={editorRef}
+        containerRef={editorPaneRef}
+        editorContent={state.editorContent}
+        editorMode={state.editorMode}
+        currentRunLine={state.currentRunLine}
+        lineResults={state.lineResults}
+        dispatch={dispatch}
       />
 
       {/* Splitter */}
-      <Splitter editorPaneRef={editorPaneRef}/>
+      <Splitter editorPaneRef={editorPaneRef} />
 
       <Console outputLines={state.outputLines} dispatch={dispatch} />
     </>

--- a/packages/extension/src/panel/components/Console/ConsoleEntry.tsx
+++ b/packages/extension/src/panel/components/Console/ConsoleEntry.tsx
@@ -43,7 +43,11 @@ export function ConsoleEntry({ entry }: { entry: Entry }) {
                     </div>
                 )}
                 {entry.status === 'error' && (
-                    <div data-type="error" className="pt-0.5 text-(--color-error) whitespace-pre-wrap">{entry.errorText}</div>
+                    <div data-type="error" className="pt-0.5 text-(--color-error) whitespace-pre-wrap">
+                        {entry.value !== undefined ? (
+                            <ObjectTree data={entry.value} />
+                        ) : entry.errorText}
+                    </div>
                 )}
             </div>
         </div>

--- a/packages/extension/src/panel/components/Console/cdpToSerialized.ts
+++ b/packages/extension/src/panel/components/Console/cdpToSerialized.ts
@@ -25,7 +25,7 @@ export interface CdpRemoteObject {
     preview?: CdpPreview;
 }
 
-interface CdpPropertyDescriptor {
+export interface CdpPropertyDescriptor {
     name: string;
     value?: CdpRemoteObject;
 }

--- a/packages/extension/src/panel/components/Console/index.tsx
+++ b/packages/extension/src/panel/components/Console/index.tsx
@@ -38,16 +38,25 @@ function outputLinesToEntries(lines: OutputLine[]): ConsoleEntry[] {
             entries.push({ id, input: line.text, status: 'done' });
             i++;
         } else if (line.type === 'info') {
-            entries.push({ id, input: '', status: 'done', text: line.text });
+            const entry: ConsoleEntry = { id, input: '', status: 'done' };
+            if (line.value !== undefined) entry.value = line.value as SerializedValue;
+            else entry.text = line.text;
+            entries.push(entry);
             i++;
         } else if (line.type === 'code-block') {
             entries.push({ id, input: '', status: 'done', codeBlock: line.text });
             i++;
         } else if (line.type === 'error') {
-            entries.push({ id, input: '', status: 'error', errorText: line.text });
+            const entry: ConsoleEntry = { id, input: '', status: 'error' };
+            if (line.value !== undefined) entry.value = line.value as SerializedValue;
+            else entry.errorText = line.text;
+            entries.push(entry);
             i++;
         } else if (line.type === 'success') {
-            entries.push({ id, input: '', status: 'done', text: line.text });
+            const entry: ConsoleEntry = { id, input: '', status: 'done' };
+            if (line.value !== undefined) entry.value = line.value as SerializedValue;
+            else entry.text = line.text;
+            entries.push(entry);
             i++;
         } else {
             i++;

--- a/packages/extension/src/panel/lib/sw-debugger.ts
+++ b/packages/extension/src/panel/lib/sw-debugger.ts
@@ -1,6 +1,8 @@
 // Attaches the panel's debugger client to the extension's service worker target
 // and evaluates expressions in the service worker's JS runtime.
 // The panel is a separate context so it CAN see the SW in getTargets().
+import { SerializedValue } from '@/components/Console/types';
+import { CdpRemoteObject, fromCdpRemoteObject, CdpPropertyDescriptor } from '@/components/Console/cdpToSerialized';
 
 let swTargetId: string | null = null;
 
@@ -49,6 +51,7 @@ async function ensureAttached(): Promise<string> {
                 if (/already attached/i.test(msg)) { swTargetId = targetId; resolve(); }
                 else reject(new Error(msg));
             } else {
+                chrome.debugger.sendCommand({ targetId }, 'Runtime.enable', {}, () => {});
                 swTargetId = targetId; resolve();
             }
         });
@@ -142,3 +145,55 @@ export async function swDebugEval(expression: string): Promise<unknown> {
         );
     });
 }
+
+type ConsoleCallback = (level: string, args: SerializedValue[]) => void;
+let consoleCallback: ConsoleCallback | null = null;
+
+export function onConsoleEvent(callback: ConsoleCallback | null) {
+    consoleCallback = callback;
+}
+
+async function eagerSerialize(obj: CdpRemoteObject, depth = 0, visited = new Set<string>()): Promise<SerializedValue> {
+    // Primitives — delegate to existing converter
+    if (obj.type !== 'object' || !obj.objectId) return fromCdpRemoteObject(obj);
+    if (depth > 3) return fromCdpRemoteObject(obj);  // preview-only at depth limit
+    if (visited.has(obj.objectId)) return { __type: 'circular' };
+    visited.add(obj.objectId);
+
+    // Fetch own properties eagerly
+    const raw = await swGetProperties(obj.objectId);
+    const descriptors = (raw as any)?.result as CdpPropertyDescriptor[];
+    if (!descriptors) return fromCdpRemoteObject(obj);
+
+    const props: Record<string, SerializedValue> = {};
+    for (const desc of descriptors) {
+        if (!desc.value) continue;
+        props[desc.name] = await eagerSerialize(desc.value, depth + 1, visited);
+    }
+
+    const cls = obj.className ?? 'Object';
+    if (obj.subtype === 'array') {
+        return { __type: 'array', cls, len: descriptors.length, props };
+        // No objectId — fully serialized, no lazy expand
+    }
+    return { __type: 'object', cls, props };
+}
+
+chrome.debugger.onEvent.addListener(async (source, method, params: any) => {
+    if (method !== 'Runtime.consoleAPICalled') return;
+    if (source.targetId !== swTargetId) return;
+    if (!consoleCallback) return;
+
+    const level = params.type; // 'log', 'error', 'warn', 'info', etc.
+    try {
+        const serialized: SerializedValue[] = [];
+        for (const arg of params.args) {
+            try {
+                serialized.push(await eagerSerialize(arg));
+            } catch {
+                serialized.push(fromCdpRemoteObject(arg));
+            }
+        }
+        consoleCallback(level, serialized);
+    } catch { /* prevent unhandled rejection from killing the listener */ }
+});


### PR DESCRIPTION
## Summary
- Listen for `Runtime.consoleAPICalled` CDP events on the service worker target and display output in the panel console
- Eagerly serialize object arguments (depth ≤ 3, circular detection) so objectIds don't go stale
- Fix `outputLinesToEntries` to pass `SerializedValue` through for standalone success/info/error lines
- Add ObjectTree rendering in error entries

Closes #116

## Test plan
- [ ] Run `console.log("hello")` from editor → output appears in panel console
- [ ] Run `console.log({a:1, nested:{b:2}})` → expandable object tree shown
- [ ] Run `console.warn("warning")` → appears in console output
- [ ] Run script with multiple `console.log` calls → all outputs appear in order
- [ ] E2E tests pass: `pnpm --filter extension test:e2e`

🤖 Generated with [Claude Code](https://claude.com/claude-code)