### PR TITLE
fix: reject WebSocket connections from web page origins

### DIFF
--- a/packages/core/src/bridge-server.ts
+++ b/packages/core/src/bridge-server.ts
@@ -13,7 +13,16 @@ export class BridgeServer {
     get connected()              { return this.socket?.readyState === WebSocket.OPEN; }
 
     async start(port = 9876): Promise<void> {
-        this.wss = new WebSocketServer({ port });
+        this.wss = new WebSocketServer({
+            port,
+            verifyClient: ({ origin }: { origin: string }) => {
+                // Allow: no origin (Node.js ws clients, curl, tests)
+                // Allow: chrome-extension:// (our offscreen document)
+                // Block: http://, https:// (web pages)
+                if (!origin) return true;
+                return origin.startsWith('chrome-extension://');
+            },
+        });
         await new Promise<void>((resolve, reject) => {
             this.wss.on('listening', resolve);
             this.wss.on('error', reject);


### PR DESCRIPTION
## Summary

- Add `verifyClient` callback to the bridge WebSocket server to reject connections from `http://` and `https://` origins (malicious websites)
- Allow `chrome-extension://` origins (our offscreen document) and missing origin (Node.js `ws` clients, CLI tests)
- Prevents cross-origin WebSocket attacks where a malicious page connects to `ws://localhost:9876` to control the browser

## Test plan

- [ ] `pnpm --filter core build` — builds
- [ ] `pnpm --filter core test` — 115 tests pass
- [ ] Start `playwright-repl --bridge`, open DevTools console on a page without CSP, run `new WebSocket('ws://localhost:9876')` — connection rejected
- [ ] Extension still connects and executes commands normally

Closes #130

🤖 Generated with [Claude Code](https://claude.com/claude-code)