### PR TITLE
fix: recording captures full fill text instead of first character

### DIFF
--- a/packages/extension/src/panel/components/CodeMirrorEditorPane.tsx
+++ b/packages/extension/src/panel/components/CodeMirrorEditorPane.tsx
@@ -5,6 +5,7 @@ import type { PanelState, Action } from "@/reducer";
 
 export interface EditorHandle {
     insertAtCursor: (text: string) => void;
+    replaceLastInsert: (text: string) => void;
 }
 
 interface EditorPaneProps extends Pick<PanelState, 'editorContent' | 'currentRunLine' | 'lineResults' | 'editorMode'> {
@@ -18,6 +19,7 @@ function CodeMirrorEditorPane({ editorContent, editorMode, currentRunLine, lineR
     const cmContainerRef = useRef<HTMLDivElement>(null);
     const viewRef = useRef<EditorView>(null);
     const externalUpdateRef = useRef(false);
+    const lastInsertRangeRef = useRef<{ from: number; to: number } | null>(null);
 
     useImperativeHandle(ref, () => ({
         insertAtCursor(text: string) {
@@ -26,11 +28,27 @@ function CodeMirrorEditorPane({ editorContent, editorMode, currentRunLine, lineR
             const { from } = view.state.selection.main;
             const before = view.state.doc.sliceString(Math.max(0, from - 1), from);
             const insert = (before && before !== '\n' ? '\n' : '') + text;
+            const insertFrom = from;
             view.dispatch({
                 changes: { from, to: from, insert },
                 selection: { anchor: from + insert.length },
                 scrollIntoView: true,
             });
+            lastInsertRangeRef.current = { from: insertFrom, to: insertFrom + insert.length };
+            view.focus();
+        },
+        replaceLastInsert(text: string) {
+            const view = viewRef.current;
+            const range = lastInsertRangeRef.current;
+            if (!view || !range) return;
+            const before = view.state.doc.sliceString(Math.max(0, range.from - 1), range.from);
+            const insert = (before && before !== '\n' ? '\n' : '') + text;
+            view.dispatch({
+                changes: { from: range.from, to: range.to, insert },
+                selection: { anchor: range.from + insert.length },
+                scrollIntoView: true,
+            });
+            lastInsertRangeRef.current = { from: range.from, to: range.from + insert.length };
             view.focus();
         },
     }));

--- a/packages/extension/src/panel/components/Toolbar.tsx
+++ b/packages/extension/src/panel/components/Toolbar.tsx
@@ -15,7 +15,7 @@ interface ToolbarProps extends Pick<PanelState, 'editorContent' | 'editorMode' |
 function Toolbar({ editorContent, editorMode, stepLine, attachedUrl, attachedTabId, isAttaching, isRunning, isStepDebugging, dispatch, editorRef }: ToolbarProps) {
     const fileInputRef = useRef<HTMLInputElement>(null);
     const recorderPortRef = useRef<chrome.runtime.Port | null>(null);
-    const prevActionCountRef = useRef(0);
+    const prevActionsRef = useRef<string[]>([]);
     const cancelRunRef = useRef(false);
     const [isRecording, setIsRecording] = useState(false);
     const [isDarkMode, setIsDarkMode] = useState(() => localStorage.getItem("theme") === 'dark');
@@ -224,9 +224,15 @@ function Toolbar({ editorContent, editorMode, stepLine, attachedUrl, attachedTab
     const handleRecordedSources = useCallback((sources: any[]) => {
         const jsonlSource = sources.find(s => s.id === 'jsonl') || sources[0];
         if (!jsonlSource?.actions?.length) return;
-        const prevCount = prevActionCountRef.current;
-        const newActions = (jsonlSource.actions as string[]).slice(prevCount);
-        prevActionCountRef.current = jsonlSource.actions.length;
+        const actions = jsonlSource.actions as string[];
+        const prev = prevActionsRef.current;
+
+        // Detect new actions (appended) vs updated actions (in-place edit, e.g. fill text changing)
+        const newActions = actions.slice(prev.length);
+        const lastUpdated = prev.length > 0 && actions.length === prev.length &&
+            actions[actions.length - 1] !== prev[prev.length - 1];
+
+        prevActionsRef.current = [...actions];
 
         // Console: show new JSONL actions as pretty JSON
         for (const a of newActions) {
@@ -239,24 +245,42 @@ function Toolbar({ editorContent, editorMode, stepLine, attachedUrl, attachedTab
 
         const isOpenPage = (jsonl: string) => { try { return JSON.parse(jsonl).name === 'openPage'; } catch { return false; } };
 
-        if (editorMode === 'js') {
-            const jsSource = sources.find(s => s.id === 'javascript');
-            const jsLines = newActions.flatMap((a, i) => {
-                if (isOpenPage(a)) return [];
-                const jsAction = (jsSource?.actions as string[] | undefined)?.[prevCount + i];
-                if (!jsAction) return [];
+        // Helper: convert a single action to editor text
+        const actionToEditorText = (jsonl: string, idx: number): string | null => {
+            if (isOpenPage(jsonl)) return null;
+            if (editorMode === 'js') {
+                const jsSource = sources.find(s => s.id === 'javascript');
+                const jsAction = (jsSource?.actions as string[] | undefined)?.[idx];
+                if (!jsAction) return null;
                 return jsAction.split('\n')
-                    .map((line: string) => line.replace(/^ {2}/, ''))           // strip 2-space base offset
-                    .map((line: string) => line.replace(/^\/\/ (await expect\()/, '$1')) // uncomment assertions
-                    .filter((line: string) => !line.startsWith('const page =')); // page already exists
-            }).filter(Boolean);
-            if (jsLines.length) editorRef.current?.insertAtCursor(jsLines.join('\n'));
-        } else {
-            const replLines = newActions
-                .filter(a => !isOpenPage(a))
-                .map((a: string) => jsonlToRepl(a, false))
+                    .map((line: string) => line.replace(/^ {2}/, ''))
+                    .map((line: string) => line.replace(/^\/\/ (await expect\()/, '$1'))
+                    .filter((line: string) => !line.startsWith('const page ='))
+                    .join('\n') || null;
+            } else {
+                return jsonlToRepl(jsonl, false) || null;
+            }
+        };
+
+        // In-place update: replace the last inserted line in the editor + console
+        if (lastUpdated) {
+            const lastAction = actions[actions.length - 1];
+            const text = actionToEditorText(lastAction, actions.length - 1);
+            if (text) editorRef.current?.replaceLastInsert(text);
+            try {
+                dispatch({ type: 'REPLACE_LAST_LINE', line: { text: JSON.stringify(JSON.parse(lastAction), null, 2), type: 'code-block' } });
+            } catch {
+                dispatch({ type: 'REPLACE_LAST_LINE', line: { text: lastAction, type: 'info' } });
+            }
+            return;
+        }
+
+        // New actions: insert at cursor
+        if (newActions.length) {
+            const texts = newActions
+                .map((a, i) => actionToEditorText(a, prev.length + i))
                 .filter(Boolean) as string[];
-            if (replLines.length) editorRef.current?.insertAtCursor(replLines.join('\n'));
+            if (texts.length) editorRef.current?.insertAtCursor(texts.join('\n'));
         }
     }, [dispatch, editorMode]);
 
@@ -293,7 +317,7 @@ function Toolbar({ editorContent, editorMode, stepLine, attachedUrl, attachedTab
         }
 
         setIsRecording(true);
-        prevActionCountRef.current = 0;
+        prevActionsRef.current = [];
 
         if (result.url && result.url !== 'about:blank') {
             const gotoCmd = editorMode === 'js'

--- a/packages/extension/src/panel/reducer.ts
+++ b/packages/extension/src/panel/reducer.ts
@@ -18,6 +18,7 @@ export type PanelState = {
 
 export type Action =
      { type: 'ADD_LINE', line: OutputLine}
+   | { type: 'REPLACE_LAST_LINE', line: OutputLine }
    | { type: 'CLEAR_CONSOLE'}
    | { type: 'COMMAND_SUBMITTED', line: OutputLine}
    | { type: 'COMMAND_SUCCESS', line: OutputLine }
@@ -56,6 +57,8 @@ export function panelReducer(state: PanelState, action: Action): PanelState {
     switch(action.type) {
         case 'ADD_LINE':
             return { ...state, outputLines: [...state.outputLines, action.line]}
+        case 'REPLACE_LAST_LINE':
+            return { ...state, outputLines: [...state.outputLines.slice(0, -1), action.line]}
         case 'CLEAR_CONSOLE':
             return { ...state, outputLines: [], passCount: 0, failCount: 0}
         case 'COMMAND_SUBMITTED':


### PR DESCRIPTION
## Summary
- Fix recording only capturing the first character of fill text (e.g. `"r"` instead of `"reading"`)
- The Playwright recorder updates fill actions in place as the user types — our code tracked by count only, missing these updates
- Switch to content-based diffing (`prevActionsRef`) and add `replaceLastInsert` / `REPLACE_LAST_LINE` so both editor and console reflect the final text

## Test plan
- [x] Record a fill action, verify editor shows full text
- [x] Verify console shows final fill text (not just first character)
- [x] Extension builds successfully

Closes #132

🤖 Generated with [Claude Code](https://claude.com/claude-code)