### PR TITLE
fix: remove unnecessary host_permissions from manifest

### DIFF
--- a/packages/extension/public/manifest.json
+++ b/packages/extension/public/manifest.json
@@ -16,9 +16,6 @@
     "page": "preferences/preferences.html",
     "open_in_tab": false
   },
-  "host_permissions": [
-    "<all_urls>"
-  ],
   "action": {
     "default_title": "Dramaturg",
     "default_icon": {


### PR DESCRIPTION
## Summary
- Remove `host_permissions: ["<all_urls>"]` from manifest.json
- The `debugger` permission covers `chrome.debugger.attach()` and `activeTab` grants access on user interaction
- Avoids Chrome Web Store in-depth review for broad host permissions

Closes #169

🤖 Generated with [Claude Code](https://claude.com/claude-code)