### PR TITLE
refactor: rename console 'playwright' mode to 'js'

### DIFF
--- a/packages/extension/src/background.ts
+++ b/packages/extension/src/background.ts
@@ -271,7 +271,7 @@ async function executeSingleCommand(command: string): Promise<{ text: string; is
   if ('error' in parsed) {
     const mode = detectMode(command.trim());
 
-    if (mode === 'playwright' || command.includes('\n')) {
+    if (mode === 'js' || command.includes('\n')) {
       const isMultiLine = command.includes('\n');
       const isStatement = isMultiLine || command.trimEnd().endsWith(';');
       const body = isStatement ? tryReturnLastExpr(command.trim()) : `return (${command.trim()})`;

--- a/packages/extension/src/panel/components/Console/useConsole.ts
+++ b/packages/extension/src/panel/components/Console/useConsole.ts
@@ -12,7 +12,7 @@ import type React from 'react';
 const SNAPSHOT_CMDS = new Set(['snapshot', 'snap', 's']);
 
 const executors = {
-    playwright: async (expr: string) => {
+    js: async (expr: string) => {
         const raw = await swDebugEval(expr) as { result?: CdpRemoteObject; error?: string };
         if (raw?.error) throw new Error(raw.error);
         if (!raw?.result) throw new Error('No result from service worker');
@@ -98,7 +98,7 @@ export function useConsole(dispatch: React.Dispatch<Action>) {
         dispatch({ type: 'COMMAND_SUBMITTED', line: { text: trimmed, type: 'command' } });
 
         try {
-            const result = await (mode === 'pw' ? executors.pw(trimmed) : executors.playwright(trimmed)) as { value?: ConsoleEntry['value']; text?: string; image?: string; codeBlock?: string; getProperties?: ConsoleEntry['getProperties'] };
+            const result = await (mode === 'pw' ? executors.pw(trimmed) : executors.js(trimmed)) as { value?: ConsoleEntry['value']; text?: string; image?: string; codeBlock?: string; getProperties?: ConsoleEntry['getProperties'] };
             if (result.value !== undefined) {
                 dispatch({ type: 'COMMAND_SUCCESS', line: { text: '', type: 'success', value: result.value, getProperties: result.getProperties } });
             } else if (result.image !== undefined) {

--- a/packages/extension/src/panel/lib/bridge.ts
+++ b/packages/extension/src/panel/lib/bridge.ts
@@ -52,7 +52,7 @@ export async function executeCommand(command: string): Promise<CommandResult> {
     const expr = command.trim();
     const mode = detectMode(expr);
 
-    if (mode === 'playwright' || expr.includes('\n')) {
+    if (mode === 'js' || expr.includes('\n')) {
       // Evaluate in SW context (page, crxApp globals available, await supported)
       try {
         const raw = await withTimeout(swDebugEval(expr)) as { result?: CdpResult };

--- a/packages/extension/src/panel/lib/execute.ts
+++ b/packages/extension/src/panel/lib/execute.ts
@@ -9,18 +9,18 @@ const PW_GLOBALS = new Set(['page', 'context', 'expect', 'crxApp', 'activeTabId'
  * Resolve the execution mode for console input.
  * Multi-line input always runs in the SW context (AsyncFunction supports await).
  */
-export function resolveConsoleMode(input: string): 'playwright' | 'pw' {
-    if (input.includes('\n')) return 'playwright';
+export function resolveConsoleMode(input: string): 'js' | 'pw' {
+    if (input.includes('\n')) return 'js';
     return detectMode(input);
 }
 
-export function detectMode(input: string): 'playwright' | 'pw' {
+export function detectMode(input: string): 'js' | 'pw' {
     const t = input.trim();
     const firstToken = t.split(/\s+/)[0];
     if (PW_COMMANDS.has(firstToken.toLowerCase())) return 'pw';
     // Playwright globals (page, context, expect, etc.) → evaluate in SW context
-    if (PW_GLOBALS.has(firstToken)) return 'playwright';
+    if (PW_GLOBALS.has(firstToken)) return 'js';
     // Bare words that look like commands → 'pw' so unknown ones show parse errors
     if (/^[a-z][\w-]*$/.test(firstToken) && !/[.()[\]=+`$;{}"']/.test(t)) return 'pw';
-    return 'playwright';
+    return 'js';
 }

--- a/packages/extension/test/background.test.ts
+++ b/packages/extension/test/background.test.ts
@@ -48,7 +48,7 @@ describe("background.ts message handlers", () => {
 
     // Default mock implementations
     mockParseReplCommand = vi.fn().mockReturnValue({ jsExpr: 'page.title()' });
-    mockDetectMode = vi.fn().mockReturnValue('playwright');
+    mockDetectMode = vi.fn().mockReturnValue('js');
 
     // Reset playwright-crx mocks
     mockPage = { url: vi.fn().mockReturnValue('https://example.com') };
@@ -690,7 +690,7 @@ describe("background.ts message handlers", () => {
     await sendMessage({ type: 'attach', tabId: 42 });
     setupDebuggerMocks('sw-1');
     mockParseReplCommand.mockReturnValue({ error: 'Unknown command' });
-    mockDetectMode.mockReturnValue('playwright');
+    mockDetectMode.mockReturnValue('js');
 
     const result = await sendMessage({ type: 'bridge-command', command: 'page.title()' });
     expect(result.isError).toBe(false);
@@ -839,7 +839,7 @@ describe("background.ts message handlers", () => {
     await sendMessage({ type: 'attach', tabId: 42 });
     setupDebuggerMocks('sw-1');
     mockParseReplCommand.mockReturnValue({ error: 'Unknown' });
-    mockDetectMode.mockReturnValue('playwright');
+    mockDetectMode.mockReturnValue('js');
 
     const result = await sendMessage({ type: 'bridge-command', command: 'page.title();' });
     expect(result.isError).toBe(false);

--- a/packages/extension/test/lib/bridge.test.ts
+++ b/packages/extension/test/lib/bridge.test.ts
@@ -129,15 +129,15 @@ describe('executeCommand', () => {
 
   // ─── Non-keyword commands (detectMode routing) ──────────────────────────
 
-  it('evaluates playwright mode via swDebugEval', async () => {
-    vi.mocked(detectMode).mockReturnValue('playwright');
+  it('evaluates js mode via swDebugEval', async () => {
+    vi.mocked(detectMode).mockReturnValue('js');
     vi.mocked(swDebugEval).mockResolvedValue({ result: { type: 'string', value: 'ok' } });
     const result = await executeCommand('page.title()');
     expect(result).toEqual({ text: 'ok', isError: false });
   });
 
-  it('returns error when playwright mode throws', async () => {
-    vi.mocked(detectMode).mockReturnValue('playwright');
+  it('returns error when js mode throws', async () => {
+    vi.mocked(detectMode).mockReturnValue('js');
     vi.mocked(swDebugEval).mockRejectedValue(new Error('page crashed'));
     const result = await executeCommand('page.title()');
     expect(result).toEqual({ text: 'page crashed', isError: true });

--- a/packages/extension/test/lib/execute.test.ts
+++ b/packages/extension/test/lib/execute.test.ts
@@ -20,63 +20,63 @@ describe('detectMode', () => {
         expect(detectMode('void 0')).toBe('pw');
     });
 
-    // ─── Playwright (service worker) context ─────────────────────────────────
+    // ─── JS (service worker) context ───────────────────────────────────────
 
-    it('returns playwright for page expressions', () => {
-        expect(detectMode('page')).toBe('playwright');
-        expect(detectMode('page.title()')).toBe('playwright');
-        expect(detectMode('page.url()')).toBe('playwright');
-        expect(detectMode('page[0]')).toBe('playwright');
-        expect(detectMode('await page.goto("https://example.com")')).toBe('playwright');
+    it('returns js for page expressions', () => {
+        expect(detectMode('page')).toBe('js');
+        expect(detectMode('page.title()')).toBe('js');
+        expect(detectMode('page.url()')).toBe('js');
+        expect(detectMode('page[0]')).toBe('js');
+        expect(detectMode('await page.goto("https://example.com")')).toBe('js');
     });
 
-    it('returns playwright for context expressions', () => {
-        expect(detectMode('context')).toBe('playwright');
-        expect(detectMode('context.cookies()')).toBe('playwright');
-        expect(detectMode('await context.clearCookies()')).toBe('playwright');
+    it('returns js for context expressions', () => {
+        expect(detectMode('context')).toBe('js');
+        expect(detectMode('context.cookies()')).toBe('js');
+        expect(detectMode('await context.clearCookies()')).toBe('js');
     });
 
-    it('returns playwright for expect expressions', () => {
-        expect(detectMode('expect')).toBe('playwright');
-        expect(detectMode('expect(page).toBeTruthy()')).toBe('playwright');
-        expect(detectMode('await expect(locator).toBeVisible()')).toBe('playwright');
+    it('returns js for expect expressions', () => {
+        expect(detectMode('expect')).toBe('js');
+        expect(detectMode('expect(page).toBeTruthy()')).toBe('js');
+        expect(detectMode('await expect(locator).toBeVisible()')).toBe('js');
     });
 
-    it('returns playwright for crxApp and activeTabId', () => {
-        expect(detectMode('crxApp')).toBe('playwright');
-        expect(detectMode('crxApp.context()')).toBe('playwright');
-        expect(detectMode('activeTabId')).toBe('playwright');
+    it('returns js for crxApp and activeTabId', () => {
+        expect(detectMode('crxApp')).toBe('js');
+        expect(detectMode('crxApp.context()')).toBe('js');
+        expect(detectMode('activeTabId')).toBe('js');
     });
 
-    // ─── Playwright (fallback) — everything else evaluates in SW context ─────
+    // ─── JS (fallback) — everything else evaluates in SW context ──────────
 
-    it('returns playwright for document and window (evaluated via page.evaluate)', () => {
-        expect(detectMode('document.title')).toBe('playwright');
-        expect(detectMode('window.location.href')).toBe('playwright');
-        expect(detectMode('JSON.stringify({})')).toBe('playwright');
+    it('returns js for document and window (evaluated via page.evaluate)', () => {
+        expect(detectMode('document.title')).toBe('js');
+        expect(detectMode('window.location.href')).toBe('js');
+        expect(detectMode('JSON.stringify({})')).toBe('js');
     });
 
-    it('returns playwright for numeric and parenthesized expressions', () => {
-        expect(detectMode('1 + 1')).toBe('playwright');
-        expect(detectMode('6')).toBe('playwright');
-        expect(detectMode('({})')).toBe('playwright');
+    it('returns js for numeric and parenthesized expressions', () => {
+        expect(detectMode('1 + 1')).toBe('js');
+        expect(detectMode('6')).toBe('js');
+        expect(detectMode('({})')).toBe('js');
     });
 
-    it('returns playwright for assignment expressions', () => {
-        expect(detectMode('a = [1, 2, 3]')).toBe('playwright');
-        expect(detectMode('x = {}')).toBe('playwright');
-        expect(detectMode('let n = 42')).toBe('playwright');
+    it('returns js for assignment expressions', () => {
+        expect(detectMode('a = [1, 2, 3]')).toBe('js');
+        expect(detectMode('x = {}')).toBe('js');
+        expect(detectMode('let n = 42')).toBe('js');
     });
 
-    it('returns playwright for function calls', () => {
-        expect(detectMode('invalid()')).toBe('playwright');
-        expect(detectMode('fetch("https://api.example.com")')).toBe('playwright');
-        expect(detectMode('await fetch("https://api.example.com")')).toBe('playwright');
+    it('returns js for function calls', () => {
+        expect(detectMode('invalid()')).toBe('js');
+        expect(detectMode('fetch("https://api.example.com")')).toBe('js');
+        expect(detectMode('await fetch("https://api.example.com")')).toBe('js');
     });
 
-    it('returns playwright for template literals and string operations', () => {
-        expect(detectMode('`hello`')).toBe('playwright');
-        expect(detectMode('"hello"')).toBe('playwright');
+    it('returns js for template literals and string operations', () => {
+        expect(detectMode('`hello`')).toBe('js');
+        expect(detectMode('"hello"')).toBe('js');
     });
 
     it('returns pw for bare document/window (treated as unknown commands)', () => {
@@ -88,17 +88,17 @@ describe('detectMode', () => {
 
 describe('resolveConsoleMode', () => {
 
-    it('returns playwright for multi-line input', () => {
-        expect(resolveConsoleMode('const el = await page.$(\'a\');\nawait el._generateLocatorString()')).toBe('playwright');
+    it('returns js for multi-line input', () => {
+        expect(resolveConsoleMode('const el = await page.$(\'a\');\nawait el._generateLocatorString()')).toBe('js');
     });
 
-    it('returns playwright for multi-line input even without playwright globals', () => {
-        expect(resolveConsoleMode('const x = 1;\nconsole.log(x)')).toBe('playwright');
+    it('returns js for multi-line input even without playwright globals', () => {
+        expect(resolveConsoleMode('const x = 1;\nconsole.log(x)')).toBe('js');
     });
 
     it('delegates to detectMode for single-line input', () => {
-        expect(resolveConsoleMode('page.title()')).toBe('playwright');
+        expect(resolveConsoleMode('page.title()')).toBe('js');
         expect(resolveConsoleMode('click e5')).toBe('pw');
-        expect(resolveConsoleMode('document.title')).toBe('playwright');
+        expect(resolveConsoleMode('document.title')).toBe('js');
     });
 });


### PR DESCRIPTION
## Summary
- Renames the console's internal mode from `'playwright'` to `'js'` to match the editor's `'pw' | 'js'` convention
- Pure rename — no behavioral change
- Updates 4 source files and 3 test files

Closes #194

## Test plan
- [x] `npx vitest run` — 614 unit tests pass
- [x] `npx vitest run --config vitest.component.config.ts` — 157 component tests pass
- [x] `npx vite build` — clean build

🤖 Generated with [Claude Code](https://claude.com/claude-code)