### PR TITLE
feat: add dedicated Debug button for JS mode

### DIFF
--- a/packages/extension/src/panel/components/Icons.tsx
+++ b/packages/extension/src/panel/components/Icons.tsx
@@ -100,6 +100,21 @@ export function UnplugIcon({ size = 16 }: { size?: number }) {
   );
 }
 
+export function BugIcon({ size = 16 }: { size?: number }) {
+  return (
+    <svg viewBox="0 0 24 24" width={size} height={size} stroke="currentColor" fill="none" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M8 2l1.88 1.88" /><path d="M14.12 3.88L16 2" />
+      <path d="M9 7.13v-1a3.003 3.003 0 1 1 6 0v1" />
+      <path d="M12 20c-3.3 0-6-2.7-6-6v-3a4 4 0 0 1 4-4h4a4 4 0 0 1 4 4v3c0 3.3-2.7 6-6 6" />
+      <path d="M12 20v-9" />
+      <path d="M6.53 9C4.6 8.8 3 7.1 3 5" />
+      <path d="M6 13H2" /><path d="M3 21c0-2.1 1.7-3.9 3.8-4" />
+      <path d="M20.97 5c0 2.1-1.6 3.8-3.5 4" />
+      <path d="M22 13h-4" /><path d="M17.2 17c2.1.1 3.8 1.9 3.8 4" />
+    </svg>
+  );
+}
+
 export function CrosshairIcon({ size = 16 }: { size?: number }) {
   return (
     <svg viewBox="0 0 16 16" width={size} height={size} fill="none" stroke="currentColor" strokeWidth="1.5" xmlns="http://www.w3.org/2000/svg">

--- a/packages/extension/src/panel/components/Toolbar.tsx
+++ b/packages/extension/src/panel/components/Toolbar.tsx
@@ -3,7 +3,7 @@ import type { PanelState, Action } from "@/reducer";
 import { attachToTab } from '@/lib/bridge';
 import { runAndDispatch, runJsScript, runJsScriptStep } from '@/lib/run';
 import { swTerminateExecution, swDebugResume } from '@/lib/sw-debugger';
-import { SunIcon, MoonIcon, FolderOpenIcon, SaveIcon, RecordIcon, StopIcon, StepForwardIcon, AbortIcon, CrosshairIcon, PlugIcon, UnplugIcon } from './Icons';
+import { SunIcon, MoonIcon, FolderOpenIcon, SaveIcon, RecordIcon, StopIcon, StepForwardIcon, AbortIcon, BugIcon, CrosshairIcon, PlugIcon, UnplugIcon } from './Icons';
 import type { EditorHandle } from './CodeMirrorEditorPane';
 import { buildPickResult, resolvePlaywrightLocator } from '@/lib/pick-info';
 import { loadSettings, storeSettings } from '@/lib/settings'
@@ -199,15 +199,15 @@ function Toolbar({ editorContent, editorMode, stepLine, attachedUrl, attachedTab
         return executableIndex;
     }
 
+    async function handleDebug() {
+        dispatch({ type: 'RUN_START', stepDebug: true });
+        await runJsScriptStep(editorContent, dispatch);
+        dispatch({ type: 'RUN_STOP' });
+    }
+
     async function handleStep() {
         if (isStepDebugging) {
             swDebugResume().catch(() => {});
-            return;
-        }
-        if (editorMode === 'js') {
-            dispatch({ type: 'RUN_START', stepDebug: true });
-            await runJsScriptStep(editorContent, dispatch);
-            dispatch({ type: 'RUN_STOP' });
             return;
         }
         // pw step mode: run next line via runAndDispatch
@@ -368,7 +368,10 @@ function Toolbar({ editorContent, editorMode, stepLine, attachedUrl, attachedTab
                     ? <button id="stop-run-btn" data-testid="stop-run-btn" title={isStepDebugging ? "Abort" : "Stop"} onClick={handleStop}>{isStepDebugging ? <AbortIcon /> : <StopIcon />}</button>
                     : <button id="run-btn" data-testid="run-btn" title="Run script (Ctrl+Enter)" disabled={!editorContent.trim()} onClick={handleRun}>&#9654;</button>
                 }
-                <button id="step-btn" data-testid="step-btn" title={editorMode === 'js' ? (isStepDebugging ? 'Step: advance to next line' : 'Step: start debug session') : 'Step: run next line'} disabled={!editorContent.trim() || (isRunning && !isStepDebugging)} onClick={handleStep}><StepForwardIcon /></button>
+                {editorMode === 'js' && !isRunning && stepLine === -1 && (
+                    <button id="debug-btn" data-testid="debug-btn" title="Debug script" disabled={!editorContent.trim()} onClick={handleDebug}><BugIcon /></button>
+                )}
+                <button id="step-btn" data-testid="step-btn" title={isStepDebugging ? 'Step: advance to next line' : 'Step: run next line'} disabled={!editorContent.trim() || (editorMode === 'js' && !isStepDebugging) || (isRunning && !isStepDebugging)} onClick={handleStep}><StepForwardIcon /></button>
                 <span className="w-px h-4.5 bg-(--color-toolbar-sep) mx-1"></span>
                 <div data-testid="mode-toggle" className="inline-flex rounded border border-(--border-button) overflow-hidden">
                     <button

--- a/packages/extension/test/components/Toolbar.browser.test.tsx
+++ b/packages/extension/test/components/Toolbar.browser.test.tsx
@@ -716,14 +716,35 @@ describe('Toolbar component tests', () => {
       });
     });
 
-    it('step button is enabled in JS mode (starts debug session)', async () => {
+    it('step button is disabled in JS mode when not debugging', async () => {
       const screen = await renderToolbar({
         editorContent: 'goto https://example.com',
         editorMode: 'js',
       });
 
       const stepBtn = screen.container.querySelector('#step-btn') as HTMLButtonElement;
-      expect(stepBtn.disabled).toBe(false);
+      expect(stepBtn.disabled).toBe(true);
+    });
+
+    it('debug button is visible in JS mode', async () => {
+      const screen = await renderToolbar({
+        editorContent: 'goto https://example.com',
+        editorMode: 'js',
+      });
+
+      const debugBtn = screen.container.querySelector('#debug-btn') as HTMLButtonElement;
+      expect(debugBtn).not.toBeNull();
+      expect(debugBtn.disabled).toBe(false);
+    });
+
+    it('debug button is hidden in pw mode', async () => {
+      const screen = await renderToolbar({
+        editorContent: 'goto https://example.com',
+        editorMode: 'pw',
+      });
+
+      const debugBtn = screen.container.querySelector('#debug-btn');
+      expect(debugBtn).toBeNull();
     });
 
     it('step button is enabled in pw mode with content', async () => {


### PR DESCRIPTION
## Summary
- Add Debug button (bug icon) to toolbar, visible only in JS mode
- Separates "start debug session" from "step to next line"
- Step button disabled in JS mode until debug session is active and paused
- PW mode unchanged

## Test plan
- [x] Unit tests pass (606/606)
- [x] Component tests pass (163/163) — updated old test + 2 new tests
- [x] Build succeeds
- [x] Manual: JS mode shows Debug button, Step disabled
- [x] Manual: Click Debug → pauses at first line, Step enabled, Stop visible
- [x] Manual: Click Step → advances line by line
- [x] Manual: PW mode — Debug hidden, Step works as before

Closes #217

🤖 Generated with [Claude Code](https://claude.com/claude-code)