### PR TITLE
fix: tab-list shows full details in bridge console

### DIFF
--- a/packages/extension/src/panel/lib/page-scripts.ts
+++ b/packages/extension/src/panel/lib/page-scripts.ts
@@ -391,12 +391,12 @@ export async function tabList(_page) {
   const activeTabId = globalThis.activeTabId;
   const windowId = activeTabId ? (await chrome.tabs.get(activeTabId)).windowId : undefined;
   const tabs = await chrome.tabs.query(windowId !== undefined ? { windowId } : {});
-  return tabs.map((tab, i) => ({
+  return JSON.stringify(tabs.map((tab, i) => ({
     index: i,
     title: tab.title || '',
     url: tab.url || '',
     current: tab.id === activeTabId,
-  }));
+  })), null, 2);
 }
 
 export async function tabNew(_page, url) {


### PR DESCRIPTION
## Summary
- `tab-list` returned an array of objects, but the bridge serializer only uses `r.description` for non-primitives, yielding `Array(12)` instead of tab details
- Fix: return `JSON.stringify(...)` from `tabList()` so it comes through as a string with full tab info

## Test plan
- [x] Run `tab-list` in remote console (bridge mode) — shows JSON array with index, title, url, current
- [x] Extension panel `tab-list` also works

🤖 Generated with [Claude Code](https://claude.com/claude-code)