### PR TITLE
feat: render snapshot as expandable tree in console

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1,255 +1,113 @@
-# Issue #72 — MCP Server for AI Browser Control
+# #88 — Snapshot as expandable tree in console
 
 ## Context
 
-The ws-bridge (v0.12.0) lets a CLI connect to a running Chrome via WebSocket. This plan exposes that bridge as an **MCP server** so AI models (Claude Desktop, Claude Code) can directly operate the browser using playwright-repl commands — no extra glue code needed.
+The `snapshot` command returns a YAML accessibility tree (from Playwright's `_snapshotForAI()`). Currently rendered as a flat `<pre>` block in the console. Goal: parse the YAML into a tree and render it as a collapsible component, so users can expand/collapse nodes.
 
-Architecture: MCP server starts a `BridgeServer`, Chrome extension connects out to it, AI calls `run_command("snapshot")` / `run_command("click Submit")` etc.
-
----
-
-## New Package: `packages/mcp/`
-
-`@playwright-repl/mcp` — publishable standalone binary `playwright-repl-mcp`.
-pnpm workspace glob `packages/*` already covers it — no workspace config changes needed.
+## Current flow
 
 ```
-packages/mcp/
-├── package.json
-├── tsconfig.json          # no-emit (IDE / typecheck)
-├── tsconfig.build.json    # composite, emits to dist/
-└── src/
-    └── index.ts           # MCP server entry point
+snapshot command
+  → useConsole.ts:36 — detects SNAPSHOT_CMDS, returns { codeBlock: result.text }
+  → useConsole.ts:114 — dispatches { type: 'COMMAND_SUCCESS', line: { text, type: 'snapshot' } }
+  → Console/index.tsx:29 — sets entry.codeBlock = next.text
+  → ConsoleEntry.tsx:23-30 — renders <pre> with Copy button
 ```
 
----
+## Approach
 
-## Files to Create
+### 0. Install js-yaml
 
-### 1. `packages/mcp/package.json`
+```bash
+pnpm --filter @playwright-repl/extension add js-yaml
+pnpm --filter @playwright-repl/extension add -D @types/js-yaml
+```
 
-```json
-{
-  "name": "@playwright-repl/mcp",
-  "version": "0.12.0",
-  "type": "module",
-  "bin": { "playwright-repl-mcp": "./dist/index.js" },
-  "main": "./dist/index.js",
-  "files": ["dist/"],
-  "scripts": { "build": "tsc --build tsconfig.build.json" },
-  "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.10.0",
-    "@playwright-repl/core": "workspace:*",
-    "zod": "^3.24.0"
-  }
+### 1. Create snapshot parser
+
+**New file:** [packages/extension/src/panel/lib/snapshot-parser.ts](packages/extension/src/panel/lib/snapshot-parser.ts)
+
+Use `js-yaml` to parse the YAML snapshot into a nested structure, then convert to our tree type.
+
+The snapshot YAML looks like:
+```
+- document [ref=e1]:
+  - navigation "Main" [ref=e2]:
+    - link "Home" [ref=e3]
+  - main [ref=e5]:
+    - heading "Welcome" [level=1] [ref=e6]
+```
+
+`yaml.load()` will parse this into nested arrays/objects. Define a `SnapshotNode` type and a conversion function:
+
+```ts
+import yaml from 'js-yaml';
+
+export interface SnapshotNode {
+  text: string;        // e.g. 'navigation "Main"'
+  ref?: string;        // e.g. 'e2'
+  children: SnapshotNode[];
+}
+
+export function parseSnapshot(yamlText: string): SnapshotNode[]
+```
+
+- Parse with `yaml.load(yamlText)`
+- Walk the resulting structure to build `SnapshotNode[]`
+- Extract `[ref=eN]` from the keys using regex
+
+### 2. Create SnapshotTree component
+
+**New file:** [packages/extension/src/panel/components/Console/SnapshotTree.tsx](packages/extension/src/panel/components/Console/SnapshotTree.tsx)
+
+Simpler than ObjectTree (no lazy loading, no CDP). Reuse existing `.ot-` CSS classes for consistent look.
+
+```tsx
+function SnapshotTree({ nodes }: { nodes: SnapshotNode[] }) {
+  // Render each node with ▶/▼ toggle if it has children
+  // Collapsed by default for depth > 1
+  // Show ref as a dimmed label: e.g. [e5]
 }
 ```
 
-### 2. `packages/mcp/tsconfig.json`
+Keep the Copy button (copy original YAML text).
 
-```json
-{
-  "extends": "../../tsconfig.base.json",
-  "compilerOptions": { "rootDir": ".", "noEmit": true },
-  "include": ["src"]
-}
+### 3. Wire into ConsoleEntry
+
+**Modify:** [packages/extension/src/panel/components/Console/ConsoleEntry.tsx](packages/extension/src/panel/components/Console/ConsoleEntry.tsx)
+
+In the `codeBlock` rendering branch (line 23), check if the codeBlock looks like a snapshot (starts with `- `). If so, parse and render `<SnapshotTree>` instead of `<pre>`. Otherwise keep `<pre>` for other code blocks (like `export` output).
+
+```tsx
+entry.codeBlock !== undefined ? (
+  isSnapshotYaml(entry.codeBlock)
+    ? <SnapshotTreeBlock text={entry.codeBlock} />
+    : <div data-type="snapshot">...<pre>...</pre>...</div>
+)
 ```
 
-### 3. `packages/mcp/tsconfig.build.json`
+No changes needed to types, reducer, useConsole, or Console/index.tsx.
 
-```json
-{
-  "extends": "../../tsconfig.base.json",
-  "compilerOptions": {
-    "rootDir": "src",
-    "outDir": "dist",
-    "composite": true
-  },
-  "references": [{ "path": "../core/tsconfig.build.json" }],
-  "include": ["src"]
-}
-```
+## Files to create/modify
 
-### 4. `packages/mcp/src/index.ts`
+1. **Create** [packages/extension/src/panel/lib/snapshot-parser.ts](packages/extension/src/panel/lib/snapshot-parser.ts) — `SnapshotNode` type + `parseSnapshot()` function
+2. **Create** [packages/extension/src/panel/components/Console/SnapshotTree.tsx](packages/extension/src/panel/components/Console/SnapshotTree.tsx) — collapsible tree component
+3. **Modify** [packages/extension/src/panel/components/Console/ConsoleEntry.tsx](packages/extension/src/panel/components/Console/ConsoleEntry.tsx) — branch on snapshot vs code-block rendering
 
-```typescript
-#!/usr/bin/env node
-import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
-import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
-import { z } from 'zod';
-import { BridgeServer } from '@playwright-repl/core';
+## Styling notes
 
-const argv = process.argv.slice(2);
-const portIdx = argv.indexOf('--port');
-const port = portIdx !== -1
-  ? parseInt(argv[portIdx + 1])
-  : (process.env.BRIDGE_PORT ? parseInt(process.env.BRIDGE_PORT) : 9876);
-
-const srv = new BridgeServer();
-await srv.start(port);
-console.error(`playwright-repl bridge listening on ws://localhost:${port}`);
-
-srv.onConnect(() => console.error('Extension connected'));
-srv.onDisconnect(() => console.error('Extension disconnected'));
-
-const server = new McpServer({ name: 'playwright-repl', version: '0.12.0' });
-
-server.tool(
-  'run_command',
-  {
-    description:
-      "Run a command in the connected Chrome browser. Supports three input modes:\n\n" +
-      "1. KEYWORD (.pw) — playwright-repl commands:\n" +
-      "   snapshot, goto <url>, click <text>, fill <label> <value>, press <key>,\n" +
-      "   verify-text <text>, verify-no-text <text>, screenshot, scroll-down,\n" +
-      "   check <label>, select <label> <value>, localstorage-list, localstorage-clear\n\n" +
-      "2. PLAYWRIGHT — Playwright API (page.* / crxApp.*):\n" +
-      "   await page.url(), await page.title(),\n" +
-      "   await page.locator('button').count()\n\n" +
-      "3. JAVASCRIPT — any JS expression evaluated in the browser:\n" +
-      "   document.title, window.location.href,\n" +
-      "   document.querySelectorAll('a').length\n\n" +
-      "Always call snapshot first to understand the page before interacting. " +
-      "Use screenshot to visually verify the current state.",
-    inputSchema: {
-      command: z.string().describe(
-        "A keyword command ('snapshot', 'goto https://example.com', 'click Submit', " +
-        "'fill \"Email\" user@example.com'), a Playwright expression " +
-        "('await page.url()'), or a JavaScript expression ('document.title')"
-      ),
-    },
-  },
-  async ({ command }) => {
-    if (!srv.connected) {
-      return {
-        content: [{ type: 'text' as const, text: 'Browser not connected. Open Chrome with the playwright-repl extension — it connects automatically.' }],
-        isError: true,
-      };
-    }
-    const result = await srv.run(command);
-    if (result.image) {
-      const [header, data] = result.image.split(',');
-      const mimeType = (header.match(/data:(.*);base64/) ?? [])[1] ?? 'image/png';
-      return { content: [{ type: 'image' as const, data, mimeType }] };
-    }
-    return {
-      content: [{ type: 'text' as const, text: result.text || 'Done' }],
-      isError: result.isError,
-    };
-  }
-);
-
-const transport = new StdioServerTransport();
-await server.connect(transport);
-```
-
----
-
-## Files to Modify
-
-### 5. Root `package.json` — add mcp to build script
-
-Change the `build` script to include `packages/mcp/tsconfig.build.json`:
-
-```
-"build": "tsc --build packages/core/tsconfig.build.json packages/cli/tsconfig.build.json packages/mcp/tsconfig.build.json && pnpm --filter @playwright-repl/extension run build"
-```
-
-### 6. `packages/extension/src/panel/App.tsx` — read bridge port from `chrome.storage`
-
-The WS connection lives in `App.tsx` (panel page), not `background.ts`. Currently `connect(port = 9876)` hardcodes the default. Make it read from `chrome.storage.sync` before connecting:
-
-```typescript
-// Replace: connect();
-// With:
-chrome.storage.sync.get({ bridgePort: 9876 }, ({ bridgePort }) => {
-  connect(bridgePort as number);
-});
-```
-
-### 7. Extension settings UI — bridge port input
-
-Add a **Bridge Port** field to the extension's settings/options panel (wherever connection settings live). Persists to `chrome.storage.sync` under key `bridgePort`. Default `9876`.
-
-- Input type `number`, label "Bridge Port"
-- On change: `chrome.storage.sync.set({ bridgePort: value })`
-- Show current connection status alongside (connected / disconnected)
-
-### 8. `README.md` — add MCP Server section (after Bridge section), including Custom Port docs
-
-```markdown
-## MCP Server (AI Browser Agent)
-
-`playwright-repl-mcp` exposes the bridge as an MCP tool so Claude and other AI models can directly operate the browser.
-
-### Setup
-
-1. Install the **playwright-repl extension** in Chrome
-2. Install: `npm install -g @playwright-repl/mcp`
-3. Add to your Claude Desktop config:
-
-\`\`\`json
-{
-  "mcpServers": {
-    "playwright-repl": {
-      "command": "playwright-repl-mcp"
-    }
-  }
-}
-\`\`\`
-
-4. Restart Claude Desktop → open Chrome → extension connects automatically
-5. Ask Claude: *"Go to github.com/trending and list the top 5 repos"*
-
-### Tool: `run_command`
-
-| Command example | What it does |
-|----------------|-------------|
-| `snapshot` | Get current page accessibility tree |
-| `goto https://example.com` | Navigate to URL |
-| `click Submit` | Click by text/label |
-| `fill "Email" user@example.com` | Type into input |
-| `screenshot` | Capture page (returned as image to Claude) |
-| `verify-text Welcome` | Assert text is visible |
-| `scroll-down` | Scroll the page |
-
-### Custom Port
-
-Via CLI args:
-\`\`\`json
-{
-  "mcpServers": {
-    "playwright-repl": {
-      "command": "playwright-repl-mcp",
-      "args": ["--port", "9877"]
-    }
-  }
-}
-\`\`\`
-
-Via environment variable:
-\`\`\`json
-{
-  "mcpServers": {
-    "playwright-repl": {
-      "command": "playwright-repl-mcp",
-      "env": { "BRIDGE_PORT": "9877" }
-    }
-  }
-}
-\`\`\`
-
-`--port` takes precedence over `BRIDGE_PORT`. Default is `9876`.
-```
-
----
+- Reuse `.ot-toggle`, `.ot-children`, `.ot-row` classes from [panel.css](packages/extension/src/panel/panel.css) (lines 213-235)
+- Ref labels (`[e5]`) in dimmed color (`var(--text-dim)`)
+- Node role/name in default text color
+- Quoted text (like `"Main"`) in string color (`var(--color-string)`)
+- You may want to add a couple of `.st-` (snapshot-tree) classes if the existing `.ot-` classes don't fit perfectly
 
 ## Verification
 
-1. `pnpm install` — resolves `@modelcontextprotocol/sdk` and `zod` in `packages/mcp`
-2. `pnpm run build` at root — `packages/mcp/dist/index.js` exists, no TS errors
-3. `node packages/mcp/dist/index.js` — prints bridge listening message to stderr; process stays running
-4. Open Chrome with extension → MCP server stderr shows `Extension connected`
-5. Configure Claude Desktop with the MCP server → restart
-6. In Claude: *"take a screenshot"* → Claude receives the image and describes it
-7. In Claude: *"go to example.com and tell me the heading"* → Claude navigates, calls snapshot, reads heading
+1. `pnpm run build`
+2. Load extension, navigate to a page, type `snapshot` in console
+3. Verify tree renders with collapsible nodes
+4. Verify Copy button still copies the original YAML text
+5. Verify `export` command still renders as `<pre>` code block (not tree)
+6. Run component tests: `pnpm --filter @playwright-repl/extension run test`
+7. Run E2E tests: `pnpm --filter @playwright-repl/extension run test:e2e`

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -22,6 +22,7 @@
     "@playwright/test": "1.59.0-alpha-2026-02-21",
     "@tailwindcss/vite": "^4.2.0",
     "@types/chrome": "^0.0.304",
+    "@types/js-yaml": "^4.0.9",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^5.1.4",
@@ -50,6 +51,7 @@
     "@lezer/highlight": "^1.2.3",
     "@playwright-repl/playwright-crx": "0.15.1",
     "codemirror": "^6.0.2",
+    "js-yaml": "^4.1.1",
     "react": "^19.2.4",
     "react-dom": "^19.2.4"
   }

