### PR TITLE
refactor: simplify JS eval with replMode + block scoping

### DIFF
--- a/packages/extension/e2e/panel/panel.spec.ts
+++ b/packages/extension/e2e/panel/panel.spec.ts
@@ -89,7 +89,7 @@ test.describe("Panel page test", () => {
     await panelPage.keyboard.press('Escape');
     await panelPage.keyboard.press('Enter');
 
-    await expect(panelPage.locator('[data-type="error"]')).toContainText('Unknown command');
+    await expect(panelPage.locator('[data-type="error"]')).toContainText('ReferenceError');
   });
 
   // ─── Command History ───────────────────────────────────────────────────────

--- a/packages/extension/src/panel/lib/commands.ts
+++ b/packages/extension/src/panel/lib/commands.ts
@@ -171,7 +171,7 @@ function ser(v: unknown): string {
 
 /** Build a JS expression that calls a page-script function in the SW context (where `page` is global) */
 function call(fn: any, ...args: unknown[]): string {
-  return `return await (${fn.toString()})(page, ${args.map(ser).join(', ')})`;
+  return `await (${fn.toString()})(page, ${args.map(ser).join(', ')})`;
 }
 
 // ─── Known boolean options ───────────────────────────────────────────────────
@@ -366,7 +366,7 @@ function resolveArgs(args: ParsedArgs): ParsedArgs | DirectExecution {
   // ── Screenshot ──────────────────────────────────────────────
   // Wrapped in JSON.stringify so bridge.ts can detect the __image result
   if (cmdName === 'screenshot')
-    return { jsExpr: `return JSON.stringify(await (${takeScreenshot.toString()})(page, ${!!(args.fullPage)}))` };
+    return { jsExpr: `JSON.stringify(await (${takeScreenshot.toString()})(page, ${!!(args.fullPage)}))` };
 
   // ── Snapshot ────────────────────────────────────────────────
   if (cmdName === 'snapshot')

--- a/packages/extension/src/panel/lib/sw-debugger.ts
+++ b/packages/extension/src/panel/lib/sw-debugger.ts
@@ -78,20 +78,6 @@ export async function swGetProperties(objectId: string): Promise<unknown> {
     });
 }
 
