### PR TITLE
feat: add clickable gutter breakpoints for JS debugger

### DIFF
--- a/packages/extension/src/panel/App.tsx
+++ b/packages/extension/src/panel/App.tsx
@@ -117,6 +117,7 @@ function App() {
         isAttaching={state.isAttaching}
         dispatch={dispatch}
         editorRef={editorRef}
+        breakPoints={state.breakPoints}
       />
       {state.isStepDebugging && <DebugBar dispatch={dispatch} />}
 

--- a/packages/extension/src/panel/components/CodeMirrorEditorPane.tsx
+++ b/packages/extension/src/panel/components/CodeMirrorEditorPane.tsx
@@ -2,6 +2,7 @@ import { useRef, useEffect, useImperativeHandle } from 'react';
 import { EditorView } from 'codemirror';
 import { baseExtensions, dispatchRunState, languageCompartment, pwModeExtension, jsModeExtension } from '@/lib/codemirror-setup';
 import type { PanelState, Action } from "@/reducer";
+import { breakpointField } from '@/lib/codemirror-setup';
 
 export interface EditorHandle {
     insertAtCursor: (text: string) => void;
@@ -61,6 +62,11 @@ function CodeMirrorEditorPane({ editorContent, editorMode, currentRunLine, lineR
                 EditorView.updateListener.of((update) => {
                     if (update.docChanged && !externalUpdateRef.current) {
                         dispatch({ type: 'EDIT_EDITOR_CONTENT', content: update.state.doc.toString() });
+                    }
+                    const oldBps = update.startState.field(breakpointField);
+                    const newBps = update.state.field(breakpointField);
+                    if (oldBps !== newBps) {
+                        dispatch({ type: 'SET_BREAKPOINTS', breakPoints: newBps });
                     }
                 }),
             ],

--- a/packages/extension/src/panel/components/Toolbar.tsx
+++ b/packages/extension/src/panel/components/Toolbar.tsx
@@ -8,12 +8,12 @@ import type { EditorHandle } from './CodeMirrorEditorPane';
 import { buildPickResult, resolvePlaywrightLocator } from '@/lib/pick-info';
 import { loadSettings, storeSettings } from '@/lib/settings'
 
-interface ToolbarProps extends Pick<PanelState, 'editorContent' | 'editorMode' | 'stepLine' | 'attachedUrl' | 'attachedTabId' | 'isAttaching' | 'isRunning' | 'isStepDebugging'> {
+interface ToolbarProps extends Pick<PanelState, 'editorContent' | 'editorMode' | 'stepLine' | 'attachedUrl' | 'attachedTabId' | 'isAttaching' | 'isRunning' | 'isStepDebugging' | 'breakPoints'> {
     dispatch: React.Dispatch<Action>,
     editorRef: React.RefObject<EditorHandle | null>,
 };
 
-function Toolbar({ editorContent, editorMode, stepLine, attachedUrl, attachedTabId, isAttaching, isRunning, isStepDebugging, dispatch, editorRef }: ToolbarProps) {
+function Toolbar({ editorContent, editorMode, stepLine, attachedUrl, attachedTabId, isAttaching, isRunning, isStepDebugging, breakPoints, dispatch, editorRef }: ToolbarProps) {
     const fileInputRef = useRef<HTMLInputElement>(null);
     const cancelRunRef = useRef(false);
     const [isRecording, setIsRecording] = useState(false);
@@ -201,7 +201,7 @@ function Toolbar({ editorContent, editorMode, stepLine, attachedUrl, attachedTab
 
     async function handleDebug() {
         dispatch({ type: 'RUN_START', stepDebug: true });
-        await runJsScriptStep(editorContent, dispatch);
+        await runJsScriptStep(editorContent, dispatch, breakPoints);
         dispatch({ type: 'RUN_STOP' });
     }
 

--- a/packages/extension/src/panel/lib/codemirror-setup.ts
+++ b/packages/extension/src/panel/lib/codemirror-setup.ts
@@ -61,10 +61,14 @@ const pwTheme = EditorView.theme({
     '.cm-tooltip-autocomplete ul li[aria-selected]': {
         backgroundColor: 'var(--bg-button)',
     },
+    '.cm-breakpoint-gutter': { width: '16px' },
+    '.cm-breakpoint-gutter .cm-gutterElement': { cursor: 'pointer', display: 'flex', alignItems: 'center', justifyContent: 'center' }
+
 });
 
 export const setRunLineEffect = StateEffect.define<number>();           // -1 = none
 export const setLineResultsEffect = StateEffect.define<(string | null)[]>();  // per-line
+export const toggleBreakpointEffect = StateEffect.define<number>();
 
 const runLineField = StateField.define<number>({
     create: () => -1,
@@ -83,6 +87,34 @@ const lineResultsField = StateField.define<(string | null)[]>({
             if (e.is(setLineResultsEffect)) return e.value;
         }
         return value;
+    },
+});
+
+export const breakpointField = StateField.define<Set<number>>({
+    create: () => new Set(),
+    update(value, tr) {
+        let set = value;
+        if (tr.docChanged) {
+            const newSet = new Set<number>();
+            for (const bp of set) {
+                if (bp >= tr.startState.doc.lines) continue;
+                const line = tr.startState.doc.line(bp + 1);
+                const mapped = tr.changes.mapPos(line.from, 1);
+                if (mapped <= tr.newDoc.length) {
+                    newSet.add(tr.newDoc.lineAt(mapped).number - 1);
+                }
+            }
+            set = newSet;
+        }
+        for (const e of tr.effects) {
+            if (e.is(toggleBreakpointEffect)) {
+                const next = new Set(set);
+                if (next.has(e.value)) next.delete(e.value);
+                else next.add(e.value);
+                set = next;
+            }
+        }
+        return set;
     },
 });
 
@@ -110,6 +142,15 @@ class ResultMarker extends GutterMarker {
     }
 }
 
+class BreakpointMarker extends GutterMarker {
+    toDOM() {
+        const dot = document.createElement('span');
+        dot.dataset.testid = 'breakpoint-marker';
+        dot.style.cssText = 'width:10px;height:10px;border-radius:50%;background:var(--color-breakpoint);display:inline-block;';
+        return dot;
+    }
+}
+
 const resultGutter = gutter({
     class: 'cm-result-gutter',
     markers(view) {
@@ -125,6 +166,27 @@ const resultGutter = gutter({
     },
 });
 
+const breakpointGutter = gutter({
+    class: 'cm-breakpoint-gutter',
+    markers(view) {
+        const bps = view.state.field(breakpointField);
+        const markers: any[] = [];
+        for (const lineNum of bps) {
+            if (lineNum < view.state.doc.lines) {
+                const line = view.state.doc.line(lineNum + 1);
+                markers.push(new BreakpointMarker().range(line.from));
+            }
+        }
+        return RangeSet.of(markers, true);
+    },
+    domEventHandlers: {
+        mousedown(view, line) {
+            const lineNum = view.state.doc.lineAt(line.from).number - 1;
+            view.dispatch({ effects: toggleBreakpointEffect.of(lineNum) });
+            return true;
+        },
+    },
+});
 export function dispatchRunState(
     view: EditorView,
     runLine: number,
@@ -167,6 +229,8 @@ export const jsModeExtension = [
 
 export const baseExtensions = [
     languageCompartment.of(pwModeExtension), // dynamic language compartment
+    breakpointField,                         // ← breakpoint state (must register before gutter)
+    breakpointGutter,                        // ← clickable breakpoint dots (leftmost gutter)
     lineNumbers(),                           // built-in line numbers
     highlightActiveLineGutter(),             // highlights gutter on cursor line
     highlightActiveLine(),                   // highlights content on cursor line

--- a/packages/extension/src/panel/lib/run.ts
+++ b/packages/extension/src/panel/lib/run.ts
@@ -4,7 +4,7 @@ import { COMMANDS, CATEGORIES, JS_CATEGORIES } from '@/lib/commands';
 import type { CommandResult } from '@/types';
 import type { Action } from '@/reducer';
 import { getCommandHistory, clearHistory, addCommand } from '@/lib/command-history';
-import { swDebugEval, swDebugEvalRaw, swGetProperties, swDebuggerEnable, swDebuggerDisable, swDebugPause, swDebugResume, onDebugPaused } from '@/lib/sw-debugger';
+import { swDebugEval, swDebugEvalRaw, swGetProperties, swDebuggerEnable, swDebuggerDisable, swDebugPause, swDebugResume, onDebugPaused, swTrackBreakpoint, swSetBreakpointByUrl, swRemoveAllBreakpoints } from '@/lib/sw-debugger';
 import { fromCdpRemoteObject } from '@/components/Console/cdpToSerialized';
 import type { CdpRemoteObject } from '@/components/Console/cdpToSerialized';
 
@@ -98,7 +98,7 @@ export async function runJsScript(code: string, dispatch: React.Dispatch<Action>
     }
 }
 
-export async function runJsScriptStep(code: string, dispatch: React.Dispatch<Action>): Promise<void> {
+export async function runJsScriptStep(code: string, dispatch: React.Dispatch<Action>, breakPoints?: Set<number>): Promise<void> {
     dispatch({ type: 'COMMAND_SUBMITTED', line: { text: '(debug JS script)', type: 'command' } });
 
     const lines = code.split('\n');
@@ -107,6 +107,12 @@ export async function runJsScriptStep(code: string, dispatch: React.Dispatch<Act
 
     try {
         await swDebuggerEnable();
+        if (breakPoints?.size) {
+            for (const line of breakPoints) {
+                const bpId = await swSetBreakpointByUrl(sourceURL, line);
+                if (bpId) swTrackBreakpoint(bpId);
+            }
+        }
 
         // Pause before the first executed statement (skips hoisted declarations)
         await swDebugPause();
@@ -156,6 +162,7 @@ export async function runJsScriptStep(code: string, dispatch: React.Dispatch<Act
     } finally {
         onDebugPaused(null);
         await swDebuggerDisable().catch(() => {});
+        await swRemoveAllBreakpoints().catch(() => {})
     }
 }
 

--- a/packages/extension/src/panel/panel.css
+++ b/packages/extension/src/panel/panel.css
@@ -47,6 +47,7 @@
   --color-splitter-handle-hover: #007acc;
   --color-toolbar-sep: #d4d4d4;
   --color-caret: #1e1e1e;
+  --color-breakpoint: #e51400;
 }
 
 .theme-dark {
@@ -93,6 +94,7 @@
   --color-splitter-handle-hover: #007acc;
   --color-toolbar-sep: #444444;
   --color-caret: #d4d4d4;
+  --color-breakpoint: #e51400;
 }
 
 /* === Reset === */

--- a/packages/extension/src/panel/reducer.ts
+++ b/packages/extension/src/panel/reducer.ts
@@ -13,7 +13,8 @@ export type PanelState = {
   lineResults: ('pass' | 'fail' | null)[]
   attachedUrl: string | null
   attachedTabId: number | null
-  isAttaching: boolean
+  isAttaching: boolean,
+  breakPoints: Set<number>;
 }
 
 export type Action =
@@ -36,6 +37,7 @@ export type Action =
    | { type: 'DETACH' }
    | { type: 'UPDATE_URL', url: string }
    | { type: 'SET_EDITOR_MODE', mode: 'pw' | 'js' }
+   | { type: 'SET_BREAKPOINTS', breakPoints: Set<number>}
 
 export const initialState : PanelState = {
     outputLines: [],
@@ -51,6 +53,7 @@ export const initialState : PanelState = {
     attachedUrl: null,
     attachedTabId: null,
     isAttaching: false,
+    breakPoints: new Set(),
 }
 
 export function panelReducer(state: PanelState, action: Action): PanelState {
@@ -124,6 +127,8 @@ export function panelReducer(state: PanelState, action: Action): PanelState {
             return { ...state, attachedUrl: action.url }
         case 'SET_EDITOR_MODE':
             return { ...state, editorMode: action.mode }
+        case 'SET_BREAKPOINTS': 
+            return { ...state, breakPoints: action.breakPoints }
         default:
             return state
     }

--- a/packages/extension/test/components/Console.browser.test.tsx
+++ b/packages/extension/test/components/Console.browser.test.tsx
@@ -26,6 +26,9 @@ vi.mock('@/lib/sw-debugger', () => ({
     swDebugStepInto: vi.fn().mockResolvedValue(undefined),
     swDebugStepOut: vi.fn().mockResolvedValue(undefined),
     swTerminateExecution: vi.fn().mockResolvedValue(undefined),
+    swSetBreakpointByUrl: vi.fn().mockResolvedValue('bp-1'),
+    swTrackBreakpoint: vi.fn(),
+    swRemoveAllBreakpoints: vi.fn().mockResolvedValue(undefined),
     onDebugPaused: vi.fn(),
 }));
 

--- a/packages/extension/test/components/Toolbar.browser.test.tsx
+++ b/packages/extension/test/components/Toolbar.browser.test.tsx
@@ -25,6 +25,9 @@ vi.mock('@/lib/sw-debugger', () => ({
   swDebugStepInto: vi.fn().mockResolvedValue(undefined),
   swDebugStepOut: vi.fn().mockResolvedValue(undefined),
   swTerminateExecution: vi.fn().mockResolvedValue(undefined),
+  swSetBreakpointByUrl: vi.fn().mockResolvedValue('bp-1'),
+  swTrackBreakpoint: vi.fn(),
+  swRemoveAllBreakpoints: vi.fn().mockResolvedValue(undefined),
   onDebugPaused: vi.fn(),
 }));
 
@@ -49,6 +52,7 @@ function renderToolbar(overrides: Partial<Parameters<typeof Toolbar>[0]> = {}) {
     isAttaching={false}
     isRunning={false}
     isStepDebugging={false}
+    breakPoints={new Set()}
     dispatch={vi.fn()}
     editorRef={editorRef}
     {...overrides}

--- a/packages/extension/test/lib/run.test.ts
+++ b/packages/extension/test/lib/run.test.ts
@@ -45,9 +45,13 @@ vi.mock('@/lib/sw-debugger', () => ({
     swDebuggerDisable: (...args: any[]) => mockSwDebuggerDisable(...args),
     swDebugPause: (...args: any[]) => mockSwDebugPause(...args),
     onDebugPaused: (...args: any[]) => mockOnDebugPaused(...args),
+    swDebugResume: vi.fn().mockResolvedValue(undefined),
     swDebugStepOver: vi.fn().mockResolvedValue(undefined),
     swDebugStepInto: vi.fn().mockResolvedValue(undefined),
     swDebugStepOut: vi.fn().mockResolvedValue(undefined),
+    swSetBreakpointByUrl: vi.fn().mockResolvedValue('bp-1'),
+    swTrackBreakpoint: vi.fn(),
+    swRemoveAllBreakpoints: vi.fn().mockResolvedValue(undefined),
 }));
 
 const mockFromCdpRemoteObject = vi.fn((_obj: unknown) => ({ __type: 'string', v: 'mocked' }) as any);


### PR DESCRIPTION
## Summary
- Add a clickable breakpoint gutter (red dots) to the CodeMirror editor, visible in both PW and JS modes
- Breakpoints sync from CM6 state to React reducer, then pass to `runJsScriptStep` which sets CDP `Debugger.setBreakpointByUrl` at debug start
- Continue (F5) pauses at the next breakpoint; breakpoints persist across debug sessions and remap on line edits
- CDP breakpoints are cleaned up in `finally` via `swRemoveAllBreakpoints`

Closes #222
Closes #219

## Test plan
- [x] Unit tests pass (`pnpm test` — 605 tests)
- [x] Component tests pass (`npm run test:component` — 163 tests)
- [x] Manual: click gutter toggles red dot on/off
- [x] Manual: set breakpoint, click Debug → pauses at first statement, Continue jumps to breakpoint
- [x] Manual: breakpoints remap when inserting/deleting lines
- [x] Manual: breakpoints persist after debug session ends

🤖 Generated with [Claude Code](https://claude.com/claude-code)