### PR TITLE
fix: debugger fails when editor has trailing empty lines

### DIFF
--- a/packages/extension/src/panel/lib/run.ts
+++ b/packages/extension/src/panel/lib/run.ts
@@ -102,7 +102,9 @@ export async function runJsScriptStep(code: string, dispatch: React.Dispatch<Act
     dispatch({ type: 'COMMAND_SUBMITTED', line: { text: '(debug JS script)', type: 'command' } });
 
     const lines = code.split('\n');
-    const lineCount = lines.length;
+    let lineCount = lines.length;
+    while (lineCount > 0 && lines[lineCount - 1].trim() === '') lineCount--;
+    if (lineCount === 0) lineCount = 1;
     const sourceURL = 'pw-repl-debug.js';
 
     try {


### PR DESCRIPTION
## Summary

- Trim trailing empty lines from `lineCount` in the debug runner so the debugger doesn't try to pause on or step through non-existent code lines
- Previously caused the debugger to get stuck or show "Internal error" when editor content ended with blank lines

## Changes

- `run.ts` — strip trailing empty lines from `lineCount`, with safety floor of 1

## Test plan

- [ ] Write JS code with trailing empty lines → click Debug → debugger works normally
- [ ] Write JS code without trailing empty lines → debugger still works
- [ ] Empty editor → debugger handles gracefully

Closes #228

🤖 Generated with [Claude Code](https://claude.com/claude-code)