### PR TITLE
feat: auto-closing brackets in editor and console

### DIFF
--- a/packages/extension/src/panel/lib/cm-console-setup.ts
+++ b/packages/extension/src/panel/lib/cm-console-setup.ts
@@ -2,7 +2,7 @@ import { EditorView, keymap, placeholder, drawSelection } from '@codemirror/view
 import { javascript, javascriptLanguage } from '@codemirror/lang-javascript';
 import { syntaxHighlighting, defaultHighlightStyle } from '@codemirror/language';
 import { history, historyKeymap } from '@codemirror/commands';
-import { autocompletion, acceptCompletion, completionStatus } from '@codemirror/autocomplete';
+import { autocompletion, acceptCompletion, completionStatus, closeBrackets, closeBracketsKeymap } from '@codemirror/autocomplete';
 import type { Extension } from '@codemirror/state';
 import { pwCompletion } from '@/lib/pw-completion';
 import { playwrightCompletions } from '@/lib/pw-completion-source';
@@ -82,10 +82,11 @@ export function consoleExtensions(opts: Opts): Extension[] {
         javascriptLanguage.data.of({ autocomplete: playwrightCompletions }),
         javascriptLanguage.data.of({ autocomplete: pwCompletion }),
         autocompletion(),
+        closeBrackets(),
         syntaxHighlighting(defaultHighlightStyle),
         drawSelection(),
         history(),
-        keymap.of(historyKeymap),
+        keymap.of([...closeBracketsKeymap, ...historyKeymap]),
         placeholder('js expression or .pw command  (Shift+Enter for newline)'),
         consoleTheme,
     ];

--- a/packages/extension/src/panel/lib/codemirror-setup.ts
+++ b/packages/extension/src/panel/lib/codemirror-setup.ts
@@ -9,7 +9,7 @@ import { pwSyntax } from './pw-language';
 import { search, searchKeymap } from '@codemirror/search';
 import { StateEffect, StateField, EditorState, RangeSet, Compartment } from '@codemirror/state';
 import { Decoration, GutterMarker, gutter } from '@codemirror/view';
-import { autocompletion, acceptCompletion } from '@codemirror/autocomplete';
+import { autocompletion, acceptCompletion, closeBrackets, closeBracketsKeymap } from '@codemirror/autocomplete';
 import { pwCompletion } from './pw-completion'
 import { playwrightCompletions } from './pw-completion-source'
 
@@ -172,9 +172,11 @@ export const baseExtensions = [
     highlightActiveLine(),                   // highlights content on cursor line
     history(),                               // undo/redo stack
     bracketMatching(),                       // highlight matching brackets
+    closeBrackets(),                         // auto-insert closing ), ], }, ", '
     search(),                                // Ctrl+F search panel
     keymap.of([
         { key: 'Tab', run: acceptCompletion }, // accept completion with Tab
+        ...closeBracketsKeymap,                 // Backspace deletes both brackets
         ...defaultKeymap,                      // basic editing keys
         ...historyKeymap,                      // Ctrl+Z, Ctrl+Y
         ...searchKeymap,                       // Ctrl+F, Ctrl+H


### PR DESCRIPTION
## Summary
- Enable `closeBrackets()` from CM6 in both editor and console
- Typing `(`, `[`, `{`, `"`, `'` auto-inserts the closing pair with cursor between
- Backspace between empty pairs deletes both characters

## Test plan
- [x] Type `(` in editor → inserts `()` with cursor between
- [x] Type `"` in editor → inserts `""` with cursor between
- [x] Backspace between `()` → deletes both
- [x] Same behavior in console input
- [x] Build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)