### PR TITLE
feat: show inline variable values on paused line during debug

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1,142 +1,243 @@
-# Auto-display scope variables on debug pause (#223)
+# Inline variable values in editor during debug pause (#224)
 
 ## Context
 
-The JS debugger pauses at breakpoints and supports stepping, but users can't see variable values without adding `console.log` statements. We want to show scope variables automatically when the debugger pauses, displayed in a "Variables" tab next to the Console.
+When paused at a breakpoint, users have to look at the Variables tab to see values. We want to show variable values inline next to the paused line in the editor, like VS Code does.
 
-## Design decisions
+## Approach
 
-- **Tab-based UI**: Add [Console] [Variables] tabs to the bottom pane. Only one tab visible at a time (full width for ~400px side panel).
-- **Auto-switch**: When debugger pauses → switch to Variables tab. When debugging ends → switch back to Console.
-- **Variables tab only visible during debugging** (`isStepDebugging === true`).
-- **Scope filtering**: Show `local`, `closure`, `script` scopes. Filter out `global` (too large).
-- **Lazy loading**: Top-level scope properties fetched on expand; nested objects use existing `ObjectTree` lazy expansion via `swGetProperties`.
-- **Local scope auto-expanded**, other scopes collapsed by default.
+**Show all local scope variables on the paused line** as faded text after the line content:
+
+```
+const x = 10;
+let total = 0;
+for (const n of arr) {
+  total += n;           ← paused here    total = 6, n = 3
+}
+```
+
+This is simpler than the "per-assignment-line" approach (which requires JS parsing) and still very useful. The `InlineValues` map supports multiple lines, so it can be extended later.
 
 ## Data flow
 
 ```
-Debugger.paused event (sw-debugger.ts)
-  → extract scopeChain from callFrames[0] (filter out 'global')
-  → pass ScopeInfo[] (type + objectId) through PauseCallback
-  → run.ts dispatches SET_SCOPE_DATA to reducer
-  → VariablesPane reads scopeData, calls swGetProperties(objectId)
-  → fromCdpGetProperties() → Record<string, SerializedValue>
-  → renders each variable with existing ObjectTree component
+Debugger.paused → sw-debugger.ts → onDebugPaused(line, scopes)
+  → run.ts dispatches SET_SCOPE_DATA + SET_RUN_LINE
+  → App.tsx useEffect: swGetProperties → fromCdpGetProperties → stores localProps
+  → localProps shared with both VariablePane (display) and formatInlineValues (inline text)
+  → formatInlineValues(line, props) → pure formatting, no CDP call
+  → passes InlineValues map to CodeMirrorEditorPane
+  → dispatches setInlineValuesEffect to CM
+  → inlineValuesDecoration renders InlineValueWidget at end of paused line
 ```
+
+**Key insight**: `swGetProperties` is called once in `App.tsx` for the local scope. The result is shared by both the Variables tab and the inline values formatter — no duplicate CDP calls.
 
 ## Changes
 
-### 1. `sw-debugger.ts` — Export ScopeInfo type + extend PauseCallback
+### 1. Export `inlineSummary` from ObjectTree.tsx
 
-Add exported type:
+Add `export` to the existing `inlineSummary` function (line 14). No other changes.
+
+### 2. `codemirror-setup.ts` — StateEffect + StateField + Widget + Decoration
+
+**a) New types/effects:**
 ```ts
-export type ScopeInfo = { type: string; name?: string; objectId: string };
+export type InlineValues = Map<number, string>;  // lineNum → "x = 10, total = 6"
+export const setInlineValuesEffect = StateEffect.define<InlineValues>();
 ```
 
-Change callback type:
+**b) StateField:**
 ```ts
-type PauseCallback = (lineNumber: number, scopes: ScopeInfo[]) => void;
+const inlineValuesField = StateField.define<InlineValues>({
+    create: () => new Map(),
+    update(value, tr) {
+        for (const e of tr.effects) {
+            if (e.is(setInlineValuesEffect)) return e.value;
+        }
+        return value;
+    },
+});
 ```
 
