### PR TITLE
fix: record failed commands and surface history write errors

### DIFF
--- a/packages/cli/src/repl.ts
+++ b/packages/cli/src/repl.ts
@@ -403,6 +403,7 @@ export async function processLine(ctx: ReplContext, line: string): Promise<void>
     ctx.log(`${c.dim}→ ${args._[1]}${c.reset}`);
   }
 
+  ctx.session.record(line);
   const startTime = performance.now();
   try {
     const result = await ctx.conn.run(args);
@@ -413,7 +414,6 @@ export async function processLine(ctx: ReplContext, line: string): Promise<void>
     }
     if (result?.isError) ctx.errors++;
     ctx.commandCount++;
-    ctx.session.record(line);
 
     if (Number(elapsed) > 500) {
       ctx.log(`${c.dim}(${elapsed}ms)${c.reset}`);
@@ -621,7 +621,9 @@ export function startCommandLoop(ctx: ReplContext): void {
         try {
           fs.mkdirSync(path.dirname(ctx.historyFile), { recursive: true });
           fs.appendFileSync(ctx.historyFile, line.trim() + '\n');
-        } catch { /* ignore */ }
+        } catch (err: unknown) {
+          console.error(`${c.dim}Warning: could not write history: ${(err as Error).message}${c.reset}`);
+        }
       }
     }
     processing = false;
@@ -965,7 +967,9 @@ async function startBridgeLoop(opts: ReplOpts, srv: BridgeServer): Promise<void>
     try {
       fs.mkdirSync(path.dirname(historyFile), { recursive: true });
       fs.appendFileSync(historyFile, command + '\n');
-    } catch { /* ignore */ }
+    } catch (err: unknown) {
+      console.error(`${c.dim}Warning: could not write history: ${(err as Error).message}${c.reset}`);
+    }
 
     if (!srv.connected) {
       log(`${c.yellow}[not connected] Waiting for extension...${c.reset}`);


### PR DESCRIPTION
## Summary
- **#78**: Move `session.record(line)` before `ctx.conn.run()` so failed/crashed commands are captured in session replay files
- **#79**: Replace silent `catch {}` with `console.error` warning in both `startCommandLoop` and `startBridgeLoop` history write paths — surfaces disk-full/permission errors

Closes #78
Closes #79

## Test plan
- [x] All 175 CLI unit tests pass
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)