### PR TITLE
fix: improve console display for Promise, Map/Set, arrays, object literals

### DIFF
--- a/packages/extension/src/panel/components/Console/ObjectTree.tsx
+++ b/packages/extension/src/panel/components/Console/ObjectTree.tsx
@@ -27,11 +27,39 @@ function inlineSummary(data: SerializedValue): string {
         return `[${items}${Object.keys(data.props).length > 3 ? ', …' : ''}]`;
     }
     if (data.__type === 'object') {
+        if (data.cls === 'Promise') {
+            const stateVal = data.props['[[PromiseState]]'];
+            const state = stateVal?.__type === 'string' ? stateVal.v : 'pending';
+            if (state === 'pending') return '';
+            const result = data.props['[[PromiseResult]]'];
+            if (result && result.__type !== 'undefined') return `{<${state}>: ${inlineSummary(result)}}`;
+            return `{<${state}>}`;
+        }
+        if (/^Map\(\d+\)$/.test(data.cls)) {
+            const keys = Object.keys(data.props).slice(0, 3);
+            const items = keys.map(k => `${k} => ${inlineSummary(data.props[k])}`).join(', ');
+            return `{${items}${Object.keys(data.props).length > 3 ? ', …' : ''}}`;
+        }
+        if (/^Set\(\d+\)$/.test(data.cls)) {
+            const keys = Object.keys(data.props).slice(0, 3);
+            const items = keys.map(k => inlineSummary(data.props[k])).join(', ');
+            return `{${items}${Object.keys(data.props).length > 3 ? ', …' : ''}}`;
+        }
         const keys = Object.keys(data.props).slice(0, 3);
         const items = keys.map(k => `${k}: ${inlineSummary(data.props[k])}`).join(', ');
         return `{${items}${Object.keys(data.props).length > 3 ? ', …' : ''}}`;
     }
     return '';
