### PR TITLE
feat: add contextual assertions to pick element

### DIFF
--- a/packages/core/src/engine.ts
+++ b/packages/core/src/engine.ts
@@ -216,13 +216,22 @@ export class Engine {
       if (args.clear) {
         args = { _: ['run-code', `async (page) => { await page.locator('#__pw_clear__').highlight().catch(() => {}); return "Cleared"; }`] };
       } else {
-        const loc = args._.slice(1).join(' ');
-        if (!loc) return { text: 'Usage: highlight <locator>', isError: true };
+        const parts = args._.slice(1);
+        if (!parts.length) return { text: 'Usage: highlight <locator>', isError: true };
         const nth = args.nth !== undefined ? parseInt(String(args.nth), 10) : undefined;
-        const isSelector = /[.#\[\]>:=]/.test(loc);
-        let locExpr = isSelector
-          ? `page.locator(${JSON.stringify(loc)})`
-          : `page.getByText(${JSON.stringify(loc)})`;
+        let locExpr: string;
+        // highlight <role> "<name>" → getByRole(role, { name })
+        if (parts.length >= 2 && /^[a-z]+$/.test(parts[0])) {
+          const role = parts[0];
+          const name = parts.slice(1).join(' ');
+          locExpr = `page.getByRole(${JSON.stringify(role)}, { name: ${JSON.stringify(name)}, exact: true })`;
+        } else {
+          const loc = parts.join(' ');
+          const isSelector = /[.#\[\]>:=]/.test(loc);
+          locExpr = isSelector
+            ? `page.locator(${JSON.stringify(loc)})`
+            : `page.getByText(${JSON.stringify(loc)})`;
+        }
         if (nth !== undefined) locExpr += `.nth(${nth})`;
         args = { _: ['run-code', `async (page) => { await ${locExpr}.highlight(); return "Highlighted"; }`] };
       }

--- a/packages/extension/src/content/picker.ts
+++ b/packages/extension/src/content/picker.ts
@@ -112,6 +112,17 @@
         return '';
     }
 
+    // ─── Locator disambiguation ─────────────────────────────────────────────
+
+    function findByRoleAndName(role: string, name: string): Element[] {
+        const matches: Element[] = [];
+        for (const el of document.querySelectorAll('*')) {
+            if (getImplicitRole(el) === role && getAccessibleName(el) === name)
+                matches.push(el);
+        }
+        return matches;
+    }
+
     // ─── Locator generation ──────────────────────────────────────────────────
 
     function escapeString(s: string): string {
@@ -128,7 +139,17 @@
         // 2. Role + accessible name
         const role = getImplicitRole(el);
         const name = getAccessibleName(el);
-        if (role && name) return `getByRole(${escapeString(role)}, { name: ${escapeString(name)} })`;
+        if (role && name) {
+            // Disambiguate when multiple elements share same role + name
+            const matches = findByRoleAndName(role, name);
+            if (matches.length > 1) {
+                // exact: true so Playwright matches same elements as our exact comparison
+                const base = `getByRole(${escapeString(role)}, { name: ${escapeString(name)}, exact: true })`;
+                const idx = matches.indexOf(el);
+                return idx === 0 ? base + '.first()' : base + `.nth(${idx})`;
+            }
+            return `getByRole(${escapeString(role)}, { name: ${escapeString(name)} })`;
+        }
 
         // 3. Label (for form elements)
         if (el instanceof HTMLInputElement || el instanceof HTMLTextAreaElement || el instanceof HTMLSelectElement) {
@@ -191,6 +212,10 @@
             visible: rect.width > 0 && rect.height > 0,
             enabled: !(el as HTMLButtonElement).disabled,
             box: { x: rect.x, y: rect.y, width: rect.width, height: rect.height },
+            value: (el instanceof HTMLInputElement || el instanceof HTMLTextAreaElement || el instanceof HTMLSelectElement)
+                ? el.value : undefined,
+            checked: (el instanceof HTMLInputElement && (el.type === 'checkbox' || el.type === 'radio'))
+                ? el.checked : undefined,
         };
     }
 

--- a/packages/extension/src/panel/components/Console/PickResult.tsx
+++ b/packages/extension/src/panel/components/Console/PickResult.tsx
@@ -1,9 +1,9 @@
 import { useState } from 'react';
 import type { PickResultData } from '@/types';
 
-function Row({ label, value }: { label: string; value: string }) {
+function SubRow({ label, value }: { label: string; value: string }) {
     return (
-        <div className="ot-row">
+        <div className="ot-row" style={{ paddingLeft: '1.2em' }}>
             <span className="ot-key">{label}</span>
             <span className="ot-colon">:&nbsp;</span>
             <span className="ot-string min-w-0 truncate">{value}</span>
@@ -17,10 +17,21 @@ export function PickResult({ data }: { data: PickResultData }) {
 
     return (
         <div data-type="pick-result">
-            <Row label="locator" value={data.locator} />
-            <Row label="js" value={data.jsExpression} />
-            {data.pwCommand && <Row label="pw" value={data.pwCommand} />}
+            {/* ─── locator section ───────────────────────────────────── */}
+            <div className="ot-row"><span className="ot-key">locator</span></div>
+            <SubRow label="js" value={data.jsExpression} />
+            {data.pwCommand && <SubRow label="pw" value={data.pwCommand} />}
 
+            {/* ─── assert section ────────────────────────────────────── */}
+            {data.assertJs && (
+                <>
+                    <div className="ot-row"><span className="ot-key">assert</span></div>
+                    <SubRow label="js" value={data.assertJs} />
+                    {data.assertPw && <SubRow label="pw" value={data.assertPw} />}
+                </>
+            )}
+
+            {/* ─── element details (expandable) ──────────────────────── */}
             {d && (
                 <div>
                     <span className="ot-toggle" onClick={() => setShowDetails(!showDetails)}>

--- a/packages/extension/src/panel/lib/commands.ts
+++ b/packages/extension/src/panel/lib/commands.ts
@@ -129,7 +129,7 @@ import {
   verifyTitle, verifyUrl, verifyNoText, verifyNoElement,
   verifyVisible, verifyInputValue,
   actionByText, fillByText, selectByText, checkByText, uncheckByText,
-  highlightByText, highlightBySelector, clearHighlight, chainAction, goBack, goForward,
+  highlightByText, highlightByRole, highlightBySelector, clearHighlight, chainAction, goBack, goForward,
   gotoUrl, reloadPage, waitMs, getTitle, getUrl,
   evalCode, runCode, takeScreenshot, takeSnapshot,
   refAction, pressKey, typeText,
@@ -379,6 +379,11 @@ function resolveArgs(args: ParsedArgs): ParsedArgs | DirectExecution {
       const nth = args.nth !== undefined ? parseInt(String(args.nth), 10) : undefined;
       const exact = args.exact ? true : undefined;
       const isSelector = /[.#[\]>:=]/.test(loc);
+      // highlight <role> "<name>" → getByRole(role, { name })
+      if (!isSelector && args._.length >= 3 && /^[a-z]+$/.test(loc)) {
+        const name = args._.slice(2).join(' ');
+        return { jsExpr: call(highlightByRole, loc, name, nth) };
+      }
       return isSelector
         ? { jsExpr: call(highlightBySelector, loc, nth) }
         : { jsExpr: call(highlightByText, loc, nth, exact) };

--- a/packages/extension/src/panel/lib/page-scripts.ts
+++ b/packages/extension/src/panel/lib/page-scripts.ts
@@ -185,6 +185,16 @@ export async function highlightByText(page, text, nth, exact) {
     : 'Highlighted ' + count + ' element' + (count !== 1 ? 's' : '');
 }
 
+export async function highlightByRole(page, role, name, nth) {
+  let loc = page.getByRole(role, { name, exact: true });
+  const count = await loc.count();
+  if (nth !== undefined) loc = loc.nth(nth);
+  await loc.highlight();
+  return nth !== undefined
+    ? 'Highlighted 1 of ' + count
+    : 'Highlighted ' + count + ' element' + (count !== 1 ? 's' : '');
+}
+
 export async function highlightBySelector(page, selector, nth) {
   let loc = page.locator(selector);
   const count = await loc.count();

--- a/packages/extension/src/panel/lib/pick-info.ts
+++ b/packages/extension/src/panel/lib/pick-info.ts
@@ -13,58 +13,177 @@ function extractNth(locator: string): string {
 }
 
 /**
+ * Try to derive a pw highlight command from a locator string.
+ * Returns null if no getBy* pattern matches.
+ */
+function parsePwCommand(locator: string, nth: string): string | null {
+    const roleNameMatch = locator.match(/getByRole\(['"](.+?)['"],\s*\{[^}]*name:\s*['"](.+?)['"]/);
+    if (roleNameMatch) return `highlight ${roleNameMatch[1]} "${roleNameMatch[2]}"${nth}`;
+
+    const roleMatch = locator.match(/getByRole\(['"](.+?)['"]\)/);
+    if (roleMatch) return `highlight ${roleMatch[1]}${nth}`;
+
+    const testIdMatch = locator.match(/getByTestId\(['"](.+?)['"]\)/);
+    if (testIdMatch) return `highlight "${testIdMatch[1]}"${nth}`;
+
+    const labelMatch = locator.match(/getByLabel\(['"](.+?)['"]\)/);
+    if (labelMatch) return `highlight "${labelMatch[1]}"${nth}`;
+
+    const textMatch = locator.match(/getByText\(['"](.+?)['"]\)/);
+    if (textMatch) return `highlight "${textMatch[1]}"${nth}`;
+
+    const placeholderMatch = locator.match(/getByPlaceholder\(['"](.+?)['"]\)/);
+    if (placeholderMatch) return `highlight "${placeholderMatch[1]}"${nth}`;
+
+    return null;
+}
+
+/**
  * Derive a .pw keyword command from element info.
+ * Tries content script's locator first, then Playwright's jsLocator as fallback.
  * Returns null if no suitable name/text can be extracted.
  */
 function derivePwCommand(info: ElementPickInfo, jsLocator?: string): string | null {
-    // Extract nth from JS locator (has .first()/.nth()) not content script's locator
-    const nth = extractNth(jsLocator ?? info.locator);
+    // Prefer nth from content script's locator (globally correct)
+    // Fall back to Playwright's locator nth only when content script has none
+    const contentNth = extractNth(info.locator);
+    const nth = contentNth || extractNth(jsLocator ?? info.locator);
 
-    // Try role + name: getByRole('button', { name: 'Submit' }) → highlight button "Submit"
-    const roleNameMatch = info.locator.match(/getByRole\(['"](.+?)['"],\s*\{\s*name:\s*['"](.+?)['"]\s*\}/);
-    if (roleNameMatch) return `highlight ${roleNameMatch[1]} "${roleNameMatch[2]}"${nth}`;
+    // Try content script's locator first
+    const fromContentScript = parsePwCommand(info.locator, nth);
+    if (fromContentScript) return fromContentScript;
 
-    // Try bare role: getByRole('tab') → highlight tab
-    const roleMatch = info.locator.match(/getByRole\(['"](.+?)['"]\)/);
-    if (roleMatch) return `highlight ${roleMatch[1]}${nth}`;
+    // Fallback: try Playwright's locator (may have better name for long-text elements)
+    if (jsLocator && jsLocator !== info.locator) {
+        const fromPlaywright = parsePwCommand(jsLocator, nth);
+        if (fromPlaywright) return fromPlaywright;
+    }
 
-    // Try test ID: getByTestId('submit')
-    const testIdMatch = info.locator.match(/getByTestId\(['"](.+?)['"]\)/);
-    if (testIdMatch) return `highlight "${testIdMatch[1]}"${nth}`;
-
-    // Try label: getByLabel('Email')
-    const labelMatch = info.locator.match(/getByLabel\(['"](.+?)['"]\)/);
-    if (labelMatch) return `highlight "${labelMatch[1]}"${nth}`;
-
-    // Try text: getByText('Submit')
-    const textMatch = info.locator.match(/getByText\(['"](.+?)['"]\)/);
-    if (textMatch) return `highlight "${textMatch[1]}"${nth}`;
-
-    // Try placeholder: getByPlaceholder('Enter email')
-    const placeholderMatch = info.locator.match(/getByPlaceholder\(['"](.+?)['"]\)/);
-    if (placeholderMatch) return `highlight "${placeholderMatch[1]}"${nth}`;
-
-    // Fallback: use element text content
+    // Last resort: use element text content
     if (info.text && info.text.length <= 80) return `highlight "${info.text}"${nth}`;
 
     return null;
 }
 
 /**
+ * Extract the quoted name from a pw command like `highlight "Submit"` or `highlight button "Submit"`.
+ */
+function extractPwName(pwCommand: string): string | null {
+    const match = pwCommand.match(/"(.+?)"/);
+    return match ? match[1] : null;
+}
+
+/**
+ * Extract the name/text argument from a JS locator string like `page.getByText('Submit')`.
+ * Used as fallback when pwCommand is null (e.g. content script locator was CSS).
+ */
+function extractLocatorName(locator: string): string | null {
+    const roleNameMatch = locator.match(/getByRole\(['"](.+?)['"],\s*\{[^}]*name:\s*['"](.+?)['"]/);
+    if (roleNameMatch) return roleNameMatch[2];
+    const textMatch = locator.match(/getByText\(['"](.+?)['"]\)/);
+    if (textMatch) return textMatch[1];
+    const labelMatch = locator.match(/getByLabel\(['"](.+?)['"]\)/);
+    if (labelMatch) return labelMatch[1];
+    const testIdMatch = locator.match(/getByTestId\(['"](.+?)['"]\)/);
+    if (testIdMatch) return testIdMatch[1];
+    const placeholderMatch = locator.match(/getByPlaceholder\(['"](.+?)['"]\)/);
+    if (placeholderMatch) return placeholderMatch[1];
+    return null;
+}
+
+/**
+ * Derive assertion strings (JS + PW) based on element type.
+ * Priority: checked > value > text > visible.
+ */
+function deriveAssertion(info: ElementPickInfo, locator: string, pwCommand: string | null): { assertJs: string; assertPw: string } {
+    const tag = info.tag;
+    const inputType = info.attributes?.type?.toLowerCase() ?? '';
+    // Extract name from pw command, falling back to JS locator string
+    const name = (pwCommand ? extractPwName(pwCommand) : null) ?? extractLocatorName(locator);
+    const quotedName = name ? `"${name}"` : null;
+    // Extract role and nth from locator for pw assertions
+    const roleMatch = locator.match(/getByRole\(['"](.+?)['"]/);
+    const role = roleMatch ? roleMatch[1] : null;
+    const nth = extractNth(locator);
+
+    // Checkbox/radio → checked assertion
+    if (tag === 'input' && (inputType === 'checkbox' || inputType === 'radio') && info.checked !== undefined) {
+        return {
+            assertJs: info.checked
+                ? `await expect(${locator}).toBeChecked();`
+                : `await expect(${locator}).not.toBeChecked();`,
+            assertPw: quotedName
+                ? `verify-value ${quotedName} "${info.checked ? 'on' : 'off'}"`
+                : `verify-value "${info.checked ? 'on' : 'off'}"`,
+        };
+    }
+
+    // Input/textarea/select → value assertion
+    if ((tag === 'input' || tag === 'textarea' || tag === 'select') && info.value !== undefined) {
+        return {
+            assertJs: `await expect(${locator}).toHaveValue('${info.value.replace(/'/g, "\\'")}');`,
+            assertPw: quotedName
+                ? `verify-value ${quotedName} "${info.value}"`
+                : `verify-value "${info.value}"`,
+        };
+    }
+
+    // Helper: build pw assertion target, consistent with JS locator's role/name/nth
+    function pwTarget(fallbackText?: string): string {
+        if (role && quotedName) return `${role} ${quotedName}${nth}`;
+        if (quotedName) return `${quotedName}${nth}`;
+        if (fallbackText) return `"${fallbackText}"${nth}`;
+        return '';
+    }
+
+    // Has text content → text assertion
+    // Skip if locator is getByText — toContainText with the same text is redundant
+    const text = info.text?.trim();
+    const locatorIsText = /\.getByText\(/.test(locator);
+    if (text && !locatorIsText) {
+        const assertText = name ?? text;
+        const target = pwTarget(assertText);
+        return {
+            assertJs: `await expect(${locator}).toContainText('${assertText.replace(/'/g, "\\'")}');`,
+            assertPw: role ? `verify-element ${target}` : `verify-text ${target}`,
+        };
+    }
+
+    // Fallback → visible assertion
+    const target = pwTarget();
+    let assertPw: string;
+    if (role) {
+        assertPw = target ? `verify-element ${target}` : 'verify-text';
+    } else if (target) {
+        assertPw = `verify-text ${target}`;
+    } else {
+        assertPw = 'verify-text';
+    }
+    return {
+        assertJs: `await expect(${locator}).toBeVisible();`,
+        assertPw,
+    };
+}
+
+/**
  * Build a PickResultData from element info gathered by the content script.
- * Playwright's locator for JS/locator display (more precise chaining).
- * Content script's locator for pw command (simpler, role-aware).
+ * Prefer content script's locator (simpler, disambiguated with .nth()).
+ * Fall back to Playwright's locator only when content script uses CSS fallback.
  */
 export function buildPickResult(info: ElementPickInfo): PickResultData {
-    const jsLocator = info.pwLocator ?? info.locator;
+    const isCssFallback = /^locator\(/.test(info.locator);
+    const jsLocator = isCssFallback ? (info.pwLocator ?? info.locator) : info.locator;
     const locator = `page.${jsLocator}`;
     const jsExpression = `await page.${jsLocator}.highlight();`;
     const pwCommand = derivePwCommand(info, jsLocator);
+    const { assertJs, assertPw } = deriveAssertion(info, locator, pwCommand);
 
     return {
         locator,
         pwCommand,
         jsExpression,
+        assertJs,
+        assertPw,
         details: {
             tag: info.tag,
             text: info.text,
@@ -74,6 +193,8 @@ export function buildPickResult(info: ElementPickInfo): PickResultData {
             count: 1,
             attributes: info.attributes,
             box: info.box,
+            value: info.value,
+            checked: info.checked,
         },
     };
 }

--- a/packages/extension/src/panel/types.ts
+++ b/packages/extension/src/panel/types.ts
@@ -9,8 +9,10 @@ export type OutputLine = {
 
 export type PickResultData = {
     locator: string;           // "page.getByRole('button', { name: 'Submit' })"
-    pwCommand: string | null;  // 'click "Submit"' or null if not expressible
-    jsExpression: string;      // "await page.getByRole('button', { name: 'Submit' }).click()"
+    pwCommand: string | null;  // 'highlight "Submit"' or null if not expressible
+    jsExpression: string;      // "await page.getByRole('button', { name: 'Submit' }).highlight()"
+    assertJs?: string;         // "await expect(page.getByRole('button', { name: 'Submit' })).toContainText('Submit')"
+    assertPw?: string;         // 'verify-text "Submit"'
     details?: {
         tag: string;
         text: string;
@@ -20,6 +22,8 @@ export type PickResultData = {
         count: number;
         attributes: Record<string, string>;
         box?: { x: number; y: number; width: number; height: number };
+        value?: string;
+        checked?: boolean;
     };
 }
 
@@ -33,6 +37,8 @@ export type ElementPickInfo = {
     visible: boolean;
     enabled: boolean;
     box: { x: number; y: number; width: number; height: number };
+    value?: string;
+    checked?: boolean;
 }
 
 export type CommandResult = {

--- a/packages/extension/test/components/PickResult.browser.test.tsx
+++ b/packages/extension/test/components/PickResult.browser.test.tsx
@@ -1,0 +1,133 @@
+import { describe, it, expect } from 'vitest';
+import { render } from 'vitest-browser-react';
+import { PickResult } from '@/components/Console/PickResult';
+import type { PickResultData } from '@/types';
+
+function makeData(overrides: Partial<PickResultData> = {}): PickResultData {
+    return {
+        locator: "page.getByRole('button', { name: 'Submit' })",
+        pwCommand: 'highlight button "Submit"',
+        jsExpression: "await page.getByRole('button', { name: 'Submit' }).highlight();",
+        assertJs: "await expect(page.getByRole('button', { name: 'Submit' })).toContainText('Submit');",
+        assertPw: 'verify-text "Submit"',
+        details: {
+            tag: 'button',
+            text: 'Submit',
+            html: '<button>Submit</button>',
+            visible: true,
+            enabled: true,
+            count: 1,
+            attributes: {},
+        },
+        ...overrides,
+    };
+}
+
+describe('PickResult component', () => {
+    // ─── Locator section ──────────────────────────────────────────────────
+
+    it('renders locator section header', async () => {
+        const screen = await render(<PickResult data={makeData()} />);
+        await expect.element(screen.getByText('locator')).toBeInTheDocument();
+    });
+
+    it('renders js sub-row with highlight expression', async () => {
+        const screen = await render(<PickResult data={makeData()} />);
+        await expect.element(screen.getByText("await page.getByRole('button', { name: 'Submit' }).highlight();")).toBeInTheDocument();
+    });
+
+    it('renders pw sub-row with highlight command', async () => {
+        const screen = await render(<PickResult data={makeData()} />);
+        await expect.element(screen.getByText('highlight button "Submit"')).toBeInTheDocument();
+    });
+
+    it('hides pw sub-row when pwCommand is null', async () => {
+        const screen = await render(<PickResult data={makeData({ pwCommand: null })} />);
+        // Only js row should exist under locator, no pw
+        const allText = screen.container.textContent ?? '';
+        expect(allText).toContain('highlight();');
+        expect(allText).not.toContain('highlight button');
+    });
+
+    // ─── Assert section ───────────────────────────────────────────────────
+
+    it('renders assert section header', async () => {
+        const screen = await render(<PickResult data={makeData()} />);
+        await expect.element(screen.getByText('assert')).toBeInTheDocument();
+    });
+
+    it('renders assert js sub-row', async () => {
+        const screen = await render(<PickResult data={makeData()} />);
+        await expect.element(screen.getByText("await expect(page.getByRole('button', { name: 'Submit' })).toContainText('Submit');")).toBeInTheDocument();
+    });
+
+    it('renders assert pw sub-row', async () => {
+        const screen = await render(<PickResult data={makeData()} />);
+        await expect.element(screen.getByText('verify-text "Submit"')).toBeInTheDocument();
+    });
+
+    it('hides assert section when assertJs is undefined', async () => {
+        const screen = await render(<PickResult data={makeData({ assertJs: undefined, assertPw: undefined })} />);
+        const allText = screen.container.textContent ?? '';
+        expect(allText).not.toContain('assert');
+        expect(allText).not.toContain('verify-');
+    });
+
+    it('hides assert pw row when assertPw is undefined', async () => {
+        const screen = await render(<PickResult data={makeData({ assertPw: undefined })} />);
+        await expect.element(screen.getByText('assert')).toBeInTheDocument();
+        const assertSection = screen.container.textContent ?? '';
+        expect(assertSection).not.toContain('verify-');
+    });
+
+    // ─── Checkbox assertion ───────────────────────────────────────────────
+
+    it('renders checked assertion for checkbox', async () => {
+        const screen = await render(<PickResult data={makeData({
+            assertJs: "await expect(page.getByRole('checkbox', { name: 'Accept' })).toBeChecked();",
+            assertPw: 'verify-value "Accept" "on"',
+        })} />);
+        await expect.element(screen.getByText(/toBeChecked/)).toBeInTheDocument();
+        await expect.element(screen.getByText('verify-value "Accept" "on"')).toBeInTheDocument();
+    });
+
+    // ─── Value assertion ──────────────────────────────────────────────────
+
+    it('renders value assertion for input', async () => {
+        const screen = await render(<PickResult data={makeData({
+            assertJs: "await expect(page.getByLabel('Email')).toHaveValue('alice@test.com');",
+            assertPw: 'verify-value "Email" "alice@test.com"',
+        })} />);
+        await expect.element(screen.getByText(/toHaveValue/)).toBeInTheDocument();
+        await expect.element(screen.getByText('verify-value "Email" "alice@test.com"')).toBeInTheDocument();
+    });
+
+    // ─── Element details ──────────────────────────────────────────────────
+
+    it('renders expandable element details', async () => {
+        const screen = await render(<PickResult data={makeData()} />);
+        await expect.element(screen.getByText('element')).toBeInTheDocument();
+        // Details should be collapsed by default
+        const allText = screen.container.textContent ?? '';
+        expect(allText).not.toContain('<button>Submit</button>');
+    });
+
+    it('expands element details on toggle click', async () => {
+        const screen = await render(<PickResult data={makeData()} />);
+        (screen.container.querySelector('.ot-toggle') as HTMLElement).click();
+        await expect.element(screen.getByText('<button>Submit</button>')).toBeInTheDocument();
+        await expect.element(screen.getByText('"button"')).toBeInTheDocument();
+    });
+
+    // ─── Sections order ──────────────────────────────────────────────────
+
+    it('renders sections in order: locator, assert, element', async () => {
+        const screen = await render(<PickResult data={makeData()} />);
+        const text = screen.container.textContent ?? '';
+        const locatorIdx = text.indexOf('locator');
+        const assertIdx = text.indexOf('assert');
+        const elementIdx = text.indexOf('element');
+        expect(locatorIdx).toBeLessThan(assertIdx);
+        expect(assertIdx).toBeLessThan(elementIdx);
+    });
+});

--- a/packages/extension/test/lib/pick-info.test.ts
+++ b/packages/extension/test/lib/pick-info.test.ts
@@ -1,0 +1,337 @@
+import { describe, it, expect, vi } from 'vitest';
+import { buildPickResult } from '@/lib/pick-info';
+import type { ElementPickInfo } from '@/types';
+
+vi.mock('@/lib/sw-debugger', () => ({
+    swDebugEval: vi.fn(),
+}));
+
+function makeInfo(overrides: Partial<ElementPickInfo> = {}): ElementPickInfo {
+    return {
+        locator: "getByRole('button', { name: 'Submit' })",
+        tag: 'button',
+        text: 'Submit',
+        html: '<button>Submit</button>',
+        attributes: {},
+        visible: true,
+        enabled: true,
+        box: { x: 0, y: 0, width: 100, height: 40 },
+        ...overrides,
+    };
+}
+
+describe('buildPickResult', () => {
+    // ─── Locator section ──────────────────────────────────────────────────
+
+    it('builds locator and jsExpression from element info', () => {
+        const result = buildPickResult(makeInfo());
+        expect(result.locator).toBe("page.getByRole('button', { name: 'Submit' })");
+        expect(result.jsExpression).toBe("await page.getByRole('button', { name: 'Submit' }).highlight();");
+    });
+
+    it('prefers content script locator over pwLocator for getByRole', () => {
+        const result = buildPickResult(makeInfo({ pwLocator: "getByRole('button', { name: 'Submit' }).first()" }));
+        expect(result.locator).toBe("page.getByRole('button', { name: 'Submit' })");
+    });
+
+    it('uses pwLocator when content script locator is CSS fallback', () => {
+        const result = buildPickResult(makeInfo({
+            locator: "locator('div.content')",
+            pwLocator: "getByText('Cross-browser')",
+        }));
+        expect(result.locator).toBe("page.getByText('Cross-browser')");
+    });
+
+    it('derives pw command from role + name', () => {
+        const result = buildPickResult(makeInfo());
+        expect(result.pwCommand).toBe('highlight button "Submit"');
+    });
+
+    // ─── Assert: text (default for elements with text) ────────────────────
+
+    it('derives text assertion for button', () => {
+        const result = buildPickResult(makeInfo());
+        expect(result.assertJs).toBe("await expect(page.getByRole('button', { name: 'Submit' })).toContainText('Submit');");
+        expect(result.assertPw).toBe('verify-element button "Submit"');
+    });
+
+    it('derives text assertion for link', () => {
+        const result = buildPickResult(makeInfo({
+            locator: "getByRole('link', { name: 'Home' })",
+            tag: 'a',
+            text: 'Home',
+            attributes: { href: '/' },
+        }));
+        expect(result.assertJs).toContain("toContainText('Home')");
+        expect(result.assertPw).toBe('verify-element link "Home"');
+    });
+
+    it('derives pw command from Playwright locator when content script locator is CSS', () => {
+        const result = buildPickResult(makeInfo({
+            locator: "locator('p.hero')",
+            pwLocator: "getByText('Cross-browser. Playwright')",
+            tag: 'p',
+            text: 'Cross-browser. Playwright supports all modern rendering engines including Chromium, WebKit, and Firefox.',
+        }));
+        // pw command should come from Playwright's locator, not the CSS fallback
+        expect(result.pwCommand).toBe('highlight "Cross-browser. Playwright"');
+        // getByText locator → toBeVisible (toContainText would be redundant)
+        expect(result.assertJs).toBe("await expect(page.getByText('Cross-browser. Playwright')).toBeVisible();");
+        expect(result.assertPw).toBe('verify-text "Cross-browser. Playwright"');
+    });
+
+    it('uses full text when no locator name can be extracted', () => {
+        const longText = 'A'.repeat(100);
+        const result = buildPickResult(makeInfo({
+            locator: "locator('div.content')",
+            tag: 'div',
+            text: longText,
+        }));
+        // No truncation — uses the full info.text
+        expect(result.assertJs).toContain(`toContainText('${longText}')`);
+        expect(result.assertPw).toContain(`verify-text "${longText}"`);
+    });
+
+    // ─── Assert: value (input/textarea/select) ───────────────────────────
+
+    it('derives value assertion for text input', () => {
+        const result = buildPickResult(makeInfo({
+            locator: "getByLabel('Email')",
+            tag: 'input',
+            text: '',
+            attributes: { type: 'text' },
+            value: 'alice@test.com',
+        }));
+        expect(result.assertJs).toBe("await expect(page.getByLabel('Email')).toHaveValue('alice@test.com');");
+        expect(result.assertPw).toBe('verify-value "Email" "alice@test.com"');
+    });
+
+    it('derives value assertion for textarea', () => {
+        const result = buildPickResult(makeInfo({
+            locator: "getByLabel('Bio')",
+            tag: 'textarea',
+            text: 'Hello world',
+            attributes: {},
+            value: 'Hello world',
+        }));
+        expect(result.assertJs).toContain("toHaveValue('Hello world')");
+        expect(result.assertPw).toContain('verify-value "Bio"');
+    });
+
+    it('derives value assertion for select', () => {
+        const result = buildPickResult(makeInfo({
+            locator: "getByLabel('Country')",
+            tag: 'select',
+            text: 'US',
+            attributes: {},
+            value: 'US',
+        }));
+        expect(result.assertJs).toContain("toHaveValue('US')");
+        expect(result.assertPw).toBe('verify-value "Country" "US"');
+    });
+
+    it('derives value assertion for date input', () => {
+        const result = buildPickResult(makeInfo({
+            locator: "getByLabel('Birthday')",
+            tag: 'input',
+            text: '',
+            attributes: { type: 'date' },
+            value: '2026-01-01',
+        }));
+        expect(result.assertJs).toContain("toHaveValue('2026-01-01')");
+        expect(result.assertPw).toBe('verify-value "Birthday" "2026-01-01"');
+    });
+
+    it('falls back to text assertion when input has no value', () => {
+        const result = buildPickResult(makeInfo({
+            locator: "getByLabel('Search')",
+            tag: 'input',
+            text: 'Search',
+            attributes: { type: 'text' },
+            value: undefined,
+        }));
+        expect(result.assertJs).toContain('toContainText');
+    });
+
+    // ─── Assert: checked (checkbox/radio) ─────────────────────────────────
+
+    it('derives checked assertion for checked checkbox', () => {
+        const result = buildPickResult(makeInfo({
+            locator: "getByRole('checkbox', { name: 'Accept' })",
+            tag: 'input',
+            text: '',
+            attributes: { type: 'checkbox' },
+            checked: true,
+        }));
+        expect(result.assertJs).toBe("await expect(page.getByRole('checkbox', { name: 'Accept' })).toBeChecked();");
+        expect(result.assertPw).toBe('verify-value "Accept" "on"');
+    });
+
+    it('derives not-checked assertion for unchecked checkbox', () => {
+        const result = buildPickResult(makeInfo({
+            locator: "getByRole('checkbox', { name: 'Accept' })",
+            tag: 'input',
+            text: '',
+            attributes: { type: 'checkbox' },
+            checked: false,
+        }));
+        expect(result.assertJs).toBe("await expect(page.getByRole('checkbox', { name: 'Accept' })).not.toBeChecked();");
+        expect(result.assertPw).toBe('verify-value "Accept" "off"');
+    });
+
+    it('derives checked assertion for radio button', () => {
+        const result = buildPickResult(makeInfo({
+            locator: "getByRole('radio', { name: 'Yes' })",
+            tag: 'input',
+            text: '',
+            attributes: { type: 'radio' },
+            checked: true,
+        }));
+        expect(result.assertJs).toContain('toBeChecked()');
+        expect(result.assertPw).toContain('verify-value "Yes" "on"');
+    });
+
+    // ─── Assert: visible (fallback) ───────────────────────────────────────
+
+    it('derives visible assertion when no text/value/checked', () => {
+        const result = buildPickResult(makeInfo({
+            locator: "getByRole('img')",
+            tag: 'img',
+            text: '',
+            attributes: {},
+        }));
+        expect(result.assertJs).toBe("await expect(page.getByRole('img')).toBeVisible();");
+        expect(result.assertPw).toBe('verify-text');
+    });
+
+    it('derives verify-element with role + name for image with alt', () => {
+        const result = buildPickResult(makeInfo({
+            locator: "getByRole('img', { name: 'Logo' })",
+            tag: 'img',
+            text: '',
+            attributes: { alt: 'Logo' },
+        }));
+        expect(result.assertJs).toBe("await expect(page.getByRole('img', { name: 'Logo' })).toBeVisible();");
+        expect(result.assertPw).toBe('verify-element img "Logo"');
+    });
+
+    it('derives verify-text for named element without role', () => {
+        const result = buildPickResult(makeInfo({
+            locator: "getByTestId('icon')",
+            tag: 'span',
+            text: '',
+            attributes: { 'data-testid': 'icon' },
+        }));
+        expect(result.assertJs).toContain('toBeVisible()');
+        expect(result.assertPw).toBe('verify-text "icon"');
+    });
+
+    // ─── Priority: checked > value > text > visible ───────────────────────
+
+    it('prefers checked over value for checkbox', () => {
+        const result = buildPickResult(makeInfo({
+            locator: "getByRole('checkbox', { name: 'Accept' })",
+            tag: 'input',
+            text: 'Accept terms',
+            attributes: { type: 'checkbox' },
+            value: 'on',
+            checked: true,
+        }));
+        expect(result.assertJs).toContain('toBeChecked()');
+    });
+
+    it('prefers value over text for input', () => {
+        const result = buildPickResult(makeInfo({
+            locator: "getByLabel('Name')",
+            tag: 'input',
+            text: 'Some label text',
+            attributes: { type: 'text' },
+            value: 'Alice',
+        }));
+        expect(result.assertJs).toContain("toHaveValue('Alice')");
+    });
+
+    // ─── Details passthrough ──────────────────────────────────────────────
+
+    it('passes value and checked into details', () => {
+        const result = buildPickResult(makeInfo({
+            tag: 'input',
+            attributes: { type: 'checkbox' },
+            value: 'on',
+            checked: true,
+        }));
+        expect(result.details?.value).toBe('on');
+        expect(result.details?.checked).toBe(true);
+    });
+
+    // ─── Exact match + nth disambiguation ──────────────────────────────────
+
+    it('handles locator with exact: true and .first()', () => {
+        const result = buildPickResult(makeInfo({
+            locator: "getByRole('tab', { name: 'npm', exact: true }).first()",
+            tag: 'div',
+            text: 'npm',
+            attributes: { role: 'tab' },
+        }));
+        expect(result.locator).toBe("page.getByRole('tab', { name: 'npm', exact: true }).first()");
+        expect(result.pwCommand).toBe('highlight tab "npm" --nth 0');
+        expect(result.assertJs).toBe("await expect(page.getByRole('tab', { name: 'npm', exact: true }).first()).toContainText('npm');");
+        expect(result.assertPw).toBe('verify-element tab "npm" --nth 0');
+    });
+
+    it('handles locator with exact: true and .nth(1)', () => {
+        const result = buildPickResult(makeInfo({
+            locator: "getByRole('tab', { name: 'npm', exact: true }).nth(1)",
+            tag: 'div',
+            text: 'npm',
+            attributes: { role: 'tab' },
+        }));
+        expect(result.pwCommand).toBe('highlight tab "npm" --nth 1');
+        expect(result.assertPw).toBe('verify-element tab "npm" --nth 1');
+    });
+
+    it('handles role without exact (no disambiguation)', () => {
+        const result = buildPickResult(makeInfo({
+            locator: "getByRole('tab', { name: 'Getting Started' })",
+            tag: 'div',
+            text: 'Getting Started',
+            attributes: { role: 'tab' },
+        }));
+        expect(result.pwCommand).toBe('highlight tab "Getting Started"');
+        expect(result.assertPw).toBe('verify-element tab "Getting Started"');
+    });
+
+    it('uses verify-text (not verify-element) when locator has no role', () => {
+        const result = buildPickResult(makeInfo({
+            locator: "getByText('Hello world')",
+            tag: 'p',
+            text: 'Hello world',
+            attributes: {},
+        }));
+        // getByText → toBeVisible (toContainText would be redundant)
+        expect(result.assertJs).toContain('toBeVisible()');
+        expect(result.assertPw).toBe('verify-text "Hello world"');
+    });
+
+    // ─── Escaping ─────────────────────────────────────────────────────────
+
+    it('escapes single quotes in value assertion', () => {
+        const result = buildPickResult(makeInfo({
+            locator: "getByLabel('Note')",
+            tag: 'input',
+            text: '',
+            attributes: { type: 'text' },
+            value: "it's a test",
+        }));
+        expect(result.assertJs).toContain("toHaveValue('it\\'s a test')");
+    });
+
+    it('escapes single quotes in text assertion', () => {
+        const result = buildPickResult(makeInfo({
+            locator: "locator('div.content')",
+            tag: 'div',
+            text: "it's a button",
+        }));
+        expect(result.assertJs).toContain("toContainText('it\\'s a button')");
+    });
+});


### PR DESCRIPTION
## Summary
- After picking an element, show auto-detected assertions in `locator` / `assert` sections with `js:` and `pw:` sub-rows
- Assertion type auto-detected: checked > value > text > visible (first match wins)
- Add `highlight <role> "name"` support (e.g. `highlight tab "npm"`) via `getByRole` — both extension and CLI
- Content script disambiguates duplicate role+name elements with `.nth(N)` and `exact: true`
- Prefer content script's clean locator over Playwright's complex chained locator
- Use `verify-element` (not `verify-text`) for role-based pw assertions

## Test plan
- [x] 28 unit tests for assertion derivation (`pick-info.test.ts`)
- [x] 14 component tests for PickResult layout (`PickResult.browser.test.tsx`)
- [x] Manual: pick button → `verify-element button "Submit"` / `toContainText`
- [x] Manual: pick input with value → `verify-value "Email" "val"` / `toHaveValue`
- [x] Manual: pick tab with disambiguation → `highlight tab "npm" --nth 0` / `verify-element tab "npm" --nth 0`
- [x] Manual: `highlight tab "npm" --nth 0` highlights correct tab (exact match, not substring)

Closes #181

🤖 Generated with [Claude Code](https://claude.com/claude-code)