### PR TITLE
chore: release v0.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,34 @@
 # Changelog
 
+## v0.16.0 — Autocompletion, Snapshot Tree & Recording Fixes
+
+**2026-03-12**
+
+### Features
+
+- **Playwright API autocompletion**: JS mode now offers ghost-text autocompletion for Playwright API methods (`page.goto()`, `page.locator()`, `expect()`, etc.). ([#137](https://github.com/stevez/playwright-repl/issues/137), [#147](https://github.com/stevez/playwright-repl/pull/147))
+- **Snapshot tree view**: `snapshot` output now renders as an expandable accessibility tree in the console — click to expand/collapse nodes instead of scrolling through raw text. ([#88](https://github.com/stevez/playwright-repl/issues/88), [#151](https://github.com/stevez/playwright-repl/pull/151))
+- **Categorized help**: `help` command groups commands by category (navigation, interaction, assertion, etc.) with per-command help (`help click`, `help fill`) and `help js` for Playwright API reference. ([#146](https://github.com/stevez/playwright-repl/pull/146))
+- **Language mode preference**: Choose default language mode (`.pw` or JS) in the Options page. Persisted via `chrome.storage`. ([#149](https://github.com/stevez/playwright-repl/pull/149))
+- **Segmented control**: Replaced the pw/js toggle button with a segmented control for clearer mode switching. ([#145](https://github.com/stevez/playwright-repl/pull/145))
+- **Auto-closing brackets**: Editor and console input now auto-close parentheses, brackets, and quotes. ([#150](https://github.com/stevez/playwright-repl/pull/150))
+
+### Fixes
+
+- **Recording captures full fill text**: Fill commands now record the complete input text instead of only the first character. ([#154](https://github.com/stevez/playwright-repl/pull/154))
+- **Recorder merges fill + Enter**: Sequential `fill` followed by `Enter` is merged into a single command; noise clicks on already-focused inputs are filtered. ([#154](https://github.com/stevez/playwright-repl/pull/154))
+- **Recording noise removed from console**: Duplicate and internal recorder output no longer appears in the console. ([#144](https://github.com/stevez/playwright-repl/pull/144))
+- **Failed commands recorded in history**: Commands that error are now saved to session history so you can arrow-up to fix and retry. ([#163](https://github.com/stevez/playwright-repl/pull/163))
+
+### Tests
+
+- Extension test coverage increased to 90%+ with new unit, component, and E2E tests. ([#157](https://github.com/stevez/playwright-repl/pull/157)–[#162](https://github.com/stevez/playwright-repl/pull/162))
+- E2E coverage collection via nextcov — merged unit + component + E2E coverage reports. ([#148](https://github.com/stevez/playwright-repl/issues/148), [#157](https://github.com/stevez/playwright-repl/pull/157))
+- Bridge E2E tests verify all commands return meaningful results via WebSocket.
+- E2E recording flow tests added. ([#160](https://github.com/stevez/playwright-repl/pull/160))
+
+---
+
 ## v0.15.1 — WebSocket Origin Check
 
 **2026-03-09**

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "playwright-repl",
-  "version": "0.15.1",
+  "version": "0.16.0",
   "description": "Interactive REPL for Playwright browser automation — keyword-driven testing from your terminal",
   "type": "module",
   "bin": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@playwright-repl/core",
-  "version": "0.15.1",
+  "version": "0.16.0",
   "type": "module",
   "main": "./dist/index.js",
   "exports": {

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@playwright-repl/extension",
-  "version": "0.15.1",
+  "version": "0.16.0",
   "private": true,
   "description": "Chrome DevTools panel extension for Playwright REPL",
   "type": "module",

--- a/packages/extension/public/manifest.json
+++ b/packages/extension/public/manifest.json
@@ -1,8 +1,8 @@
 {
   "manifest_version": 3,
   "name": "Dramaturg",
-  "version": "0.15.1",
-  "description": "Playwright automation console inside Chrome — keyword commands, Playwright API, and JavaScript in one side panel.",
+  "version": "0.16.0",
+  "description": "Playwright engineer's companion — console, editor, runner, and recorder in a Chrome side panel.",
   "permissions": [
     "activeTab",
     "tabs",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@playwright-repl/mcp",
-    "version": "0.15.1",
+    "version": "0.16.0",
     "type": "module",
     "bin": {
         "playwright-repl-mcp": "./dist/index.js"


### PR DESCRIPTION
## Summary

- Bump version from 0.15.1 to 0.16.0 across all packages (core, cli, mcp, extension) and manifest.json
- Add v0.16.0 CHANGELOG entry (6 features, 4 fixes, testing improvements)
- Update extension manifest description

## Test plan

- [x] `pnpm install --lockfile-only` — lockfile updated
- [x] `pnpm run build` — all packages build successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)