+}
+
+/** For Map/Set expansion: keep original flattened entries, merge metadata, drop [[Entries]]. */
+function mergeMapSetProps(original: Record<string, SerializedValue>, fetched: Record<string, SerializedValue>): Record<string, SerializedValue> {
+    const merged: Record<string, SerializedValue> = { ...original };
+    for (const [k, v] of Object.entries(fetched)) {
+        if (k === '[[Entries]]') continue;
+        merged[k] = v;
+    }
+    return merged;
 }
 
 export function ObjectTree({ data, label, depth = 0, getProperties }: Props) {
@@ -99,7 +127,10 @@ export function ObjectTree({ data, label, depth = 0, getProperties }: Props) {
 
     // Object / Array
     const isArray = data.__type === 'array';
-    const propsToShow = childProps ?? data.props;
+    const isMapOrSet = !isArray && /^(Map|Set)\(\d+\)$/.test(data.cls);
+    const propsToShow = childProps
+        ? (isMapOrSet ? mergeMapSetProps(data.props, childProps) : childProps)
+        : data.props;
     const keys = Object.keys(propsToShow);
     const header = isArray ? `Array(${data.len})` : data.cls;
 
@@ -120,11 +151,22 @@ export function ObjectTree({ data, label, depth = 0, getProperties }: Props) {
                 <div className="ot-children">
                     {loading
                         ? <div className="ot-row"><span className="ot-empty">Loading…</span></div>
-                        : keys.map(k => (
-                            <div key={k} className="ot-row">
-                                <ObjectTree data={propsToShow[k]} label={k} depth={depth + 1} getProperties={getProperties} />
-                            </div>
-                        ))
+                        : keys.map(k => {
+                            const isMapEntry = isMapOrSet && /^Map\(/.test(data.cls) && k in data.props;
+                            return (
+                                <div key={k} className="ot-row">
+                                    {isMapEntry ? (
+                                        <span>
+                                            <span className="ot-key">{k}</span>
+                                            <span className="ot-colon">{' => '}</span>
+                                            <ObjectTree data={propsToShow[k]} depth={depth + 1} getProperties={getProperties} />
+                                        </span>
+                                    ) : (
+                                        <ObjectTree data={propsToShow[k]} label={k} depth={depth + 1} getProperties={getProperties} />
+                                    )}
+                                </div>
+                            );
+                        })
                     }
                 </div>
             )}

--- a/packages/extension/src/panel/components/Console/cdpToSerialized.ts
+++ b/packages/extension/src/panel/components/Console/cdpToSerialized.ts
@@ -36,6 +36,13 @@ export interface CdpPropertyDescriptor {
     value?: CdpRemoteObject;
 }
 
+/** Parse array length from CDP description string like "Array(2)" */
+function parseArrayLength(description?: string): number | undefined {
+    if (!description) return undefined;
+    const m = description.match(/^Array\((\d+)\)$/);
+    return m ? Number(m[1]) : undefined;
+}
+
 function fromPreviewProperty(prop: CdpPropertyPreview): SerializedValue {
     const { type, subtype, value, name } = prop;
     if (type === 'undefined') return { __type: 'undefined' };
@@ -77,6 +84,22 @@ export function fromCdpRemoteObject(obj: CdpRemoteObject): SerializedValue {
             }
             return { __type: 'object', cls: description ?? className ?? (subtype === 'map' ? 'Map' : 'Set'), props, objectId };
         }
+        // Promise — extract state + result from preview internal properties
+        if (subtype === 'promise') {
+            const props: Record<string, SerializedValue> = {};
+            let state = 'pending';
+            if (preview?.properties) {
+                for (const prop of preview.properties) {
+                    if (prop.name === '[[PromiseState]]') {
+                        state = prop.value ?? 'pending';
+                    } else if (prop.name === '[[PromiseResult]]') {
+                        props['[[PromiseResult]]'] = fromPreviewProperty(prop);
+                    }
+                }
+            }
+            props['[[PromiseState]]'] = { __type: 'string', v: state };
+            return { __type: 'object', cls: 'Promise', props, objectId };
+        }
         const cls = className ?? 'Object';
         const isArray = subtype === 'array';
         // Use preview properties as initial display; objectId enables lazy full expansion
@@ -87,7 +110,7 @@ export function fromCdpRemoteObject(obj: CdpRemoteObject): SerializedValue {
             }
         }
         if (isArray) {
-            const len = preview?.properties?.length ?? 0;
+            const len = parseArrayLength(description) ?? preview?.properties?.length ?? 0;
             return { __type: 'array', cls, len, props, objectId };
         }
         return { __type: 'object', cls, props, objectId };
@@ -112,7 +135,7 @@ export function fromCdpGetProperties(raw: unknown): Record<string, SerializedVal
         const entries = internals.find(d => d.name === '[[Entries]]');
         if (entries?.value) props[entries.name] = fromCdpRemoteObject(entries.value);
         for (const desc of internals) {
-            if (desc.name === '[[Entries]]') continue;
+            if (desc.name === '[[Entries]]' || desc.name === '[[Prototype]]') continue;
             if (desc.value) props[desc.name] = fromCdpRemoteObject(desc.value);
         }
     }