-In `Debugger.paused` handler (~line 326), extract scope chain and pass to callback:
+**c) Widget class:**
 ```ts
-const scopes: ScopeInfo[] = (params.callFrames[0].scopeChain ?? [])
-    .filter((s: any) => s.type !== 'global')
-    .map((s: any) => ({ type: s.type, name: s.name, objectId: s.object.objectId }));
-pauseCallback?.(params.callFrames[0].location.lineNumber, scopes);
+class InlineValueWidget extends WidgetType {
+    constructor(readonly text: string) { super(); }
+    toDOM() {
+        const span = document.createElement('span');
+        span.className = 'cm-inline-values';
+        span.textContent = '  ' + this.text;
+        return span;
+    }
+    eq(other: InlineValueWidget) { return this.text === other.text; }
+}
 ```
 
-### 2. `reducer.ts` — Add scopeData + bottomTab state
+**d) Decoration:**
 
-State additions:
+Note: import `Range` from `@codemirror/state`.
+
 ```ts
-scopeData: ScopeInfo[];                    // initial: []
-bottomTab: 'console' | 'variables';       // initial: 'console'
+const inlineValuesDecoration = EditorView.decorations.compute(
+    [inlineValuesField],
+    (state) => {
+        const values = state.field(inlineValuesField);
+        if (values.size === 0) return Decoration.none;
+        const decorations: Range<Decoration>[] = [];
+        for (const [lineNum, text] of values) {
+            if (lineNum < 0 || lineNum >= state.doc.lines) continue;
+            const line = state.doc.line(lineNum + 1);
+            decorations.push(
+                Decoration.widget({
+                    widget: new InlineValueWidget(text),
+                    side: 1,
+                }).range(line.to)
+            );
+        }
+        return Decoration.set(decorations, true);
+    }
+);
 ```
 
-New actions:
+**e) Register** `inlineValuesField` and `inlineValuesDecoration` in `baseExtensions`.
+
+**f) Update `dispatchRunState`:**
 ```ts
-| { type: 'SET_SCOPE_DATA', scopes: ScopeInfo[] }
-| { type: 'SET_BOTTOM_TAB', tab: 'console' | 'variables' }
+export function dispatchRunState(
+    view: EditorView, runLine: number,
+    lineResults: (string | null)[],
+    inlineValues: InlineValues = new Map(),
+) {
+    view.dispatch({
+        effects: [
+            setRunLineEffect.of(runLine),
+            setLineResultsEffect.of(lineResults),
+            setInlineValuesEffect.of(inlineValues),
+        ],
+    });
+}
 ```
 
-Handlers:
-- `SET_SCOPE_DATA`: set `scopeData`, auto-switch `bottomTab` to `'variables'` when scopes non-empty
-- `SET_BOTTOM_TAB`: set `bottomTab`
-- `RUN_STOP`: also clear `scopeData: []` and reset `bottomTab: 'console'`
-
-### 3. `run.ts` — Dispatch scope data on pause
-
-Update `onDebugPaused` callback signature to `(line: number, scopes: ScopeInfo[])`. Dispatch `SET_SCOPE_DATA` alongside `SET_RUN_LINE` on each pause:
+**g) Add to `pwTheme`:**
 ```ts
-dispatch({ type: 'SET_SCOPE_DATA', scopes });
+'.cm-inline-values': {
+    color: 'var(--color-inline-value)',
+    fontStyle: 'italic',
+    opacity: '0.7',
+    pointerEvents: 'none',
+},
 ```
 
-### 4. `VariablesPane.tsx` — New component
+### 3. New file: `lib/inline-values.ts`
 
-Renders scope sections. Each `ScopeSection`:
-- Shows header (e.g. "Local", "Closure (greet)") — click to expand/collapse
-- On expand: calls `swGetProperties(scope.objectId)` → `fromCdpGetProperties()` → renders each variable with `ObjectTree`
-- Local scope auto-expanded; others collapsed
-- Re-fetches when `scope.objectId` changes (new pause event)
-- Empty state: "Not paused" message
+Pure formatter — no CDP calls. Receives already-fetched props from App.tsx:
 
