### PR TITLE
chore: bump version to 0.16.1 + update CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## v0.16.1 — Exact Match & Highlight Improvements
+
+**2026-03-13**
+
+### Features
+
+- **`--exact` flag**: All text locator commands (`click`, `fill`, `hover`, `check`, `uncheck`, `select`, `highlight`) now support `--exact` to skip the fallback chain and use only the primary locator match. ([#156](https://github.com/stevez/playwright-repl/issues/156), [#165](https://github.com/stevez/playwright-repl/pull/165))
+- **Highlight match count**: `highlight` now returns the number of matched elements (e.g. `Highlighted 5 elements`, `Highlighted 1 of 24`). ([#165](https://github.com/stevez/playwright-repl/pull/165))
+- **`highlight --clear`**: Dismiss Playwright's highlight overlay with `highlight --clear`. ([#165](https://github.com/stevez/playwright-repl/pull/165))
+- **`highlight --nth`**: Highlight a single element by index using CSS outline (Playwright's `.highlight()` ignores `.nth()`). ([#165](https://github.com/stevez/playwright-repl/pull/165))
+
+### Fixes
+
+- **Bare `document`/`window` in console**: Fixed mode detection so `document` and `window` are correctly routed to JS mode instead of being treated as `.pw` keywords. ([#168](https://github.com/stevez/playwright-repl/pull/168))
+- **Remove `host_permissions`**: Removed unnecessary `<all_urls>` host permission from the extension manifest — the `debugger` and `activeTab` permissions are sufficient. ([#169](https://github.com/stevez/playwright-repl/issues/169), [#170](https://github.com/stevez/playwright-repl/pull/170))
+
+---
+
 ## v0.16.0 — Autocompletion, Snapshot Tree & Recording Fixes
 
 **2026-03-12**

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "playwright-repl",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "description": "Interactive REPL for Playwright browser automation — keyword-driven testing from your terminal",
   "type": "module",
   "bin": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@playwright-repl/core",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "type": "module",
   "main": "./dist/index.js",
   "exports": {

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@playwright-repl/extension",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "private": true,
   "description": "Chrome DevTools panel extension for Playwright REPL",
   "type": "module",

--- a/packages/extension/public/manifest.json
+++ b/packages/extension/public/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Dramaturg",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "description": "Playwright engineer's companion — console, editor, runner, and recorder in a Chrome side panel.",
   "permissions": [
     "activeTab",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@playwright-repl/mcp",
-    "version": "0.16.0",
+    "version": "0.16.1",
     "type": "module",
     "bin": {
         "playwright-repl-mcp": "./dist/index.js"


### PR DESCRIPTION
## Summary
- Bump all packages to 0.16.1
- Add CHANGELOG entry for v0.16.1: --exact flag, highlight improvements, document/window fix, host_permissions removal

## Test plan
- [x] All tests pass locally (115 core + 581 extension)
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)