--- a/packages/extension/src/panel/lib/sw-debugger.ts
+++ b/packages/extension/src/panel/lib/sw-debugger.ts
@@ -98,14 +98,15 @@ export async function swCallFunctionOn(objectId: string, functionDeclaration: st
 
 export async function swDebugEval(expression: string): Promise<unknown> {
     const targetId = await ensureAttached();
+    // Wrap {…} in parens so V8 parses it as an object literal, not a block statement.
+    // This is the same approach Chrome DevTools and Node REPL use.
+    const expr = expression.trimStart().startsWith('{') ? `(${expression})` : expression;
     // replMode: true enables top-level await and returns completion values automatically.
-    // { } block wrapping keeps const/let scoped per call (isolated, no leaking).
-    const wrapped = '{\n' + expression + '\n}';
     return new Promise((resolve, reject) => {
         chrome.debugger.sendCommand(
             { targetId },
             'Runtime.evaluate',
-            { expression: wrapped, awaitPromise: true, returnByValue: false, generatePreview: true, objectGroup: 'console', replMode: true },
+            { expression: expr, awaitPromise: true, returnByValue: false, generatePreview: true, objectGroup: 'console', replMode: true },
             (result: any) => {
                 if (chrome.runtime.lastError) {
                     swTargetId = null;

--- a/packages/extension/test/components/ObjectTree.browser.test.tsx
+++ b/packages/extension/test/components/ObjectTree.browser.test.tsx
@@ -134,6 +134,54 @@ describe('ObjectTree refs', () => {
     });
 });
 
+// ─── Promises ──────────────────────────────────────────────────────────────
+
+describe('ObjectTree promises', () => {
+    it('renders pending promise without state in title', async () => {
+        const data: SerializedValue = {
+            __type: 'object', cls: 'Promise',
+            props: { '[[PromiseState]]': { __type: 'string', v: 'pending' } },
+        };
+        const screen = await render(<ObjectTree data={data} depth={1} />);
+        await expect.element(screen.getByText(/Promise/)).toBeInTheDocument();
+    });
+
+    it('renders fulfilled promise with value', async () => {
+        const data: SerializedValue = {
+            __type: 'object', cls: 'Promise',
+            props: {
+                '[[PromiseState]]': { __type: 'string', v: 'fulfilled' },
+                '[[PromiseResult]]': { __type: 'number', v: 42 },
+            },
+        };
+        const screen = await render(<ObjectTree data={data} depth={1} />);
+        await expect.element(screen.getByText(/Promise/)).toBeInTheDocument();
+        await expect.element(screen.getByText(/\{<fulfilled>: 42\}/)).toBeInTheDocument();
+    });
+});
+
+// ─── Map / Set ─────────────────────────────────────────────────────────────
+
+describe('ObjectTree Map/Set', () => {
+    it('renders Map with arrow notation in summary', async () => {
+        const data: SerializedValue = {
+            __type: 'object', cls: 'Map(2)',
+            props: { a: { __type: 'number', v: 1 }, b: { __type: 'number', v: 2 } },
+        };
+        const screen = await render(<ObjectTree data={data} depth={1} />);
+        await expect.element(screen.getByText(/a => 1/)).toBeInTheDocument();
+    });
+
+    it('renders Set with values only in summary', async () => {
+        const data: SerializedValue = {
+            __type: 'object', cls: 'Set(2)',
+            props: { 0: { __type: 'number', v: 1 }, 1: { __type: 'number', v: 2 } },
+        };
+        const screen = await render(<ObjectTree data={data} depth={1} />);
+        await expect.element(screen.getByText(/\{1, 2\}/)).toBeInTheDocument();
+    });
+});
+
 // ─── Lazy loading ───────────────────────────────────────────────────────────
 
 describe('ObjectTree lazy loading', () => {

--- a/packages/extension/test/lib/cdpToSerialized.test.ts
+++ b/packages/extension/test/lib/cdpToSerialized.test.ts
@@ -99,6 +99,42 @@ describe('fromCdpRemoteObject', () => {
         expect(result).toMatchObject({ __type: 'array', len: 2 });
     });
 
+    // ─── Array length from description ────────────────────────────────────
+
+    it('parses array length from description when preview is truncated', () => {
+        const obj: CdpRemoteObject = {
+            type: 'object', subtype: 'array', className: 'Array',
+            description: 'Array(5)',
+            preview: { type: 'object', subtype: 'array', properties: [
+                { name: '0', type: 'number', value: '1' },
+                { name: '1', type: 'number', value: '2' },
+            ]},
+        };
+        const result = fromCdpRemoteObject(obj);
+        expect(result).toMatchObject({ __type: 'array', len: 5 });
+    });
+
+    it('falls back to preview length when description is missing', () => {
+        const obj: CdpRemoteObject = {
+            type: 'object', subtype: 'array', className: 'Array',
+            preview: { type: 'object', subtype: 'array', properties: [
+                { name: '0', type: 'number', value: '1' },
+            ]},
+        };
+        const result = fromCdpRemoteObject(obj);
+        expect(result).toMatchObject({ __type: 'array', len: 1 });
+    });
+
+    it('parses length from description for [[Entries]] array with empty preview', () => {
+        const obj: CdpRemoteObject = {
+            type: 'object', subtype: 'array', className: 'Array',
+            description: 'Array(3)',
+            preview: { type: 'object', subtype: 'array', properties: [] },
+        };
+        const result = fromCdpRemoteObject(obj);
+        expect(result).toMatchObject({ __type: 'array', len: 3 });
+    });
+
     // ─── Special subtypes ──────────────────────────────────────────────────
 
     it('returns date description for subtype === "date"', () => {
@@ -274,6 +310,70 @@ describe('fromCdpRemoteObject', () => {
         };
         const result = fromCdpRemoteObject(obj);
         expect(result).toMatchObject({ __type: 'object', cls: 'Set(0)', props: {} });
+    });
+
+    // ─── Promise ─────────────────────────────────────────────────────────
+
+    it('serializes fulfilled promise', () => {
+        const obj: CdpRemoteObject = {
+            type: 'object', subtype: 'promise', className: 'Promise',
+            description: 'Promise',
+            preview: {
+                type: 'object', subtype: 'promise', description: 'Promise',
+                properties: [
+                    { name: '[[PromiseState]]', type: 'string', value: 'fulfilled' },
+                    { name: '[[PromiseResult]]', type: 'number', value: '42' },
+                ],
+            },
+        };
+        const result = fromCdpRemoteObject(obj);
+        expect(result).toMatchObject({
+            __type: 'object', cls: 'Promise',
+            props: {
+                '[[PromiseState]]': { __type: 'string', v: 'fulfilled' },
+                '[[PromiseResult]]': { __type: 'number', v: 42 },
+            },
+        });
+    });
+
+    it('serializes pending promise', () => {
+        const obj: CdpRemoteObject = {
+            type: 'object', subtype: 'promise', className: 'Promise',
+            description: 'Promise',
+            preview: {
+                type: 'object', subtype: 'promise', description: 'Promise',
+                properties: [
+                    { name: '[[PromiseState]]', type: 'string', value: 'pending' },
+                ],
+            },
+        };
+        const result = fromCdpRemoteObject(obj);
+        expect(result).toMatchObject({
+            __type: 'object', cls: 'Promise',
+            props: { '[[PromiseState]]': { __type: 'string', v: 'pending' } },
+        });
+    });
+
+    it('serializes rejected promise', () => {
+        const obj: CdpRemoteObject = {
+            type: 'object', subtype: 'promise', className: 'Promise',
+            description: 'Promise',
+            preview: {
+                type: 'object', subtype: 'promise', description: 'Promise',
+                properties: [
+                    { name: '[[PromiseState]]', type: 'string', value: 'rejected' },
+                    { name: '[[PromiseResult]]', type: 'string', value: 'Error: fail' },
+                ],
+            },
+        };
+        const result = fromCdpRemoteObject(obj);
+        expect(result).toMatchObject({
+            __type: 'object', cls: 'Promise',
+            props: {
+                '[[PromiseState]]': { __type: 'string', v: 'rejected' },
+                '[[PromiseResult]]': { __type: 'string', v: 'Error: fail' },
+            },
+        });
     });
 
     // ─── Fallback types ──────────────────────────────────────────────────

--- a/packages/extension/test/lib/sw-debugger.test.ts
+++ b/packages/extension/test/lib/sw-debugger.test.ts
@@ -63,7 +63,7 @@ describe('swDebugEval', () => {
         (chrome.runtime.sendMessage as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
     });
 
-    it('evaluates expression with replMode and block wrapping', async () => {
+    it('evaluates expression with replMode', async () => {
         mockGetTargets([SW_TARGET]);
         mockAttachSuccess();
         mockSendCommand({ result: { type: 'number', value: 42 } });
@@ -74,7 +74,7 @@ describe('swDebugEval', () => {
             { targetId: 'target-1' },
             'Runtime.evaluate',
             expect.objectContaining({
-                expression: '{\n1 + 1\n}',
+                expression: '1 + 1',
                 replMode: true,
                 awaitPromise: true,
             }),
@@ -82,24 +82,7 @@ describe('swDebugEval', () => {
         );
     });
 
-    it('wraps multi-line code in a block', async () => {
-        mockGetTargets([SW_TARGET]);
-        mockAttachSuccess();
-        mockSendCommand({ result: { type: 'undefined' } });
-
-        await swDebugEval('const x = 1\nx + 1');
-        expect(chrome.debugger.sendCommand).toHaveBeenCalledWith(
-            { targetId: 'target-1' },
-            'Runtime.evaluate',
-            expect.objectContaining({
-                expression: '{\nconst x = 1\nx + 1\n}',
-                replMode: true,
-            }),
-            expect.any(Function),
-        );
-    });
-
-    it('does not use AsyncFunction wrapper', async () => {
+    it('passes expression directly without wrapping', async () => {
         mockGetTargets([SW_TARGET]);
         mockAttachSuccess();
         mockSendCommand({ result: { type: 'undefined' } });
@@ -107,9 +90,29 @@ describe('swDebugEval', () => {
         await swDebugEval('const x = 42');
         const expr = (chrome.debugger.sendCommand as ReturnType<typeof vi.fn>).mock.calls
             .find((c: any) => c[1] === 'Runtime.evaluate')![2].expression;
-        expect(expr).not.toContain('Object.getPrototypeOf');
-        expect(expr).not.toContain('return (const');
-        expect(expr).toBe('{\nconst x = 42\n}');
+        expect(expr).toBe('const x = 42');
+    });
+
+    it('wraps object literal in parens to avoid block parse', async () => {
+        mockGetTargets([SW_TARGET]);
+        mockAttachSuccess();
+        mockSendCommand({ result: { type: 'object', value: { a: 1, b: 2 } } });
+
+        await swDebugEval('{a:1, b:2}');
+        const expr = (chrome.debugger.sendCommand as ReturnType<typeof vi.fn>).mock.calls
+            .find((c: any) => c[1] === 'Runtime.evaluate')![2].expression;
+        expect(expr).toBe('({a:1, b:2})');
+    });
+
+    it('does not wrap non-brace expressions', async () => {
+        mockGetTargets([SW_TARGET]);
+        mockAttachSuccess();
+        mockSendCommand({ result: { type: 'undefined' } });
+
+        await swDebugEval('const x = {a:1}');
+        const expr = (chrome.debugger.sendCommand as ReturnType<typeof vi.fn>).mock.calls
+            .find((c: any) => c[1] === 'Runtime.evaluate')![2].expression;
+        expect(expr).toBe('const x = {a:1}');
     });
 
     it('rejects with exceptionDetails message', async () => {


### PR DESCRIPTION
## Summary
- **#205** — Promise display: show state (`pending`/`fulfilled`/`rejected`) and result from CDP preview. Pending shows just `Promise`, fulfilled/rejected shows `Promise {<state>: value}`
- **#206** — Map entries with arrow notation (`a => 1`), Set values-only summary (`{1, 2}`). `mergeMapSetProps` keeps flattened entries on expand, drops `[[Entries]]`
- **#208** — Parse array length from CDP `description` field (`"Array(5)"`) instead of relying on empty `preview.properties`
- Wrap `{`-starting expressions in `()` to fix object literal parsing (`{a:1}` → `({a:1})`)
- Skip `[[Prototype]]` in expanded properties view
- Remove block wrapping, pass expressions directly with `replMode: true`

## Test plan
- [x] Unit tests pass (611)
- [x] Browser component tests pass (161)
- [x] Manual: `page.title()` shows Promise with fulfilled state
- [x] Manual: `new Promise(() => {})` shows `Promise` (no pending in title)
- [x] Manual: `Promise.reject(new Error('x'))` shows rejected state
- [x] Manual: `new Map([['a',1],['b',2]])` shows `Map(2) {a => 1, b => 2}`
- [x] Manual: `new Set([1,2,3])` shows `Set(3) {1, 2, 3}`
- [x] Manual: `{a:1, b:2}` returns object (no SyntaxError)
- [x] Manual: `const foo = () => "foo"` + `foo()` works across evals

Closes #205, Closes #206, Closes #208

🤖 Generated with [Claude Code](https://claude.com/claude-code)