-Reuses existing exports:
-- `ObjectTree` from `Console/ObjectTree.tsx` (named export)
-- `fromCdpGetProperties` from `Console/cdpToSerialized.ts`
-- `swGetProperties` from `sw-debugger.ts`
+```ts
+import { inlineSummary } from '@/components/Console/ObjectTree';
+import type { SerializedValue } from '@/components/Console/types';
+import type { InlineValues } from './codemirror-setup';
 
-### 5. `BottomPane.tsx` — New wrapper component
+const MAX_INLINE_LENGTH = 80;
 
-Contains:
-- **Tab bar**: [Console] [Variables] buttons with `data-active` attribute pattern
-- Variables tab button only rendered when `isStepDebugging === true`
-- Conditionally renders `<Console>` or `<VariablesPane>` based on `bottomTab`
+export function formatInlineValues(
+    pausedLine: number,
+    props: Record<string, SerializedValue> | null,
+): InlineValues {
+    const values = new Map<number, string>();
+    if (pausedLine < 0 || !props) return values;
 
-### 6. `Console/index.tsx` — Remove header bar
+    const parts: string[] = [];
+    for (const [name, val] of Object.entries(props)) {
+        if (name.startsWith('[[')) continue;
+        const summary = inlineSummary(val);
+        if (!summary) continue;
+        parts.push(`${name} = ${summary}`);
+    }
+    if (parts.length > 0) {
+        let text = parts.join(', ');
+        if (text.length > MAX_INLINE_LENGTH) text = text.slice(0, MAX_INLINE_LENGTH) + '…';
+        values.set(pausedLine, text);
+    }
 
-The Console currently renders its own header (`<span>Console</span>` at line 97-99). Remove this header since the tab bar in `BottomPane` replaces it. Keep the clear button row.
+    return values;
+}
+```
 
-### 7. `App.tsx` — Replace Console with BottomPane
+### 4. `App.tsx` — Fetch local scope props + derive inline values
 
-Replace `<Console outputLines={state.outputLines} dispatch={dispatch} />` with:
+Fetch local scope properties once, share with both VariablePane and inline values:
+
 ```tsx
-<BottomPane
-    bottomTab={state.bottomTab}
-    outputLines={state.outputLines}
-    scopeData={state.scopeData}
-    isStepDebugging={state.isStepDebugging}
-    dispatch={dispatch}
-/>
+const [localProps, setLocalProps] = useState<Record<string, SerializedValue> | null>(null);
+
+// Fetch local scope properties (shared by VariablePane + inline values)
+useEffect(() => {
+    if (state.scopeData.length === 0) {
+        setLocalProps(null);
+        return;
+    }
+    const localScope = state.scopeData.find(s => s.type === 'local' || s.type === 'block');
+    if (!localScope) { setLocalProps(null); return; }
+
+    let cancelled = false;
+    swGetProperties(localScope.objectId).then(raw => {
+        if (!cancelled) setLocalProps(fromCdpGetProperties(raw));
+    });
+    return () => { cancelled = true; };
+}, [state.scopeData]);
+
+// Derive inline values from already-fetched props (pure, no CDP call)
+const inlineValues = useMemo(
+    () => formatInlineValues(state.currentRunLine, localProps),
+    [state.currentRunLine, localProps],
+);
 ```
 
-### 8. `panel.css` — Tab styling
+Pass `inlineValues` to `<CodeMirrorEditorPane>` and `localProps` to `<VariablePane>`.
 
