### PR TITLE
fix: correct Map/Set preview values and enable expansion

### DIFF
--- a/packages/extension/src/panel/components/Console/cdpToSerialized.ts
+++ b/packages/extension/src/panel/components/Console/cdpToSerialized.ts
@@ -72,7 +72,7 @@ export function fromCdpRemoteObject(obj: CdpRemoteObject): SerializedValue {
                     const key = subtype === 'map'
                         ? String(entry.key?.value ?? entry.key?.description ?? i)
                         : String(i);
-                    props[key] = fromPreviewProperty({ name: key, type: entry.value.type, subtype: entry.value.subtype, value: entry.value.value });
+                    props[key] = fromPreviewProperty({ name: key, type: entry.value.type, subtype: entry.value.subtype, value: entry.value.value ?? entry.value.description });
                 }
             }
             return { __type: 'object', cls: description ?? className ?? (subtype === 'map' ? 'Map' : 'Set'), props, objectId };
@@ -97,11 +97,24 @@ export function fromCdpRemoteObject(obj: CdpRemoteObject): SerializedValue {
 
 /** Convert Runtime.getProperties response into SerializedValue props map. */
 export function fromCdpGetProperties(raw: unknown): Record<string, SerializedValue> {
-    const result = (raw as any)?.result as CdpPropertyDescriptor[] | undefined;
-    if (!result) return {};
+    const data = raw as any;
+    const result = data?.result as CdpPropertyDescriptor[] | undefined;
     const props: Record<string, SerializedValue> = {};
-    for (const desc of result) {
-        if (desc.value) props[desc.name] = fromCdpRemoteObject(desc.value);
+    if (result) {
+        for (const desc of result) {
+            if (desc.value) props[desc.name] = fromCdpRemoteObject(desc.value);
+        }
+    }
+    // Internal properties (e.g. [[Entries]] for Map/Set, [[Prototype]])
+    // Show [[Entries]] first for Maps/Sets
+    const internals = data?.internalProperties as CdpPropertyDescriptor[] | undefined;
+    if (internals) {
+        const entries = internals.find(d => d.name === '[[Entries]]');
+        if (entries?.value) props[entries.name] = fromCdpRemoteObject(entries.value);
+        for (const desc of internals) {
+            if (desc.name === '[[Entries]]') continue;
+            if (desc.value) props[desc.name] = fromCdpRemoteObject(desc.value);
+        }
     }
     return props;
 }

--- a/packages/extension/test/lib/cdpToSerialized.test.ts
+++ b/packages/extension/test/lib/cdpToSerialized.test.ts
@@ -144,6 +144,74 @@ describe('fromCdpRemoteObject', () => {
         });
     });
 
