### PR TITLE
fix: resolve TypeScript type-check errors in extension

### DIFF
--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "build": "vite build",
     "dev": "vite dev",
-    "typecheck": "tsc",
+    "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:e2e": "npx playwright test",

--- a/packages/extension/src/offscreen/offscreen.ts
+++ b/packages/extension/src/offscreen/offscreen.ts
@@ -59,3 +59,5 @@ chrome.runtime.onMessage.addListener((msg) => {
         connect(msg.port as number);
     }
 });
+
+export {};

--- a/packages/extension/src/panel/lib/page-scripts.ts
+++ b/packages/extension/src/panel/lib/page-scripts.ts
@@ -106,7 +106,7 @@ export async function verifyInputValue(page, label, expected) {
 
 // ─── Text locator actions ───────────────────────────────────────────────────
 
-export async function actionByText(page, text, action, nth, exact) {
+export async function actionByText(page, text, action, nth?, exact?) {
   let loc = page.getByText(text, { exact: true });
   if (!exact) {
     if (await loc.count() === 0) loc = page.getByRole('button', { name: text });
@@ -120,7 +120,7 @@ export async function actionByText(page, text, action, nth, exact) {
   await loc[action]();
 }
 
-export async function fillByText(page, text, value, nth, exact) {
+export async function fillByText(page, text, value, nth?, exact?) {
   let loc = page.getByLabel(text);
   if (!exact) {
     if (await loc.count() === 0) loc = page.getByPlaceholder(text);
@@ -130,7 +130,7 @@ export async function fillByText(page, text, value, nth, exact) {
   await loc.fill(value);
 }
 
-export async function selectByText(page, text, value, nth, exact) {
+export async function selectByText(page, text, value, nth?, exact?) {
   let loc = page.getByLabel(text);
   if (!exact) {
     if (await loc.count() === 0) loc = page.getByRole('combobox', { name: text });
@@ -139,7 +139,7 @@ export async function selectByText(page, text, value, nth, exact) {
   await loc.selectOption(value);
 }
 
-export async function checkByText(page, text, nth, exact) {
+export async function checkByText(page, text, nth?, exact?) {
   if (!exact) {
     const item = page.getByRole('listitem').filter({ hasText: text });
     if (await item.count() > 0) {
@@ -156,7 +156,7 @@ export async function checkByText(page, text, nth, exact) {
   await loc.check();
 }
 
-export async function uncheckByText(page, text, nth, exact) {
+export async function uncheckByText(page, text, nth?, exact?) {
   if (!exact) {
     const item = page.getByRole('listitem').filter({ hasText: text });
     if (await item.count() > 0) {
@@ -195,7 +195,7 @@ export async function selectByRole(page, role, name, value, nth) {
 
 // ─── Highlight ──────────────────────────────────────────────────────────────
 
-export async function highlightByText(page, text, nth, exact) {
+export async function highlightByText(page, text, nth?, exact?) {
   let loc = exact ? page.getByText(text, { exact: true }) : page.getByText(text);
   const count = await loc.count();
   if (nth !== undefined) loc = loc.filter({ visible: true }).nth(nth);
@@ -215,7 +215,7 @@ export async function highlightByRole(page, role, name, nth) {
     : 'Highlighted ' + count + ' element' + (count !== 1 ? 's' : '');
 }
 
-export async function highlightBySelector(page, selector, nth) {
+export async function highlightBySelector(page, selector, nth?) {
   let loc = page.locator(selector);
   const count = await loc.count();
   if (nth !== undefined) loc = loc.filter({ visible: true }).nth(nth);

--- a/packages/extension/test/components/ObjectTree.browser.test.tsx
+++ b/packages/extension/test/components/ObjectTree.browser.test.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import { describe, it, expect, vi } from 'vitest';
 import { render } from 'vitest-browser-react';
 import { ObjectTree } from '@/components/Console/ObjectTree';

--- a/packages/extension/test/lib/run.test.ts
+++ b/packages/extension/test/lib/run.test.ts
@@ -9,7 +9,7 @@ vi.mock('@/lib/bridge', () => ({
 
 const mockFilterResponse = vi.fn((text: string) => text);
 vi.mock('@/lib/filter', () => ({
-    filterResponse: (...args: any[]) => mockFilterResponse(...args),
+    filterResponse: (...args: [string]) => mockFilterResponse(...args),
 }));
 
 vi.mock('@/lib/commands', () => ({
@@ -37,7 +37,7 @@ vi.mock('@/lib/sw-debugger', () => ({
     swGetProperties: (...args: any[]) => mockSwGetProperties(...args),
 }));
 
-const mockFromCdpRemoteObject = vi.fn((_obj: unknown) => ({ __type: 'string', v: 'mocked' }));
+const mockFromCdpRemoteObject = vi.fn((_obj: unknown) => ({ __type: 'string', v: 'mocked' }) as any);
 vi.mock('@/components/Console/cdpToSerialized', () => ({
     fromCdpRemoteObject: (obj: any) => mockFromCdpRemoteObject(obj),
 }));
@@ -52,7 +52,7 @@ import { runAndDispatch, runJsScript, runJsScriptStep } from '@/lib/run';
 // ─── Helpers ────────────────────────────────────────────────────────────────
 
 function createDispatch() {
-    return vi.fn() as React.Dispatch<any>;
+    return vi.fn() as unknown as React.Dispatch<any> & ReturnType<typeof vi.fn>;
 }
 
 // ─── Setup ──────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Make `nth` and `exact` params optional in `page-scripts.ts` functions (`actionByText`, `fillByText`, `selectByText`, `checkByText`, `uncheckByText`, `highlightByText`, `highlightBySelector`)
- Add `export {}` to `offscreen.ts` so TypeScript treats it as a module
- Fix mock typings in `run.test.ts` (`createDispatch`, `filterResponse` spread, `fromCdpRemoteObject` return type)
- Remove unused `eslint-disable` directive in `ObjectTree.browser.test.tsx`
- Update `typecheck` script to `tsc --noEmit` (Vite handles builds, tsc is for type checking only)

`npm run typecheck` now passes with 0 errors (was 41).

## Test plan
- [x] `npm run typecheck` — 0 errors
- [x] `vitest run` — 640/640 tests passing
- [x] `eslint` — 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)