### PR TITLE
fix: auto-stop recording when run/debug starts

### DIFF
--- a/packages/extension/src/panel/components/Toolbar.tsx
+++ b/packages/extension/src/panel/components/Toolbar.tsx
@@ -243,6 +243,14 @@ function Toolbar({ editorContent, editorMode, stepLine, attachedUrl, attachedTab
         return () => chrome.runtime.onMessage.removeListener(listener);
     }, [editorMode]);
 
+    // Auto-stop recording when run/debug starts
+    useEffect(() => {
+        if (isRunning && isRecording) {
+            setIsRecording(false);
+            chrome.runtime.sendMessage({ type: 'record-stop' }).catch(() => {});
+        }
+    }, [isRunning]);
+
     async function handleRecord() {
         if (!chrome.tabs?.query) return;
 
@@ -355,7 +363,7 @@ function Toolbar({ editorContent, editorMode, stepLine, attachedUrl, attachedTab
                     data-testid="record-btn"
                     className={isRecording ? 'recording' : ''}
                     title={isRecording ? "Stop recording" : "Start Recording"}
-                    disabled={isPicking}
+                    disabled={isPicking || isRunning}
                     onClick={handleRecord}
                 >
                     {isRecording ? <StopIcon /> : <RecordIcon />}


### PR DESCRIPTION
## Summary
- Auto-stop recording when Run or Debug is clicked (useEffect watching `isRunning`)
- Disable Record button while a script is running

Closes #234

## Test plan
- [x] Start recording → click Run → recording stops, script runs
- [x] Start recording → click Debug → recording stops, debug starts
- [x] Start running → Record button is disabled
- [x] Run finishes → Record button re-enables

🤖 Generated with [Claude Code](https://claude.com/claude-code)