### PR TITLE
fix: skip noise keys in recorder (Backspace, Tab, arrows)

### DIFF
--- a/packages/extension/src/content/recorder.ts
+++ b/packages/extension/src/content/recorder.ts
@@ -113,6 +113,13 @@ export function onKeyDownCapture(e: KeyboardEvent) {
 
     const target = e.target as Element;
 
+    // Tab changes focus but is navigation noise — flush fill, don't emit
+    if (e.key === 'Tab') { flushPendingFill(); return; }
+
+    // Inside a text field, only Enter is a meaningful action —
+    // everything else (Backspace, arrows, etc.) is editing noise
+    if (e.key !== 'Enter' && target && isTextField(target)) return;
+
     // Any special key during fill → flush fill, then fall through to emit press
     flushPendingFill();
 


### PR DESCRIPTION
## Summary
- Tab: flush pending fill but never emit `press Tab` (navigation noise across all elements)
- In text fields: only emit `press Enter`, skip all other special keys (Backspace, Delete, arrows are editing noise — `input` event captures value changes as fill updates)

Closes #238

## Test plan
- [x] Type in text field, press Backspace → fill value updates live, no `press Backspace` line
- [x] Press Tab on any element → no `press Tab` recorded, focus moves normally
- [x] Press Enter in text field → `press Enter` recorded correctly
- [x] Click, check, select actions unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)