--- a/packages/extension/src/panel/components/Console/ConsoleEntry.tsx
+++ b/packages/extension/src/panel/components/Console/ConsoleEntry.tsx
@@ -1,5 +1,7 @@
 import { useState } from 'react';
 import { ObjectTree } from './ObjectTree';
+import { SnapshotTree } from './SnapshotTree';
+import { parseSnapshot } from '@/lib/snapshot-parser';
 import Lightbox from '../Lightbox';
 import type { ConsoleEntry as Entry } from './types';
 
@@ -21,13 +23,7 @@ export function ConsoleEntry({ entry }: { entry: Entry }) {
                         {entry.value !== undefined ? (
                             <div data-type="success"><ObjectTree data={entry.value} getProperties={entry.getProperties} /></div>
                         ) : entry.codeBlock !== undefined ? (
-                            <div data-type="snapshot" className="relative border border-solid border-(--border-primary) rounded-[4px] my-[6px] mx-0 bg-(--bg-line-highlight)">
-                                <pre className="m-0 py-2 px-3 text-(--color-command) font-[inherit] text-[12px] leading-4 whitespace-pre-wrap wrap-break-word">{entry.codeBlock}</pre>
-                                <button
-                                    className="absolute top-1 right-1 bg-(--bg-button) text-(--text-default) border border-solid border-(--border-button) rounded-[3px] py-[2px] px-2 font-[inherit] text-[10px] cursor-pointer hover:bg-(--bg-button-hover)"
-                                    onClick={() => navigator.clipboard.writeText(entry.codeBlock!)}
-                                >Copy</button>
-                            </div>
+                            <SnapshotCodeBlock codeBlock={entry.codeBlock} />
                         ) : entry.image !== undefined ? (
                             <div data-type="screenshot">
                                 <img
@@ -50,6 +46,22 @@ export function ConsoleEntry({ entry }: { entry: Entry }) {
                     </div>
                 )}
             </div>
+        </div>
+    );
+}
+
+function SnapshotCodeBlock({ codeBlock }: { codeBlock: string }) {
+    const node = codeBlock.trimStart().startsWith('- ') ? parseSnapshot(codeBlock) : null;
+    return (
+        <div data-type="snapshot" className="relative border border-solid border-(--border-primary) rounded-[4px] my-[6px] mx-0 bg-(--bg-line-highlight)">
+            {node
+                ? <div className="py-2 px-3"><SnapshotTree node={node} depth={0} /></div>
+                : <pre className="m-0 py-2 px-3 text-(--color-command) font-[inherit] text-[12px] leading-4 whitespace-pre-wrap wrap-break-word">{codeBlock}</pre>
+            }
+            <button
+                className="absolute top-1 right-1 bg-(--bg-button) text-(--text-default) border border-solid border-(--border-button) rounded-[3px] py-[2px] px-2 font-[inherit] text-[10px] cursor-pointer hover:bg-(--bg-button-hover)"
+                onClick={() => navigator.clipboard.writeText(codeBlock)}
+            >Copy</button>
         </div>
     );
 }