+    it('returns Map entries with description-only values (real CDP format)', () => {
+        const obj: CdpRemoteObject = {
+            type: 'object', subtype: 'map', className: 'Map', description: 'Map(2)',
+            preview: {
+                type: 'object', subtype: 'map',
+                entries: [
+                    { key: { type: 'string', value: 'a' }, value: { type: 'number', description: '1' } },
+                    { key: { type: 'string', value: 'b' }, value: { type: 'number', description: '2' } },
+                ],
+            },
+        };
+        const result = fromCdpRemoteObject(obj);
+        expect(result).toMatchObject({
+            __type: 'object', cls: 'Map(2)',
+            props: { a: { __type: 'number', v: 1 }, b: { __type: 'number', v: 2 } },
+        });
+    });
+
+    it('returns Map with mixed value types', () => {
+        const obj: CdpRemoteObject = {
+            type: 'object', subtype: 'map', className: 'Map', description: 'Map(3)',
+            preview: {
+                type: 'object', subtype: 'map',
+                entries: [
+                    { key: { type: 'string', value: 'str' }, value: { type: 'string', value: 'hello' } },
+                    { key: { type: 'string', value: 'num' }, value: { type: 'number', description: '42' } },
+                    { key: { type: 'string', value: 'bool' }, value: { type: 'boolean', value: 'true' } },
+                ],
+            },
+        };
+        const result = fromCdpRemoteObject(obj);
+        expect(result).toMatchObject({
+            __type: 'object', cls: 'Map(3)',
+            props: {
+                str: { __type: 'string', v: 'hello' },
+                num: { __type: 'number', v: 42 },
+                bool: { __type: 'boolean', v: true },
+            },
+        });
+    });
+
+    it('returns Map with numeric keys', () => {
+        const obj: CdpRemoteObject = {
+            type: 'object', subtype: 'map', className: 'Map', description: 'Map(2)',
+            preview: {
+                type: 'object', subtype: 'map',
+                entries: [
+                    { key: { type: 'number', description: '1' }, value: { type: 'string', value: 'one' } },
+                    { key: { type: 'number', description: '2' }, value: { type: 'string', value: 'two' } },
+                ],
+            },
+        };
+        const result = fromCdpRemoteObject(obj);
+        expect(result).toMatchObject({
+            __type: 'object', cls: 'Map(2)',
+            props: { 1: { __type: 'string', v: 'one' }, 2: { __type: 'string', v: 'two' } },
+        });
+    });
+
+    it('returns empty Map', () => {
+        const obj: CdpRemoteObject = {
+            type: 'object', subtype: 'map', className: 'Map', description: 'Map(0)',
+            preview: { type: 'object', subtype: 'map', entries: [] },
+        };
+        const result = fromCdpRemoteObject(obj);
+        expect(result).toMatchObject({ __type: 'object', cls: 'Map(0)', props: {} });
+    });
+
     it('returns Set entries from preview', () => {
         const obj: CdpRemoteObject = {
             type: 'object', subtype: 'set', className: 'Set', description: 'Set(3)',
@@ -161,6 +229,51 @@ describe('fromCdpRemoteObject', () => {
             __type: 'object', cls: 'Set(3)',
             props: { 0: { __type: 'number', v: 1 }, 1: { __type: 'number', v: 2 }, 2: { __type: 'number', v: 3 } },
         });
+    });
+
+    it('returns Set entries with description-only values', () => {
+        const obj: CdpRemoteObject = {
+            type: 'object', subtype: 'set', className: 'Set', description: 'Set(2)',
+            preview: {
+                type: 'object', subtype: 'set',
+                entries: [
+                    { value: { type: 'number', description: '10' } },
+                    { value: { type: 'number', description: '20' } },
+                ],
+            },
+        };
+        const result = fromCdpRemoteObject(obj);
+        expect(result).toMatchObject({
+            __type: 'object', cls: 'Set(2)',
+            props: { 0: { __type: 'number', v: 10 }, 1: { __type: 'number', v: 20 } },
+        });
+    });
+
+    it('returns Set with string entries', () => {
+        const obj: CdpRemoteObject = {
+            type: 'object', subtype: 'set', className: 'Set', description: 'Set(2)',
+            preview: {
+                type: 'object', subtype: 'set',
+                entries: [
+                    { value: { type: 'string', value: 'hello' } },
+                    { value: { type: 'string', value: 'world' } },
+                ],
+            },
+        };
+        const result = fromCdpRemoteObject(obj);
+        expect(result).toMatchObject({
+            __type: 'object', cls: 'Set(2)',
+            props: { 0: { __type: 'string', v: 'hello' }, 1: { __type: 'string', v: 'world' } },
+        });
+    });
+
+    it('returns empty Set', () => {
+        const obj: CdpRemoteObject = {
+            type: 'object', subtype: 'set', className: 'Set', description: 'Set(0)',
+            preview: { type: 'object', subtype: 'set', entries: [] },
+        };
+        const result = fromCdpRemoteObject(obj);
+        expect(result).toMatchObject({ __type: 'object', cls: 'Set(0)', props: {} });
     });
 
     // ─── Fallback types ──────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Fix Map/Set preview showing `0` for all values — CDP entry previews use `description` field, not `value`, for numbers
- Enable Map/Set expansion by including `internalProperties` (where `[[Entries]]` lives) in `fromCdpGetProperties`
- Show `[[Entries]]` before `[[Prototype]]` when expanding
- Add 7 new test cases for Map/Set serialization with real CDP data formats

## Before / After

| | Before | After |
|---|---|---|
| `new Map([['a', 1], ['b', 2]])` | `Map(2) {a: 0, b: 0}` | `Map(2) {a: 1, b: 2}` |
| `new Set([1, 2, 3])` | `Set(3) {0: 0, 1: 0, 2: 0}` | `Set(3) {0: 1, 1: 2, 2: 3}` |
| Expand Map | empty | `[[Entries]]`, `[[Prototype]]` |

## Test plan
- [x] 39 cdpToSerialized tests pass (7 new)
- [x] Manual: Map preview shows correct values
- [x] Manual: Set preview shows correct values
- [x] Manual: Map/Set expandable with [[Entries]]

Closes #203

🤖 Generated with [Claude Code](https://claude.com/claude-code)