### PR TITLE
fix: multi-line await in console (#173)

### DIFF
--- a/packages/extension/src/panel/components/Console/useConsole.ts
+++ b/packages/extension/src/panel/components/Console/useConsole.ts
@@ -4,7 +4,7 @@ import { addCommand, getCommandHistory, clearHistory } from '@/lib/command-histo
 import { swDebugEval, swGetProperties } from '@/lib/sw-debugger';
 import { cdpEvaluate, executeCommandForConsole } from '@/lib/bridge';
 import { fromCdpRemoteObject, type CdpRemoteObject } from './cdpToSerialized';
-import { detectMode } from '@/lib/execute';
+import { resolveConsoleMode } from '@/lib/execute';
 import { runJsScript } from '@/lib/run';
 import type { Action } from '@/reducer';
 import type React from 'react';
@@ -100,7 +100,7 @@ export function useConsole(dispatch: React.Dispatch<Action>) {
 
         addCommand(trimmed);
 
-        const mode = detectMode(trimmed);
+        const mode = resolveConsoleMode(trimmed);
         dispatch({ type: 'COMMAND_SUBMITTED', line: { text: trimmed, type: 'command' } });
 
         try {

--- a/packages/extension/src/panel/lib/bridge.ts
+++ b/packages/extension/src/panel/lib/bridge.ts
@@ -57,12 +57,15 @@ export async function executeCommand(command: string): Promise<CommandResult> {
   if ('error' in parsed) {
     // Not a keyword command — check if it's a raw playwright/JS expression
     const { detectMode } = await import('@/lib/execute');
-    const mode = detectMode(command.trim());
+    const expr = command.trim();
+    const isMultiLine = expr.includes('\n');
+    const mode = detectMode(expr);
 
-    if (mode === 'playwright') {
+    // Multi-line input → evaluate in SW context (AsyncFunction supports await)
+    if (mode === 'playwright' || isMultiLine) {
       // Evaluate in SW context (page, crxApp globals available)
       try {
-        const raw = await withTimeout(swDebugEval(command.trim())) as { result?: CdpResult };
+        const raw = await withTimeout(swDebugEval(expr)) as { result?: CdpResult };
         return formatResult(raw?.result);
       } catch (e: any) {
         return { text: e?.message ?? String(e), isError: true };
@@ -72,7 +75,6 @@ export async function executeCommand(command: string): Promise<CommandResult> {
     if (mode === 'js' || mode === 'pw') {
       // Evaluate in tab context, serializing objects via JSON.stringify
       try {
-        const expr = command.trim();
         const wrapped = `(function(){try{var __v=(${expr});`
           + `if(__v===undefined)return undefined;`
           + `try{return JSON.stringify(__v,null,2);}catch(_){return String(__v);}`

--- a/packages/extension/src/panel/lib/execute.ts
+++ b/packages/extension/src/panel/lib/execute.ts
@@ -2,6 +2,15 @@ import { COMMAND_NAMES } from '@/lib/commands';
 
 const PW_COMMANDS = new Set(COMMAND_NAMES);
 
+/**
+ * Resolve the execution mode for console input.
+ * Multi-line input always runs in the SW context (AsyncFunction supports await).
+ */
+export function resolveConsoleMode(input: string): 'playwright' | 'js' | 'pw' {
+    if (input.includes('\n')) return 'playwright';
+    return detectMode(input);
+}
+
 export function detectMode(input: string): 'playwright' | 'js' | 'pw' {
     const t = input.trim();
     const firstToken = t.split(/\s+/)[0].toLowerCase();

--- a/packages/extension/test/lib/execute.test.ts
+++ b/packages/extension/test/lib/execute.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { detectMode } from '@/lib/execute';
+import { detectMode, resolveConsoleMode } from '@/lib/execute';
 
 describe('detectMode', () => {
 
@@ -84,4 +84,21 @@ describe('detectMode', () => {
         expect(detectMode('"hello"')).toBe('js');
     });
 
+});
+
+describe('resolveConsoleMode', () => {
+
+    it('returns playwright for multi-line input', () => {
+        expect(resolveConsoleMode('const el = await page.$(\'a\');\nawait el._generateLocatorString()')).toBe('playwright');
+    });
+
+    it('returns playwright for multi-line input even without playwright globals', () => {
+        expect(resolveConsoleMode('const x = 1;\nconsole.log(x)')).toBe('playwright');
+    });
+
+    it('delegates to detectMode for single-line input', () => {
+        expect(resolveConsoleMode('page.title()')).toBe('playwright');
+        expect(resolveConsoleMode('click e5')).toBe('pw');
+        expect(resolveConsoleMode('document.title')).toBe('js');
+    });
 });


### PR DESCRIPTION
## Summary
- Multi-line console input (via Shift+Enter) now routes to `swDebugEval` which uses AsyncFunction constructor — `await` works correctly
- Added `resolveConsoleMode()` that forces `'playwright'` mode for multi-line input, delegates to `detectMode()` for single-line
- Same fix applied in `bridge.ts` for the editor command path

## Test plan
- [x] Unit tests: 3 new tests for `resolveConsoleMode` (584 total pass)
- [x] Manual: multi-line `const el = await page.$(...); await el._generateLocatorString()` returns locator string
- [x] Single-line commands unchanged

Closes #173

🤖 Generated with [Claude Code](https://claude.com/claude-code)