### PR TITLE
feat: only prepend goto when editor is empty on record start

### DIFF
--- a/packages/extension/src/panel/components/Toolbar.tsx
+++ b/packages/extension/src/panel/components/Toolbar.tsx
@@ -223,6 +223,15 @@ function Toolbar({ editorContent, editorMode, stepLine, attachedUrl, attachedTab
 
     // ─── Recording (content script-based) ───
 
+    function isEditorEmpty(): boolean {
+        return editorContent.split('\n').every(line => {
+            const trimmed = line.trim();
+            if (!trimmed) return true;
+            if (editorMode === 'pw') return trimmed.startsWith('#');
+            return trimmed.startsWith('//') || trimmed.startsWith('/*');
+        });
+    }
+
     useEffect(() => {
         if (!chrome.runtime?.onMessage) return;
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -261,7 +270,7 @@ function Toolbar({ editorContent, editorMode, stepLine, attachedUrl, attachedTab
 
         setIsRecording(true);
 
-        if (result.url && result.url !== 'about:blank' && !result.url.startsWith('chrome://')) {
+        if (result.url && result.url !== 'about:blank' && !result.url.startsWith('chrome://') && isEditorEmpty()) {
             const gotoCmd = editorMode === 'js'
                 ? `await page.goto(${JSON.stringify(result.url)});`
                 : `goto "${result.url}"`;

--- a/packages/extension/test/components/Toolbar.browser.test.tsx
+++ b/packages/extension/test/components/Toolbar.browser.test.tsx
@@ -458,6 +458,75 @@ describe('Toolbar component tests', () => {
   });
 
 
+  // ─── Record: goto insertion depends on editor content ─────────────────────
+
+  it('should insert goto when recording starts with empty editor', async () => {
+    window.chrome.runtime.sendMessage = vi.fn().mockResolvedValue({ ok: true, url: 'https://example.com' });
+    const insertAtCursor = vi.fn();
+    const editorRef = { current: { insertAtCursor, replaceLastInsert: vi.fn() } };
+
+    const screen = await renderToolbar({ editorContent: '', editorRef: editorRef as any });
+    await screen.getByRole('button', { name: 'Record' }).click();
+
+    await vi.waitFor(() => {
+      expect(insertAtCursor).toHaveBeenCalledWith('goto "https://example.com"');
+    });
+  });
+
+  it('should insert goto when editor has only comments in pw mode', async () => {
+    window.chrome.runtime.sendMessage = vi.fn().mockResolvedValue({ ok: true, url: 'https://example.com' });
+    const insertAtCursor = vi.fn();
+    const editorRef = { current: { insertAtCursor, replaceLastInsert: vi.fn() } };
+
+    const screen = await renderToolbar({ editorContent: '# this is a comment\n\n# another', editorMode: 'pw', editorRef: editorRef as any });
+    await screen.getByRole('button', { name: 'Record' }).click();
+
+    await vi.waitFor(() => {
+      expect(insertAtCursor).toHaveBeenCalledWith('goto "https://example.com"');
+    });
+  });
+
+  it('should insert goto when editor has only comments in js mode', async () => {
+    window.chrome.runtime.sendMessage = vi.fn().mockResolvedValue({ ok: true, url: 'https://example.com' });
+    const insertAtCursor = vi.fn();
+    const editorRef = { current: { insertAtCursor, replaceLastInsert: vi.fn() } };
+
+    const screen = await renderToolbar({ editorContent: '// comment\n/* block */', editorMode: 'js', editorRef: editorRef as any });
+    await screen.getByRole('button', { name: 'Record' }).click();
+
+    await vi.waitFor(() => {
+      expect(insertAtCursor).toHaveBeenCalledWith(expect.stringContaining('await page.goto'));
+    });
+  });
+
+  it('should NOT insert goto when editor has existing commands', async () => {
+    window.chrome.runtime.sendMessage = vi.fn().mockResolvedValue({ ok: true, url: 'https://example.com' });
+    const insertAtCursor = vi.fn();
+    const editorRef = { current: { insertAtCursor, replaceLastInsert: vi.fn() } };
+
+    const screen = await renderToolbar({ editorContent: 'click "Submit"', editorMode: 'pw', editorRef: editorRef as any });
+    await screen.getByRole('button', { name: 'Record' }).click();
+
+    await vi.waitFor(() => {
+      expect(window.chrome.runtime.sendMessage).toHaveBeenCalledWith({ type: 'record-start' });
+    });
+    expect(insertAtCursor).not.toHaveBeenCalled();
+  });
+
+  it('should NOT insert goto when editor has existing JS code', async () => {
+    window.chrome.runtime.sendMessage = vi.fn().mockResolvedValue({ ok: true, url: 'https://example.com' });
+    const insertAtCursor = vi.fn();
+    const editorRef = { current: { insertAtCursor, replaceLastInsert: vi.fn() } };
+
+    const screen = await renderToolbar({ editorContent: 'document.title', editorMode: 'js', editorRef: editorRef as any });
+    await screen.getByRole('button', { name: 'Record' }).click();
+
+    await vi.waitFor(() => {
+      expect(window.chrome.runtime.sendMessage).toHaveBeenCalledWith({ type: 'record-start' });
+    });
+    expect(insertAtCursor).not.toHaveBeenCalled();
+  });
+
   // ─── Attach icon toggle ────────────────────────────────────────────────────
 
   it('shows attach button when not attached', async () => {


### PR DESCRIPTION
Closes #189

## Summary
- Add `isEditorEmpty()` helper that treats blank lines and comments (# for pw, // and /* for js) as empty
- Only insert `goto` URL when recording starts if the editor has no real content
- When editor already has commands/code, recording inserts actions at the cursor position without prepending goto

## Test plan
- [ ] Start recording with empty editor — goto is inserted
- [ ] Start recording with only comments — goto is inserted
- [ ] Start recording with existing commands — no goto inserted, actions recorded at cursor
- [ ] Verify in both pw and js modes
- [ ] `npm run test:component` passes (5 new tests added)

🤖 Generated with [Claude Code](https://claude.com/claude-code)