-Style active/inactive tabs using `data-active` attribute (same pattern as .pw/JS mode toggle).
+### 4b. `VariablePane.tsx` — Accept pre-fetched local props
+
+Update `ScopeSection` for the local scope to use the pre-fetched `localProps` from App.tsx instead of calling `swGetProperties` again. Other scopes (closure, script) still fetch on expand as before.
+
+### 5. `CodeMirrorEditorPane.tsx` — Accept + dispatch
+
+Add `inlineValues` prop. Update the `useEffect` that calls `dispatchRunState`:
+```ts
+dispatchRunState(view, currentRunLine, lineResults, inlineValues ?? new Map());
+```
+Add `inlineValues` to the dependency array.
+
+### 6. `panel.css` — Color variable
+
+```css
+/* In :root */
+--color-inline-value: #6e6e6e;
+
+/* In .theme-dark */
+--color-inline-value: #888888;
+```
+
+## Cleanup on debug end
+
+Automatic — `RUN_STOP` sets `scopeData: []` and `currentRunLine: -1`, which triggers the `useEffect` to clear `inlineValues` to an empty map.
 
 ## Files
 
 | File | Change |
 |------|--------|
-| `src/panel/lib/sw-debugger.ts` | Export `ScopeInfo`, extend `PauseCallback`, extract scope chain |
-| `src/panel/reducer.ts` | Add `scopeData`, `bottomTab` state + actions, clear on `RUN_STOP` |
-| `src/panel/lib/run.ts` | Update `onDebugPaused` callback to accept + dispatch scopes |
-| `src/panel/components/VariablesPane.tsx` | **New** — scope sections with ObjectTree rendering |
-| `src/panel/components/BottomPane.tsx` | **New** — tab bar + conditional Console/Variables rendering |
-| `src/panel/components/Console/index.tsx` | Remove header bar (replaced by tab bar) |
-| `src/panel/App.tsx` | Replace `<Console>` with `<BottomPane>` |
-| `src/panel/panel.css` | Tab active/inactive styles |
+| `src/panel/components/Console/ObjectTree.tsx` | Export `inlineSummary` |
+| `src/panel/lib/codemirror-setup.ts` | StateEffect, StateField, Widget, decoration, update dispatchRunState (import `Range` from `@codemirror/state`) |
+| `src/panel/lib/inline-values.ts` | **New** — pure `formatInlineValues` formatter (no CDP calls) |
+| `src/panel/App.tsx` | Fetch local scope props once, derive inlineValues via `useMemo`, pass to both VariablePane and EditorPane |
+| `src/panel/components/VariablePane.tsx` | Accept pre-fetched `localProps` for local scope (avoid duplicate fetch) |
+| `src/panel/components/CodeMirrorEditorPane.tsx` | Accept + dispatch inlineValues prop |
+| `src/panel/panel.css` | --color-inline-value CSS variable |
 
 ## Verification
 
 1. Build: `cd packages/extension && pnpm build`
-2. Tests: `cd packages/extension && pnpm test && npm run test:component`
-3. Manual testing:
-   - Click Debug → Variables tab auto-appears with scope data
-   - Step Over → variables update in place
-   - Local scope shows variables; Closure scope collapsed
-   - Click Console tab → console output visible; click Variables → back to variables
-   - Click Stop → switches back to Console tab, Variables tab disappears
-   - Expand nested object → lazy loads properties
-   - When not debugging, only Console tab shown (no Variables tab)
+2. Debug JS code with breakpoints → faded inline values appear on paused line
+3. Step Over → inline values update
+4. Stop → inline values disappear
+5. Code without local variables (top-level only) → no inline values (only local/block scope shown)

--- a/packages/extension/src/panel/App.tsx
+++ b/packages/extension/src/panel/App.tsx
@@ -1,4 +1,4 @@
-import { useReducer, useRef, useEffect } from 'react'
+import { useReducer, useRef, useEffect, useState, useMemo } from 'react'
 import Toolbar from './components/Toolbar'
 import CodeMirrorEditorPane, { type EditorHandle } from "./components/CodeMirrorEditorPane"
 import Splitter from './components/Splitter'