-/** Attempt to insert `return` before the last expression line so the caller gets the value. */
-export function tryReturnLastExpr(code: string): string {
-    const lines = code.split('\n');
-    let i = lines.length - 1;
-    while (i >= 0 && !lines[i].trim()) i--;
-    if (i < 0) return code;
-    const trimmed = lines[i].trimStart();
-    // Skip lines that are statements, not expressions
-    if (/^(const |let |var |function |class |if |for |while |do |switch |try |throw |import |export |return |})/.test(trimmed)) return code;
-    const leading = lines[i].slice(0, lines[i].length - trimmed.length);
-    lines[i] = leading + 'return ' + trimmed;
-    return lines.join('\n');
-}
-
 export async function swCallFunctionOn(objectId: string, functionDeclaration: string): Promise<unknown> {
     const targetId = await ensureAttached();
     return new Promise((resolve, reject) => {
@@ -112,21 +98,14 @@ export async function swCallFunctionOn(objectId: string, functionDeclaration: st
 
 export async function swDebugEval(expression: string): Promise<unknown> {
     const targetId = await ensureAttached();
-    // Always use AsyncFunction constructor so that:
-    //   (1) await is valid (proper async function scope),
-    //   (2) const/let are scoped per call and don't leak between runs,
-    //   (3) last expression value is captured via tryReturnLastExpr,
-    //   (4) side-effects like locator.highlight() work correctly (arrow functions don't).
-    const isMultiLine = expression.includes('\n');
-    const isStatement = isMultiLine || expression.trimEnd().endsWith(';')
-        || /^(const |let |var |function |class |if |for |while |do |switch |try |throw |import |export |return |})/.test(expression.trimStart());
-    const body = isStatement ? tryReturnLastExpr(expression) : `return (${expression})`;
-    const wrapped = `(new (Object.getPrototypeOf(async function(){}).constructor)(${JSON.stringify(body)}))()`;
+    // replMode: true enables top-level await and returns completion values automatically.
+    // { } block wrapping keeps const/let scoped per call (isolated, no leaking).
+    const wrapped = '{\n' + expression + '\n}';
     return new Promise((resolve, reject) => {
         chrome.debugger.sendCommand(
             { targetId },
             'Runtime.evaluate',
-            { expression: wrapped, awaitPromise: true, returnByValue: false, generatePreview: true, objectGroup: 'console' },
+            { expression: wrapped, awaitPromise: true, returnByValue: false, generatePreview: true, objectGroup: 'console', replMode: true },
             (result: any) => {
                 if (chrome.runtime.lastError) {
                     swTargetId = null;

--- a/packages/extension/test/lib/sw-debugger.test.ts
+++ b/packages/extension/test/lib/sw-debugger.test.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import {
-    tryReturnLastExpr,
     swDebugTargets,
     swGetProperties,
     swCallFunctionOn,
@@ -44,76 +43,6 @@ function resetSwTargetId() {
     (chrome.debugger.onDetach as any).callListeners({ targetId: 'target-1' });
 }
 
-// ─── tryReturnLastExpr ──────────────────────────────────────────────────────
-
-describe('tryReturnLastExpr', () => {
-
-    // ─── Adds return ────────────────────────────────────────────────────────
-
-    it('adds return before a simple expression', () => {
-        expect(tryReturnLastExpr('1 + 2')).toBe('return 1 + 2');
-    });
-
-    it('adds return before a function call', () => {
-        expect(tryReturnLastExpr('inc(5)')).toBe('return inc(5)');
-    });
-
-    it('adds return to the last line of a multi-line script', () => {
-        const input = 'const inc = (a) => a + 1\ninc(5)';
-        expect(tryReturnLastExpr(input)).toBe('const inc = (a) => a + 1\nreturn inc(5)');
-    });
-
-    it('preserves leading whitespace when inserting return', () => {
-        const input = 'function f() {}\n  f()';
-        expect(tryReturnLastExpr(input)).toBe('function f() {}\n  return f()');
-    });
-
-    it('ignores trailing empty lines and inserts return on last non-empty line', () => {
-        const input = 'inc(5)\n\n';
-        expect(tryReturnLastExpr(input)).toBe('return inc(5)\n\n');
-    });
-
-    // ─── Does NOT add return ─────────────────────────────────────────────────
-
-    it('does not add return before const declaration', () => {
-        const input = 'const x = 5';
-        expect(tryReturnLastExpr(input)).toBe('const x = 5');
-    });
-
-    it('does not add return before let declaration', () => {
-        expect(tryReturnLastExpr('let x = 5')).toBe('let x = 5');
-    });
-
-    it('does not add return before var declaration', () => {
-        expect(tryReturnLastExpr('var x = 5')).toBe('var x = 5');
-    });
-
-    it('does not add return before function declaration', () => {
-        expect(tryReturnLastExpr('function f() {}')).toBe('function f() {}');
-    });
-
-    it('does not add return before if statement', () => {
-        expect(tryReturnLastExpr('if (x) {}')).toBe('if (x) {}');
-    });
-
-    it('does not add return before for loop', () => {
-        expect(tryReturnLastExpr('for (let i=0;i<3;i++) {}')).toBe('for (let i=0;i<3;i++) {}');
-    });
-
-    it('does not add return if already has return', () => {
-        expect(tryReturnLastExpr('return 42')).toBe('return 42');
-    });
-
-    it('does not add return before throw', () => {
-        expect(tryReturnLastExpr('throw new Error("x")')).toBe('throw new Error("x")');
-    });
-
-    it('returns empty string unchanged', () => {
-        expect(tryReturnLastExpr('')).toBe('');
-    });
-
-});
-
 // ─── swDebugTargets ──────────────────────────────────────────────────────────
 
 describe('swDebugTargets', () => {
@@ -134,23 +63,26 @@ describe('swDebugEval', () => {
         (chrome.runtime.sendMessage as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
     });
 
-    it('evaluates a simple expression in the SW context', async () => {
+    it('evaluates expression with replMode and block wrapping', async () => {
         mockGetTargets([SW_TARGET]);
         mockAttachSuccess();
         mockSendCommand({ result: { type: 'number', value: 42 } });
 
         const result = await swDebugEval('1 + 1');
         expect(result).toEqual({ result: { type: 'number', value: 42 } });
-        // Simple expression — wrapped as arrow
         expect(chrome.debugger.sendCommand).toHaveBeenCalledWith(
             { targetId: 'target-1' },
             'Runtime.evaluate',
-            expect.objectContaining({ expression: expect.stringContaining('return (1 + 1)') }),
+            expect.objectContaining({
+                expression: '{\n1 + 1\n}',
+                replMode: true,
+                awaitPromise: true,
+            }),
             expect.any(Function),
         );
     });
 
-    it('wraps multi-line expression with AsyncFunction constructor', async () => {
+    it('wraps multi-line code in a block', async () => {
         mockGetTargets([SW_TARGET]);
         mockAttachSuccess();
         mockSendCommand({ result: { type: 'undefined' } });
@@ -159,41 +91,25 @@ describe('swDebugEval', () => {
         expect(chrome.debugger.sendCommand).toHaveBeenCalledWith(
             { targetId: 'target-1' },
             'Runtime.evaluate',
-            expect.objectContaining({ expression: expect.stringContaining('Object.getPrototypeOf') }),
+            expect.objectContaining({
+                expression: '{\nconst x = 1\nx + 1\n}',
+                replMode: true,
+            }),
             expect.any(Function),
         );
     });
 
-    it('wraps statement-ending expression with AsyncFunction constructor', async () => {
-        mockGetTargets([SW_TARGET]);
-        mockAttachSuccess();
-        mockSendCommand({ result: { type: 'undefined' } });
-
-        await swDebugEval('doSomething();');
-        expect(chrome.debugger.sendCommand).toHaveBeenCalledWith(
-            { targetId: 'target-1' },
-            'Runtime.evaluate',
-            expect.objectContaining({ expression: expect.stringContaining('Object.getPrototypeOf') }),
-            expect.any(Function),
-        );
-    });
-
-    it('treats const/let/var declarations as statements (not wrapped with return)', async () => {
+    it('does not use AsyncFunction wrapper', async () => {
         mockGetTargets([SW_TARGET]);
         mockAttachSuccess();
         mockSendCommand({ result: { type: 'undefined' } });
 
         await swDebugEval('const x = 42');
-        expect(chrome.debugger.sendCommand).toHaveBeenCalledWith(
-            { targetId: 'target-1' },
-            'Runtime.evaluate',
-            expect.objectContaining({ expression: expect.stringContaining('const x = 42') }),
-            expect.any(Function),
-        );
-        // Should NOT contain 'return (const' — that's a SyntaxError
         const expr = (chrome.debugger.sendCommand as ReturnType<typeof vi.fn>).mock.calls
             .find((c: any) => c[1] === 'Runtime.evaluate')![2].expression;
+        expect(expr).not.toContain('Object.getPrototypeOf');
         expect(expr).not.toContain('return (const');
+        expect(expr).toBe('{\nconst x = 42\n}');
     });
 
     it('rejects with exceptionDetails message', async () => {


### PR DESCRIPTION
## Summary
- Replace AsyncFunction constructor wrapper + regex heuristics with CDP `replMode: true` + `{ }` block wrapping in `swDebugEval`
- Remove `tryReturnLastExpr` function and expression-vs-statement detection logic
- Remove `return` keyword from generated `jsExpr` in `commands.ts` (no longer needed — V8 returns completion values automatically in replMode)
- Update E2E test to match new JS-mode error for unknown commands

## What this gives us
- Top-level `await` works natively (replMode)
- Completion values returned automatically (no `return` insertion needed)
- `const`/`let` isolated per call (`{ }` block-scoped)
- `const [a, b] = [1, 2]; a` → returns `1` (previously "Done")
- `try { x } catch(e) { e.message }` → returns error message (previously "Done")
- Net -105 lines of code

## Test plan
- [x] 597 unit tests pass
- [x] E2E tests pass (103 passed)
- [x] Manual: PW commands (`goto`, `click`, `snapshot`, `screenshot`) work
- [x] Manual: JS mode (`page.title()`, `const [a,b] = [1,2]; a`) works
- [x] Manual: Editor run-code works
- [x] Build passes

Closes #201

🤖 Generated with [Claude Code](https://claude.com/claude-code)