### PR TITLE
fix: recording CSS selector fallback + pick element pw output

### DIFF
--- a/packages/extension/public/manifest.json
+++ b/packages/extension/public/manifest.json
@@ -13,6 +13,9 @@
     "offscreen",
     "scripting"
   ],
+  "host_permissions": [
+    "<all_urls>"
+  ],
   "options_ui": {
     "page": "preferences/preferences.html",
     "open_in_tab": false

--- a/packages/extension/src/content/picker.ts
+++ b/packages/extension/src/content/picker.ts
@@ -73,9 +73,14 @@
             if (label) return label;
         }
 
-        // For buttons, links: text content
+        // For roles that get name from content (ARIA "name from content" roles)
         const role = getImplicitRole(el);
-        if (role === 'button' || role === 'link' || role === 'heading') {
+        const NAME_FROM_CONTENT = new Set([
+            'button', 'link', 'heading', 'tab', 'menuitem', 'menuitemcheckbox',
+            'menuitemradio', 'option', 'radio', 'checkbox', 'switch', 'cell',
+            'columnheader', 'rowheader', 'tooltip', 'treeitem',
+        ]);
+        if (role && NAME_FROM_CONTENT.has(role)) {
             const text = (el.textContent || '').trim();
             if (text && text.length <= 80) return text;
         }

--- a/packages/extension/src/panel/lib/converter.ts
+++ b/packages/extension/src/panel/lib/converter.ts
@@ -96,45 +96,38 @@ export function jsonlToRepl(jsonStr: string, isFirst: boolean): string | null {
         // Skip focus-clicks on text inputs — noise before fill
         if (kind === 'role' && body === 'textbox') return null;
         if (text) return `click ${q(text)}${nth}`;
-        if (kind === 'role' && body) return `click ${body}${nth}`;
-        if (kind === 'default' && a.selector && !['html', 'body'].includes(a.selector.trim()))
+        if ((kind === 'role' || kind === 'default') && a.selector && !['html', 'body'].includes(a.selector.trim()))
           return `click ${q(a.selector)}`;
         return null;
 
       case 'fill':
         if (text) return `fill ${q(text)} ${q(a.text ?? '')}${nth}`;
-        if (kind === 'role' && body) return `fill ${body} ${q(a.text ?? '')}${nth}`;
-        if (kind === 'default' && a.selector) return `fill ${q(a.selector)} ${q(a.text ?? '')}`;
+        if ((kind === 'role' || kind === 'default') && a.selector) return `fill ${q(a.selector)} ${q(a.text ?? '')}`;
         return null;
 
       case 'press':
         if (text) return `press ${q(text)} ${a.key ?? ''}${nth}`;
-        if (kind === 'role' && body) return `press ${body} ${a.key ?? ''}${nth}`;
         // Global key press (no locator)
         return a.key ? `press ${a.key}` : null;
 
       case 'hover':
         if (text) return `hover ${q(text)}${nth}`;
-        if (kind === 'role' && body) return `hover ${body}${nth}`;
-        if (kind === 'default' && a.selector) return `hover ${q(a.selector)}`;
+        if ((kind === 'role' || kind === 'default') && a.selector) return `hover ${q(a.selector)}`;
         return null;
 
       case 'check':
         if (text) return `check ${q(text)}${nth}`;
-        if (kind === 'role' && body) return `check ${body}${nth}`;
         if (a.selector) return `check ${q(a.selector)}`;
         return null;
 
       case 'uncheck':
         if (text) return `uncheck ${q(text)}${nth}`;
-        if (kind === 'role' && body) return `uncheck ${body}${nth}`;
         if (a.selector) return `uncheck ${q(a.selector)}`;
         return null;
 
       case 'selectOption':
       case 'select':
         if (text) return `select ${q(text)} ${q(a.options?.[0] ?? '')}${nth}`;
-        if (kind === 'role' && body) return `select ${body} ${q(a.options?.[0] ?? '')}${nth}`;
         if (a.selector) return `select ${q(a.selector)} ${q(a.options?.[0] ?? '')}`;
         return null;
 

--- a/packages/extension/src/panel/lib/pick-info.ts
+++ b/packages/extension/src/panel/lib/pick-info.ts
@@ -2,45 +2,64 @@ import { swDebugEval } from '@/lib/sw-debugger';
 import type { ElementPickInfo, PickResultData } from '@/types';
 
 /**
+ * Extract --nth flag from a JS locator chain (.first(), .last(), .nth(N)).
+ */
+function extractNth(locator: string): string {
+    if (/\.first\(\)/.test(locator)) return ' --nth 0';
+    if (/\.last\(\)/.test(locator)) return ' --nth -1';
+    const nthMatch = locator.match(/\.nth\((\d+)\)/);
+    if (nthMatch) return ` --nth ${nthMatch[1]}`;
+    return '';
+}
+
+/**
  * Derive a .pw keyword command from element info.
  * Returns null if no suitable name/text can be extracted.
  */
-function derivePwCommand(info: ElementPickInfo): string | null {
-    // Try accessible name from role-based locator: getByRole('button', { name: 'Submit' })
-    const roleMatch = info.locator.match(/getByRole\([^,]+,\s*\{\s*name:\s*['"](.+?)['"]\s*\}/);
-    if (roleMatch) return `highlight "${roleMatch[1]}"`;
+function derivePwCommand(info: ElementPickInfo, jsLocator?: string): string | null {
+    // Extract nth from JS locator (has .first()/.nth()) not content script's locator
+    const nth = extractNth(jsLocator ?? info.locator);
+
+    // Try role + name: getByRole('button', { name: 'Submit' }) → highlight button "Submit"
+    const roleNameMatch = info.locator.match(/getByRole\(['"](.+?)['"],\s*\{\s*name:\s*['"](.+?)['"]\s*\}/);
+    if (roleNameMatch) return `highlight ${roleNameMatch[1]} "${roleNameMatch[2]}"${nth}`;
+
+    // Try bare role: getByRole('tab') → highlight tab
+    const roleMatch = info.locator.match(/getByRole\(['"](.+?)['"]\)/);
+    if (roleMatch) return `highlight ${roleMatch[1]}${nth}`;
 
     // Try test ID: getByTestId('submit')
     const testIdMatch = info.locator.match(/getByTestId\(['"](.+?)['"]\)/);
-    if (testIdMatch) return `highlight "${testIdMatch[1]}"`;
+    if (testIdMatch) return `highlight "${testIdMatch[1]}"${nth}`;
 
     // Try label: getByLabel('Email')
     const labelMatch = info.locator.match(/getByLabel\(['"](.+?)['"]\)/);
-    if (labelMatch) return `highlight "${labelMatch[1]}"`;
+    if (labelMatch) return `highlight "${labelMatch[1]}"${nth}`;
 
     // Try text: getByText('Submit')
     const textMatch = info.locator.match(/getByText\(['"](.+?)['"]\)/);
-    if (textMatch) return `highlight "${textMatch[1]}"`;
+    if (textMatch) return `highlight "${textMatch[1]}"${nth}`;
 
     // Try placeholder: getByPlaceholder('Enter email')
     const placeholderMatch = info.locator.match(/getByPlaceholder\(['"](.+?)['"]\)/);
-    if (placeholderMatch) return `highlight "${placeholderMatch[1]}"`;
+    if (placeholderMatch) return `highlight "${placeholderMatch[1]}"${nth}`;
 
     // Fallback: use element text content
-    if (info.text && info.text.length <= 80) return `highlight "${info.text}"`;
+    if (info.text && info.text.length <= 80) return `highlight "${info.text}"${nth}`;
 
     return null;
 }
 
 /**
  * Build a PickResultData from element info gathered by the content script.
- * Uses Playwright's locator when available, falls back to content script's own.
+ * Playwright's locator for JS/locator display (more precise chaining).
+ * Content script's locator for pw command (simpler, role-aware).
  */
 export function buildPickResult(info: ElementPickInfo): PickResultData {
-    const locatorExpr = info.pwLocator ?? info.locator;
-    const locator = `page.${locatorExpr}`;
-    const jsExpression = `await page.${locatorExpr}.highlight();`;
-    const pwCommand = derivePwCommand({ ...info, locator: locatorExpr });
+    const jsLocator = info.pwLocator ?? info.locator;
+    const locator = `page.${jsLocator}`;
+    const jsExpression = `await page.${jsLocator}.highlight();`;
+    const pwCommand = derivePwCommand(info, jsLocator);
 
     return {
         locator,

--- a/packages/extension/test/lib/converter.test.ts
+++ b/packages/extension/test/lib/converter.test.ts
@@ -120,9 +120,9 @@ describe("jsonlToRepl", () => {
     expect(jsonlToRepl(action, false)).toBeNull();
   });
 
-  it("converts click with role locator but no name", () => {
-    const action = jsonl({ name: "click", selector: "button", locator: { kind: "role", body: "navigation" } });
-    expect(jsonlToRepl(action, false)).toBe("click navigation");
+  it("converts click with role locator but no name to CSS selector", () => {
+    const action = jsonl({ name: "click", selector: "nav.main", locator: { kind: "role", body: "navigation" } });
+    expect(jsonlToRepl(action, false)).toBe('click "nav.main"');
   });
 
   it("converts click with default locator and CSS selector", () => {
@@ -147,9 +147,9 @@ describe("jsonlToRepl", () => {
     expect(jsonlToRepl(action, false)).toBe('fill "Name" "Alice"');
   });
 
-  it("converts fill with role locator (no name)", () => {
-    const action = jsonl({ name: "fill", text: "test", locator: { kind: "role", body: "textbox" } });
-    expect(jsonlToRepl(action, false)).toBe('fill textbox "test"');
+  it("converts fill with role locator (no name) to CSS selector", () => {
+    const action = jsonl({ name: "fill", text: "test", selector: "input.email", locator: { kind: "role", body: "textbox" } });
+    expect(jsonlToRepl(action, false)).toBe('fill "input.email" "test"');
   });
 
   it("converts fill with default locator", () => {
@@ -169,9 +169,9 @@ describe("jsonlToRepl", () => {
     expect(jsonlToRepl(action, false)).toBe('press "Search" Enter');
   });
 
-  it("converts press with role locator (no name)", () => {
+  it("converts press with role locator (no name) to global key press", () => {
     const action = jsonl({ name: "press", key: "Tab", locator: { kind: "role", body: "textbox" } });
-    expect(jsonlToRepl(action, false)).toBe("press textbox Tab");
+    expect(jsonlToRepl(action, false)).toBe("press Tab");
   });
 
   it("converts global key press (no locator)", () => {
@@ -191,9 +191,9 @@ describe("jsonlToRepl", () => {
     expect(jsonlToRepl(action, false)).toBe('hover "Menu"');
   });
 
-  it("converts hover with role locator (no name)", () => {
-    const action = jsonl({ name: "hover", locator: { kind: "role", body: "link" } });
-    expect(jsonlToRepl(action, false)).toBe("hover link");
+  it("converts hover with role locator (no name) to CSS selector", () => {
+    const action = jsonl({ name: "hover", selector: "a.nav-link", locator: { kind: "role", body: "link" } });
+    expect(jsonlToRepl(action, false)).toBe('hover "a.nav-link"');
   });
 
   it("converts hover with default locator", () => {
@@ -213,9 +213,9 @@ describe("jsonlToRepl", () => {
     expect(jsonlToRepl(action, false)).toBe('check "Accept terms"');
   });
 
-  it("converts check with role locator (no name)", () => {
-    const action = jsonl({ name: "check", locator: { kind: "role", body: "checkbox" } });
-    expect(jsonlToRepl(action, false)).toBe("check checkbox");
+  it("converts check with role locator (no name) to selector", () => {
+    const action = jsonl({ name: "check", selector: "input[type=checkbox]", locator: { kind: "role", body: "checkbox" } });
+    expect(jsonlToRepl(action, false)).toBe('check "input[type=checkbox]"');
   });
 
   it("converts check with selector fallback", () => {
@@ -233,9 +233,9 @@ describe("jsonlToRepl", () => {
     expect(jsonlToRepl(action, false)).toBe('uncheck "Newsletter"');
   });
 
-  it("converts uncheck with role locator (no name)", () => {
-    const action = jsonl({ name: "uncheck", locator: { kind: "role", body: "checkbox" } });
-    expect(jsonlToRepl(action, false)).toBe("uncheck checkbox");
+  it("converts uncheck with role locator (no name) to selector", () => {
+    const action = jsonl({ name: "uncheck", selector: "input[type=checkbox]", locator: { kind: "role", body: "checkbox" } });
+    expect(jsonlToRepl(action, false)).toBe('uncheck "input[type=checkbox]"');
   });
 
   it("converts uncheck with selector fallback", () => {
@@ -255,9 +255,9 @@ describe("jsonlToRepl", () => {
     expect(jsonlToRepl(action, false)).toBe('select "Color" "red"');
   });
 
-  it("converts select with role locator (no name)", () => {
-    const action = jsonl({ name: "select", options: ["sm"], locator: { kind: "role", body: "combobox" } });
-    expect(jsonlToRepl(action, false)).toBe('select combobox "sm"');
+  it("converts select with role locator (no name) to selector", () => {
+    const action = jsonl({ name: "select", options: ["sm"], selector: "select.size", locator: { kind: "role", body: "combobox" } });
+    expect(jsonlToRepl(action, false)).toBe('select "select.size" "sm"');
   });
 
   it("converts selectOption with selector fallback", () => {


### PR DESCRIPTION
## Summary
- **Recording fix**: Remove bare-role fallback in converter that produced unexecutable commands like `click tab --nth 0` when the recorder provides roles without accessible names. Now falls through to CSS selector (e.g., `click "div >> internal:role=tab >> nth=0"`), restoring behavior from before #154.
- **Manifest**: Restore `host_permissions: ["<all_urls>"]` (reverts #170) — needed for full recorder access.
- **Pick element**: Expand `getAccessibleName` for ARIA "name from content" roles (tab, menuitem, checkbox, etc.) and improve `derivePwCommand` to extract role + nth from locator patterns → `highlight tab "npm" --nth 2`.

## Test plan
- [x] Unit tests pass (581/581)
- [ ] Record tab clicks on playwright.dev → should produce CSS selectors, not bare roles
- [ ] Pick element on tab → pw shows `highlight tab "name" --nth N`
- [ ] Record fill/check/select actions → still work with named roles

🤖 Generated with [Claude Code](https://claude.com/claude-code)