--- a/packages/extension/src/panel/components/Console/SnapshotTree.tsx
+++ b/packages/extension/src/panel/components/Console/SnapshotTree.tsx
@@ -1,0 +1,28 @@
+import { useState } from "react";
+import { SnapshotNode } from "@/lib/snapshot-parser";
+
+export function SnapshotTree({node, depth}: { node: SnapshotNode, depth: number}) {
+    const [open, setOpen] = useState(depth < 2);
+    const hasChildren = node.children.length > 0;
+
+    return (
+        <div>
+            <div className="ot-row">
+                {hasChildren ? (
+                    <span className="ot-toggle" onClick={() => setOpen(o => !o)}>
+                        {open ? '▼' : '▶'}
+                    </span>
+                ) : <span style={{ width: 12, display: 'inline-block' }} />}
+                <span>{node.text}</span>
+                {node.ref && <span className="ot-key" style={{ marginLeft: 4 }}>[ref={node.ref}]</span>}
+            </div>
+            {open && hasChildren && (
+                <div className="ot-children">
+                    {node.children.map((child, i) => (
+                        <SnapshotTree key={i} node={child} depth={depth + 1} />
+                    ))}
+                </div>
+            )}
+        </div>
+    )
+}

--- a/packages/extension/src/panel/lib/snapshot-parser.ts
+++ b/packages/extension/src/panel/lib/snapshot-parser.ts
@@ -1,0 +1,37 @@
+import yaml from 'js-yaml';
+
+export interface SnapshotNode {
+    text: string,
+    ref?: string,
+    children: SnapshotNode[];
+}
+
+export function parseSnapshot(yamlText: string): SnapshotNode | null {
+    const parsed = yaml.load(yamlText);
+    if (!Array.isArray(parsed)) return null;
+    const nodes = toNodes(parsed);
+    return nodes[0] ?? null;
+}
+
+function toNodes(parsed: unknown[]): SnapshotNode[] {
+    return parsed.map(item => {
+        if(typeof item === 'string') {
+            return { text: stripRef(item), ref: extractRef(item), children: []}
+        }
+        // Object: { "document [ref=e1]": [...children] }
+        const obj = item as Record<string, unknown[]>;
+        const key = Object.keys(obj)[0];
+        const children = obj[key];
+        return { text: stripRef(key), ref: extractRef(key), children: Array.isArray(children) ? toNodes(children) : [] }
+    })
+}
+
+// "document [ref=e1]" → "document"
+function stripRef(text: string): string {
+  return text.replace(/\s*\[ref=e\d+\]/, '').trim();
+}
+
+// "document [ref=e1]" → "e1"
+function extractRef(text: string): string | undefined {
+  return text.match(/\[ref=(e\d+)\]/)?.[1];
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -94,6 +94,9 @@ importers:
       codemirror:
         specifier: ^6.0.2
         version: 6.0.2
+      js-yaml:
+        specifier: ^4.1.1
+        version: 4.1.1
       react:
         specifier: ^19.2.4
         version: 19.2.4
@@ -113,6 +116,9 @@ importers:
       '@types/chrome':
         specifier: ^0.0.304
         version: 0.0.304
+      '@types/js-yaml':
+        specifier: ^4.0.9
+        version: 4.0.9
       '@types/react':
         specifier: ^19.2.14
         version: 19.2.14
@@ -817,6 +823,9 @@ packages:
   '@types/har-format@1.2.16':
     resolution: {integrity: sha512-fluxdy7ryD3MV6h8pTfTYpy/xQzCFC7m89nOH9y94cNqJ1mDIDPut7MnRHI3F6qRmh/cT2fUjG1MLdCNb4hE9A==}
 
+  '@types/js-yaml@4.0.9':
+    resolution: {integrity: sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==}
+
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
@@ -986,6 +995,9 @@ packages:
 
   ajv@8.18.0:
     resolution: {integrity: sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==}
+
+  argparse@2.0.1:
+    resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
@@ -1394,6 +1406,10 @@ packages:
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
+  js-yaml@4.1.1:
+    resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
+    hasBin: true
 
   jsesc@3.1.0:
     resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
@@ -2553,6 +2569,8 @@ snapshots:
 
   '@types/har-format@1.2.16': {}
 
+  '@types/js-yaml@4.0.9': {}
+
   '@types/json-schema@7.0.15': {}
 
   '@types/minimist@1.2.5': {}
@@ -2802,6 +2820,8 @@ snapshots:
       fast-uri: 3.1.0
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
+
+  argparse@2.0.1: {}
 
   assertion-error@2.0.1: {}
 
@@ -3243,6 +3263,10 @@ snapshots:
   js-tokens@10.0.0: {}
 
   js-tokens@4.0.0: {}
+
+  js-yaml@4.1.1:
+    dependencies:
+      argparse: 2.0.1
 
   jsesc@3.1.0: {}
 


### PR DESCRIPTION
## Summary
- Parse YAML accessibility snapshot with `js-yaml` into a `SnapshotNode` tree
- Render collapsible tree using recursive `SnapshotTree` component (reuses `.ot-` CSS classes)
- Non-snapshot code blocks (e.g. `export` output) still render as `<pre>`
- Copy button preserved — copies original YAML text

## Test plan
- [ ] Build: `pnpm run build`
- [ ] Load extension, navigate to a page, run `snapshot` — verify tree renders with collapsible nodes
- [ ] Verify Copy button copies the original YAML text
- [ ] Verify `export` command still renders as `<pre>` code block
- [ ] Run component tests: `pnpm --filter @playwright-repl/extension run test`
- [ ] Run E2E tests: `pnpm --filter @playwright-repl/extension run test:e2e`

Closes #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)