@@ -8,12 +8,20 @@ import { BottomPane } from './components/BottomPane'
 import DebugBar from './components/DebugBar';
 import { onConsoleEvent } from '@/lib/sw-debugger';
 import { loadSettings } from './lib/settings';
+import { SerializedValue } from './components/Console/types'
+import { formatInlineValues } from './lib/inline-values'
 
 function App() {
   const [state, dispatch] = useReducer(panelReducer, initialState)
   const editorPaneRef = useRef<HTMLDivElement>(null)
   const editorRef = useRef<EditorHandle | null>(null);
   const attachedTabRef = useRef<number | null>(null);
+  const [localProps, setLocalProps] = useState<Record<string, SerializedValue> | null>(null);
+
+  const inlineValues = useMemo(
+    () => formatInlineValues(state.currentRunLine, localProps),
+    [state.currentRunLine, localProps],
+  );
 
   useEffect(() => {
     onConsoleEvent((level, args) => {
@@ -129,6 +137,7 @@ function App() {
           editorMode={state.editorMode}
           currentRunLine={state.currentRunLine}
           lineResults={state.lineResults}
+          inlineValues={inlineValues}
           dispatch={dispatch}
         />
       </div>
@@ -142,6 +151,7 @@ function App() {
           bottomTab={state.bottomTab}
           isStepDebugging={state.isStepDebugging}
           scopeData={state.scopeData} 
+          onLocalProps={setLocalProps}
       />
     </>
   )

--- a/packages/extension/src/panel/components/BottomPane.tsx
+++ b/packages/extension/src/panel/components/BottomPane.tsx
@@ -1,12 +1,14 @@
 import { Console } from './Console';
 import { VariablePane } from './VariablePane';
 import type { PanelState, Action } from "@/reducer";
+import type { SerializedValue } from '@/components/Console/types';
 
 interface BottomPaneProps extends Pick<PanelState, 'isStepDebugging' | 'bottomTab' | 'outputLines'| 'scopeData'> {
     dispatch: React.Dispatch<Action>,
+    onLocalProps?: (props: Record<string, SerializedValue> | null) => void;
 };
 
-export function BottomPane({isStepDebugging, bottomTab, outputLines, dispatch, scopeData }: BottomPaneProps) {
+export function BottomPane({isStepDebugging, bottomTab, outputLines, dispatch, scopeData, onLocalProps }: BottomPaneProps) {
     return (
         <div className="flex flex-col flex-1 min-h-20 overflow-hidden" data-testid="bottom-pane">
         {/* Tab bar */}
@@ -26,7 +28,7 @@ export function BottomPane({isStepDebugging, bottomTab, outputLines, dispatch, s
         </div>
         {/* Tab content */}
         { bottomTab === 'console' &&  <Console outputLines={outputLines} dispatch={dispatch} />}
-        { bottomTab === 'variables' && isStepDebugging && <VariablePane scopeData={scopeData} />}
+        { bottomTab === 'variables' && isStepDebugging && <VariablePane scopeData={scopeData} onLocalProps={onLocalProps} />}
         </div>
         
     )

--- a/packages/extension/src/panel/components/CodeMirrorEditorPane.tsx
+++ b/packages/extension/src/panel/components/CodeMirrorEditorPane.tsx
@@ -3,6 +3,7 @@ import { EditorView } from 'codemirror';
 import { baseExtensions, dispatchRunState, languageCompartment, pwModeExtension, jsModeExtension } from '@/lib/codemirror-setup';
 import type { PanelState, Action } from "@/reducer";
 import { breakpointField } from '@/lib/codemirror-setup';
+import { InlineValues } from '@/lib/codemirror-setup';
 
 export interface EditorHandle {
     insertAtCursor: (text: string) => void;
@@ -13,10 +14,11 @@ interface EditorPaneProps extends Pick<PanelState, 'editorContent' | 'currentRun
     dispatch: React.Dispatch<Action>
     ref?: React.Ref<EditorHandle | null>
     containerRef?: React.Ref<HTMLDivElement>
+    inlineValues: InlineValues
 }
 
 
-function CodeMirrorEditorPane({ editorContent, editorMode, currentRunLine, lineResults, dispatch, ref, containerRef }: EditorPaneProps) {
+function CodeMirrorEditorPane({ editorContent, editorMode, currentRunLine, lineResults, dispatch, ref, containerRef, inlineValues }: EditorPaneProps) {
     const cmContainerRef = useRef<HTMLDivElement>(null);
     const viewRef = useRef<EditorView>(null);
     const externalUpdateRef = useRef(false);
@@ -90,8 +92,8 @@ function CodeMirrorEditorPane({ editorContent, editorMode, currentRunLine, lineR
     useEffect(()=> {
         const view = viewRef.current;
         if(!view) return;
-        dispatchRunState(view, currentRunLine, lineResults);
-    }, [currentRunLine, lineResults]);
+        dispatchRunState(view, currentRunLine, lineResults, inlineValues ?? new Map());
+    }, [currentRunLine, lineResults, inlineValues]);
 
     useEffect(() => {
         const view = viewRef.current;

--- a/packages/extension/src/panel/components/Console/ObjectTree.tsx
+++ b/packages/extension/src/panel/components/Console/ObjectTree.tsx
@@ -11,7 +11,7 @@ interface Props {
     getProperties?: (objectId: string) => Promise<unknown>;
 }
 
-function inlineSummary(data: SerializedValue): string {
+export function inlineSummary(data: SerializedValue): string {
     if (data.__type === 'null')      return 'null';
     if (data.__type === 'undefined') return 'undefined';
     if (data.__type === 'string')    return `"${data.v}"`;

--- a/packages/extension/src/panel/components/VariablePane.tsx
+++ b/packages/extension/src/panel/components/VariablePane.tsx
@@ -11,13 +11,15 @@ import type { SerializedValue } from '@/components/Console/types';
 
 interface VariablePaneProps {
     scopeData: ScopeInfo[];
+    onLocalProps?: (props: Record<string, SerializedValue> | null) => void;
 }
 
 interface ScopeSectionProps {
     scope: ScopeInfo;
-    defaultOpen: boolean
+    defaultOpen: boolean,
+    onLocalProps?: (props: Record<string, SerializedValue> | null) => void;
 }
-function ScopeSection({ scope, defaultOpen }: ScopeSectionProps) {
+function ScopeSection({ scope, defaultOpen, onLocalProps }: ScopeSectionProps) {
     const [open, setOpen] = useState(defaultOpen);
     const [props, setProps] = useState<Record<string, SerializedValue> | null>(null);
     const [loading, setLoading] = useState(false);
@@ -38,8 +40,10 @@ function ScopeSection({ scope, defaultOpen }: ScopeSectionProps) {
     function fetchProps() {
         setLoading(true);
         swGetProperties(scope.objectId).then(raw => {
-            setProps(fromCdpGetProperties(raw));
+            const parsed = fromCdpGetProperties(raw);
+            setProps(parsed);
             setLoading(false);
+            onLocalProps?.(parsed);
         });
     }
 
@@ -70,13 +74,17 @@ function ScopeSection({ scope, defaultOpen }: ScopeSectionProps) {
 }
 
 
-export function VariablePane({ scopeData }: VariablePaneProps) {
+export function VariablePane({ scopeData, onLocalProps }: VariablePaneProps) {
     return (
         <div className="overflow-auto flex-1 p-2">
             { scopeData.length === 0 
               ? <div className='ot-empty'>No local variables</div>
               : scopeData.map((scope) => (
-                <ScopeSection key={scope.objectId} scope={scope} defaultOpen={scope.type === 'local'} />
+                <ScopeSection 
+                        key={scope.objectId} 
+                        scope={scope} 
+                        defaultOpen={scope.type === 'local'} 
+                        onLocalProps={(scope.type === 'local' || scope.type === 'block') ? onLocalProps : undefined }/>
               ))
             }
         </div>

--- a/packages/extension/src/panel/lib/codemirror-setup.ts
+++ b/packages/extension/src/panel/lib/codemirror-setup.ts
@@ -1,17 +1,19 @@
 
 import { EditorView } from "codemirror";
-import { lineNumbers, highlightActiveLineGutter, highlightActiveLine, keymap, placeholder } from '@codemirror/view';
+import { lineNumbers, highlightActiveLineGutter, highlightActiveLine, keymap, placeholder, WidgetType } from '@codemirror/view';
 import { history, historyKeymap, defaultKeymap } from '@codemirror/commands';
 import { bracketMatching, syntaxHighlighting, HighlightStyle } from '@codemirror/language';
 import { tags } from '@lezer/highlight';
 import { javascript, javascriptLanguage } from '@codemirror/lang-javascript';
 import { pwSyntax } from './pw-language';
 import { search, searchKeymap } from '@codemirror/search';
-import { StateEffect, StateField, EditorState, RangeSet, Compartment } from '@codemirror/state';
+import { StateEffect, StateField, EditorState, RangeSet, Compartment, Range } from '@codemirror/state';
 import { Decoration, GutterMarker, gutter } from '@codemirror/view';
 import { autocompletion, acceptCompletion, closeBrackets, closeBracketsKeymap } from '@codemirror/autocomplete';
 import { pwCompletion } from './pw-completion'
 import { playwrightCompletions } from './pw-completion-source'
+
+export type InlineValues = Map<number, string>;
 
 const pwTheme = EditorView.theme({
     '&': {
@@ -62,13 +64,20 @@ const pwTheme = EditorView.theme({
         backgroundColor: 'var(--bg-button)',
     },
     '.cm-breakpoint-gutter': { width: '16px' },
-    '.cm-breakpoint-gutter .cm-gutterElement': { cursor: 'pointer', display: 'flex', alignItems: 'center', justifyContent: 'center' }
+    '.cm-breakpoint-gutter .cm-gutterElement': { cursor: 'pointer', display: 'flex', alignItems: 'center', justifyContent: 'center' },
+    '.cm-inline-values': {
+        color: 'var(--color-inline-value)',
+        fontStyle: 'italic',
+        opacity: '0.7',
+        pointerEvents: 'none',
+    },
 
 });
 
 export const setRunLineEffect = StateEffect.define<number>();           // -1 = none
 export const setLineResultsEffect = StateEffect.define<(string | null)[]>();  // per-line
 export const toggleBreakpointEffect = StateEffect.define<number>();
+export const setInlineValuesEffect = StateEffect.define<InlineValues>();
 
 const runLineField = StateField.define<number>({
     create: () => -1,
@@ -118,6 +127,16 @@ export const breakpointField = StateField.define<Set<number>>({
     },
 });
 
+const inlineValuesField = StateField.define<InlineValues>({
+    create: () => new Map(),
+    update(value, tr) {
+        for (const e of tr.effects) {
+            if (e.is(setInlineValuesEffect)) return e.value;
+        }
+        return value;
+    }
+});
+
 const runLineHighlight = EditorView.decorations.compute(
     [runLineField],
     (state) => {
@@ -130,6 +149,25 @@ const runLineHighlight = EditorView.decorations.compute(
     }
 );
 
+const inlineValuesDecoration = EditorView.decorations.compute(
+    [inlineValuesField],
+    (state) => {
+        const values = state.field(inlineValuesField);
+        if (values.size === 0) return Decoration.none;
+        const decorations: Range<Decoration>[] = [];
+        for (const [lineNum, text] of values) {
+            if (lineNum < 0 || lineNum >= state.doc.lines ) continue;
+            const line = state.doc.line(lineNum + 1);
+            decorations.push(
+                Decoration.widget({
+                    widget: new InlineValueWidget(text),
+                    side: 1,
+                }).range(line.to)
+            );
+        }
+        return Decoration.set(decorations, true);
+    }
+)
 class ResultMarker extends GutterMarker {
     constructor(readonly result: string) { super(); }
     toDOM() {
@@ -149,6 +187,17 @@ class BreakpointMarker extends GutterMarker {
         dot.style.cssText = 'width:10px;height:10px;border-radius:50%;background:var(--color-breakpoint);display:inline-block;';
         return dot;
     }
+}
+
+class InlineValueWidget extends WidgetType {
+    constructor(readonly text: string) { super();}
+    toDOM() {
+        const span = document.createElement('span');
+        span.className = 'cm-inline-values';
+        span.textContent = '  ' + this.text;
+        return span;
+    }
+    eq(other: InlineValueWidget) { return this.text === other.text; }
 }
 
 const resultGutter = gutter({
@@ -187,15 +236,18 @@ const breakpointGutter = gutter({
         },
     },
 });
+
 export function dispatchRunState(
     view: EditorView,
     runLine: number,
     lineResults: (string | null)[],
+    inlineValues: InlineValues = new Map(),
 ) {
     view.dispatch({
         effects: [
             setRunLineEffect.of(runLine),
             setLineResultsEffect.of(lineResults),
+            setInlineValuesEffect.of(inlineValues),
         ],
     });
 }
@@ -251,5 +303,7 @@ export const baseExtensions = [
     lineResultsField,      // ← register the StateField so CM6 tracks it
     runLineHighlight,      // ← decoration that reads runLineField
     resultGutter,          // ← gutter that reads lineResultsField
+    inlineValuesField,
+    inlineValuesDecoration
 ];
 

--- a/packages/extension/src/panel/lib/inline-values.ts
+++ b/packages/extension/src/panel/lib/inline-values.ts
@@ -1,0 +1,28 @@
+import { inlineSummary } from '@/components/Console/ObjectTree';
+import type { SerializedValue } from '@/components/Console/types';
+import type { InlineValues } from './codemirror-setup';
+
+const MAX_INLINE_LENGTH = 80;
+
+export function formatInlineValues(
+    pausedLine: number,
+    props: Record<string, SerializedValue> | null,
+): InlineValues {
+    const values = new Map<number, string>();
+    if (pausedLine < 0 || !props) return values;
+
+    const parts: string[] = [];
+    for (const [name, val] of Object.entries(props)) {
+        if (name.startsWith('[[')) continue;
+        const summary = inlineSummary(val);
+        if (!summary) continue;
+        parts.push(`${name} = ${summary}`);
+    }
+    if (parts.length > 0) {
+        let text = parts.join(', ');
+        if (text.length > MAX_INLINE_LENGTH) text = text.slice(0, MAX_INLINE_LENGTH) + '…';
+        values.set(pausedLine, text);
+    }
+
+    return values;
+}

--- a/packages/extension/src/panel/panel.css
+++ b/packages/extension/src/panel/panel.css
@@ -48,6 +48,7 @@
   --color-toolbar-sep: #d4d4d4;
   --color-caret: #1e1e1e;
   --color-breakpoint: #e51400;
+  --color-inline-value: #6e6e6e;
 }
 
 .theme-dark {
@@ -95,6 +96,7 @@
   --color-toolbar-sep: #444444;
   --color-caret: #d4d4d4;
   --color-breakpoint: #e51400;
+  --color-inline-value: #888888;
 }
 
 /* === Reset === */


### PR DESCRIPTION
## Summary
- When paused at a breakpoint, local/block scope variable values now appear inline at the end of the paused line as faded italic text (e.g. `total = 6, n = 3`)
- Pure formatter in `inline-values.ts` — no duplicate CDP calls; reuses scope data already fetched by VariablePane via `onLocalProps` callback
- New CodeMirror StateField + widget decoration for rendering inline values

Closes #224

## Test plan
- [ ] Build: `cd packages/extension && pnpm build`
- [ ] Debug JS code with breakpoints → faded inline values appear on paused line
- [ ] Step Over → inline values update
- [ ] Stop → inline values disappear
- [ ] Code without local variables → no inline values shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)