### PR TITLE
fix: record Enter as separate press command instead of --submit flag

### DIFF
--- a/packages/extension/src/content/locator.ts
+++ b/packages/extension/src/content/locator.ts
@@ -232,7 +232,6 @@ export function buildCommands(action: string, el: Element, opts?: {
     key?: string;
     checked?: boolean;
     option?: string;
-    submit?: boolean;
 }): { pw: string; js: string } | null {
     const locator = generateLocator(el);
     const jsLoc = `page.${locator}`;
@@ -248,9 +247,8 @@ export function buildCommands(action: string, el: Element, opts?: {
 
         case 'fill': {
             const val = opts?.value ?? '';
-            const submitFlag = opts?.submit ? ' --submit' : '';
             return {
-                pw: `fill ${pwArgs} ${q(val)}${submitFlag}`,
+                pw: `fill ${pwArgs} ${q(val)}`,
                 js: `await ${jsLoc}.fill(${escapeString(val)});`,
             };
         }

--- a/packages/extension/src/content/recorder.ts
+++ b/packages/extension/src/content/recorder.ts
@@ -101,17 +101,7 @@ export function onKeyDownCapture(e: KeyboardEvent) {
 
     const target = e.target as Element;
 
-    // Enter during fill → submit variant
-    if (e.key === 'Enter' && pendingFill) {
-        const cmds = buildCommands('fill', pendingFill.el, { value: pendingFill.value, submit: true });
-        if (cmds) {
-            chrome.runtime.sendMessage({ type: 'recorded-fill-submit', action: cmds });
-        }
-        flushPendingFill();
-        return;
-    }
-
-    // Other special key → flush fill, emit press
+    // Any special key during fill → flush fill, then fall through to emit press
     flushPendingFill();
 
     const cmds = target && target !== document.body && target !== document.documentElement

--- a/packages/extension/src/panel/components/Toolbar.tsx
+++ b/packages/extension/src/panel/components/Toolbar.tsx
@@ -235,7 +235,7 @@ function Toolbar({ editorContent, editorMode, stepLine, attachedUrl, attachedTab
             if (msg.type === 'recorded-action') {
                 editorRef.current?.insertAtCursor(editorMode === 'pw' ? msg.action.pw : msg.action.js);
             }
-            if (msg.type === 'recorded-fill-update' || msg.type === 'recorded-fill-submit') {
+            if (msg.type === 'recorded-fill-update') {
                 editorRef.current?.replaceLastInsert(editorMode === 'pw' ? msg.action.pw : msg.action.js);
             }
         };

--- a/packages/extension/test/content/locator.test.ts
+++ b/packages/extension/test/content/locator.test.ts
@@ -546,11 +546,11 @@ describe('locator', () => {
             expect(cmds!.js).toContain(".fill('test@example.com')");
         });
 
-        it('builds fill with --submit flag', () => {
+        it('builds fill without --submit flag', () => {
             document.body.innerHTML = '<label for="q">Search</label><input id="q" type="text">';
             const input = document.querySelector('input')!;
-            const cmds = buildCommands('fill', input, { value: 'query', submit: true });
-            expect(cmds!.pw).toContain('--submit');
+            const cmds = buildCommands('fill', input, { value: 'query' });
+            expect(cmds!.pw).not.toContain('--submit');
         });
 
         it('builds fill with empty value', () => {

--- a/packages/extension/test/content/recorder.test.ts
+++ b/packages/extension/test/content/recorder.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import {
     SPECIAL_KEYS,
+    pendingFill,
     flushPendingFill,
     onClickCapture,
     onInputCapture,
@@ -244,7 +245,7 @@ describe('recorder', () => {
             );
         });
 
-        it('sends fill-submit on Enter during pending fill', () => {
+        it('sends press Enter as separate action after flushing pending fill', () => {
             document.body.innerHTML = '<label for="q">Query</label><input id="q" type="text" value="test">';
             const input = document.querySelector('input')!;
 
@@ -254,13 +255,14 @@ describe('recorder', () => {
             onInputCapture(inputEvent);
             vi.mocked(chrome.runtime.sendMessage).mockClear();
 
-            // Then Enter
+            // Then Enter — should flush fill and emit separate press Enter
             const enterEvent = new KeyboardEvent('keydown', { key: 'Enter', bubbles: true });
             Object.defineProperty(enterEvent, 'target', { value: input });
             onKeyDownCapture(enterEvent);
             expect(chrome.runtime.sendMessage).toHaveBeenCalledWith(
-                expect.objectContaining({ type: 'recorded-fill-submit' })
+                expect.objectContaining({ type: 'recorded-action' })
             );
+            expect(pendingFill).toBeNull();
         });
     });
 


### PR DESCRIPTION
## Summary
- The `--submit` flag on fill commands was silently ignored during replay since Playwright's `fill()` has no submit option
- Enter during a pending fill now flushes the fill and emits a separate `press Enter` command, which actually works on replay
- Removed the `submit` option from `buildCommands()` and `recorded-fill-submit` message type

**Before:** `fill "What needs to be done?" "reading" --submit` (Enter lost on replay)
**After:** `fill "What needs to be done?" "reading"` + `press "What needs to be done?" Enter` (works on replay)

## Test plan
- [x] All 605 tests pass
- [ ] Record on TodoMVC: fill + Enter produces separate fill and press Enter lines
- [ ] Replay recorded script: todos are actually submitted

🤖 Generated with [Claude Code](https://claude.com/claude-code)