### PR TITLE
feat: ancestor context disambiguation for recorder

### DIFF
--- a/packages/extension/src/content/locator.ts
+++ b/packages/extension/src/content/locator.ts
@@ -28,8 +28,12 @@ export const IMPLICIT_ROLES: Record<string, string | ((el: Element) => string | 
     UL: 'list', OL: 'list',
     LI: 'listitem',
     TABLE: 'table',
+    TR: 'row',
+    TH: 'columnheader',
+    TD: 'cell',
     FORM: 'form',
     DIALOG: 'dialog',
+    ARTICLE: 'article',
 };
 
 export function getImplicitRole(el: Element): string | null {
@@ -97,6 +101,74 @@ export function getLabel(el: HTMLInputElement | HTMLTextAreaElement | HTMLSelect
         if (text) return text;
     }
     return '';
+}
+
+// ─── Ancestor context disambiguation ─────────────────────────────────────
+
+/** Container roles suitable for ancestor-context disambiguation. */
+const CONTAINER_ROLES = new Set(['listitem', 'row', 'article', 'group']);
+
+/**
+ * Find distinctive text in an ancestor that doesn't come from the excluded element's subtree.
+ * Returns text from the first child subtree that doesn't contain the excluded element,
+ * recursing into wrappers that do contain it. This ensures the returned text is a
+ * contiguous substring of the ancestor's full textContent (needed for hasText matching).
+ */
+function getContextText(ancestor: Element, exclude: Element): string {
+    function findText(node: Node): string {
+        for (const child of node.childNodes) {
+            if (child === exclude) continue;
+            if (child.nodeType === Node.ELEMENT_NODE && (child as Element).contains(exclude)) {
+                // This subtree contains the target — recurse to find non-target siblings
+                const inner = findText(child);
+                if (inner) return inner;
+                continue;
+            }
+            const text = (child.textContent || '').trim();
+            if (text && text.length <= 50) return text;
+        }
+        return '';
+    }
+    return findText(ancestor);
+}
+
+/** Walk up from el to find nearest ancestor with a container role. */
+function findContainerAncestor(el: Element): { ancestor: Element; role: string } | null {
+    let current = el.parentElement;
+    while (current && current !== document.body && current !== document.documentElement) {
+        const role = getImplicitRole(current);
+        if (role && CONTAINER_ROLES.has(role)) return { ancestor: current, role };
+        current = current.parentElement;
+    }
+    return null;
+}
+
+/**
+ * Try to disambiguate using ancestor context.
+ * Returns a chained locator like:
+ *   getByRole('listitem').filter({ hasText: 'reading' }).getByRole('button', { name: 'Delete' })
+ * or null if ancestor context doesn't produce a unique result.
+ */
+function tryAncestorContext(el: Element, role: string, name: string, matches: Element[]): string | null {
+    const container = findContainerAncestor(el);
+    if (!container) return null;
+
+    const contextText = getContextText(container.ancestor, el);
+    if (!contextText || contextText.length > 50) return null;
+
+    // Verify uniqueness: only one match's container ancestor should contain this text
+    let count = 0;
+    for (const match of matches) {
+        const mc = findContainerAncestor(match);
+        if (!mc || mc.role !== container.role) continue;
+        if ((mc.ancestor.textContent || '').includes(contextText)) {
+            count++;
+            if (count > 1) return null;
+        }
+    }
+    if (count !== 1) return null;
+
+    return `getByRole(${escapeString(container.role)}).filter({ hasText: ${escapeString(contextText)} }).getByRole(${escapeString(role)}, { name: ${escapeString(name)} })`;
 }
 
 // ─── Locator disambiguation ─────────────────────────────────────────────
@@ -211,7 +283,10 @@ export function generateLocator(el: Element): string {
         // Disambiguate when multiple elements share same role + name
         const matches = findByRoleAndName(role, name);
         if (matches.length > 1) {
-            // exact: true so Playwright matches same elements as our exact comparison
+            // Try ancestor context first (readable chained locators)
+            const ancestorLocator = tryAncestorContext(el, role, name, matches);
+            if (ancestorLocator) return ancestorLocator;
+            // Fallback to nth-based disambiguation
             const base = `getByRole(${escapeString(role)}, { name: ${escapeString(name)}, exact: true })`;
             const idx = matches.indexOf(el);
             return idx === 0 ? base + '.first()' : base + `.nth(${idx})`;
@@ -249,6 +324,24 @@ export function generateLocator(el: Element): string {
     return `locator(${escapeString(buildCssSelector(el))})`;
 }
 
+/**
+ * Generate separate JS and PW locators.
+ * JS uses ancestor context when available; PW always uses .nth() (no --in flag yet).
+ */
+export function generateLocatorPair(el: Element): { js: string; pw: string } {
+    const jsLocator = generateLocator(el);
+    if (!jsLocator.includes('.filter(')) return { js: jsLocator, pw: jsLocator };
+
+    // JS used ancestor context — generate a .nth() locator for PW
+    const role = getImplicitRole(el)!;
+    const name = getAccessibleName(el);
+    const matches = findByRoleAndName(role, name);
+    const base = `getByRole(${escapeString(role)}, { name: ${escapeString(name)}, exact: true })`;
+    const idx = matches.indexOf(el);
+    const pwLocator = idx === 0 ? base + '.first()' : base + `.nth(${idx})`;
+    return { js: jsLocator, pw: pwLocator };
+}
+
 // ─── Element classification ─────────────────────────────────────────────
 
 /** Check if element is a text-entry field */
@@ -277,9 +370,9 @@ export function buildCommands(action: string, el: Element, opts?: {
     checked?: boolean;
     option?: string;
 }): { pw: string; js: string } | null {
-    const locator = generateLocator(el);
-    const jsLoc = `page.${locator}`;
-    const pwArgs = locatorToPwArgs(locator);
+    const { js: jsLocator, pw: pwLocator } = generateLocatorPair(el);
+    const jsLoc = `page.${jsLocator}`;
+    const pwArgs = locatorToPwArgs(pwLocator);
     const q = (s: string) => `"${s}"`;
 
     switch (action) {

--- a/packages/extension/test/content/locator.test.ts
+++ b/packages/extension/test/content/locator.test.ts
@@ -9,6 +9,7 @@ import {
     locatorToPwArgs,
     escapeString,
     generateLocator,
+    generateLocatorPair,
     buildCssSelector,
     isTextField,
     isCheckable,
@@ -399,6 +400,142 @@ describe('locator', () => {
         });
     });
 
+    // ─── ancestor context disambiguation ────────────────────────────────────
+
+    describe('ancestor context disambiguation', () => {
+        it('uses ancestor listitem context instead of .nth()', () => {
+            document.body.innerHTML = `
+                <ul>
+                    <li><span>reading</span><button>Delete</button></li>
+                    <li><span>shopping</span><button>Delete</button></li>
+                    <li><span>learning</span><button>Delete</button></li>
+                </ul>`;
+            const buttons = document.querySelectorAll('button');
+            expect(generateLocator(buttons[0])).toBe(
+                "getByRole('listitem').filter({ hasText: 'reading' }).getByRole('button', { name: 'Delete' })"
+            );
+            expect(generateLocator(buttons[1])).toBe(
+                "getByRole('listitem').filter({ hasText: 'shopping' }).getByRole('button', { name: 'Delete' })"
+            );
+            expect(generateLocator(buttons[2])).toBe(
+                "getByRole('listitem').filter({ hasText: 'learning' }).getByRole('button', { name: 'Delete' })"
+            );
+        });
+
+        it('falls back to .nth() when ancestor text is not unique', () => {
+            document.body.innerHTML = `
+                <ul>
+                    <li><span>same</span><button>Delete</button></li>
+                    <li><span>same</span><button>Delete</button></li>
+                </ul>`;
+            const buttons = document.querySelectorAll('button');
+            expect(generateLocator(buttons[0])).toContain('.first()');
+            expect(generateLocator(buttons[1])).toContain('.nth(1)');
+        });
+
+        it('falls back to .nth() when no container ancestor exists', () => {
+            document.body.innerHTML = '<button>Save</button><button>Save</button>';
+            const buttons = document.querySelectorAll('button');
+            expect(generateLocator(buttons[0])).toContain('.first()');
+            expect(generateLocator(buttons[1])).toContain('.nth(1)');
+        });
+
+        it('falls back to .nth() when context text is empty', () => {
+            document.body.innerHTML = `
+                <ul>
+                    <li><button>Delete</button></li>
+                    <li><button>Delete</button></li>
+                </ul>`;
+            const buttons = document.querySelectorAll('button');
+            expect(generateLocator(buttons[0])).toContain('.first()');
+            expect(generateLocator(buttons[1])).toContain('.nth(1)');
+        });
+
+        it('falls back to .nth() when context text is too long', () => {
+            const longText = 'x'.repeat(51);
+            document.body.innerHTML = `
+                <ul>
+                    <li><span>${longText}</span><button>Delete</button></li>
+                    <li><span>short</span><button>Delete</button></li>
+                </ul>`;
+            const buttons = document.querySelectorAll('button');
+            expect(generateLocator(buttons[0])).toContain('.first()');
+        });
+
+        it('works with article container role', () => {
+            document.body.innerHTML = `
+                <article><h2>Post A</h2><button>Like</button></article>
+                <article><h2>Post B</h2><button>Like</button></article>`;
+            const buttons = document.querySelectorAll('button');
+            expect(generateLocator(buttons[0])).toContain("filter({ hasText: 'Post A' })");
+            expect(generateLocator(buttons[1])).toContain("filter({ hasText: 'Post B' })");
+        });
+
+        it('works with table row container role', () => {
+            document.body.innerHTML = `
+                <table>
+                    <tr><td>Alice</td><td><button>Edit</button></td></tr>
+                    <tr><td>Bob</td><td><button>Edit</button></td></tr>
+                    <tr><td>Carol</td><td><button>Edit</button></td></tr>
+                </table>`;
+            const buttons = document.querySelectorAll('button');
+            expect(generateLocator(buttons[0])).toBe(
+                "getByRole('row').filter({ hasText: 'Alice' }).getByRole('button', { name: 'Edit' })"
+            );
+            expect(generateLocator(buttons[1])).toBe(
+                "getByRole('row').filter({ hasText: 'Bob' }).getByRole('button', { name: 'Edit' })"
+            );
+            expect(generateLocator(buttons[2])).toBe(
+                "getByRole('row').filter({ hasText: 'Carol' }).getByRole('button', { name: 'Edit' })"
+            );
+        });
+
+        it('works with multi-column table rows with multiple buttons', () => {
+            document.body.innerHTML = `
+                <table>
+                    <tr><td>Alice</td><td>alice@example.com</td><td><button>Edit</button> <button>Delete</button></td></tr>
+                    <tr><td>Bob</td><td>bob@example.com</td><td><button>Edit</button> <button>Delete</button></td></tr>
+                    <tr><td>Carol</td><td>carol@example.com</td><td><button>Edit</button> <button>Delete</button></td></tr>
+                </table>`;
+            const editButtons = [...document.querySelectorAll('button')].filter(b => b.textContent === 'Edit');
+            const deleteButtons = [...document.querySelectorAll('button')].filter(b => b.textContent === 'Delete');
+            expect(generateLocator(editButtons[0])).toBe(
+                "getByRole('row').filter({ hasText: 'Alice' }).getByRole('button', { name: 'Edit' })"
+            );
+            expect(generateLocator(editButtons[2])).toBe(
+                "getByRole('row').filter({ hasText: 'Carol' }).getByRole('button', { name: 'Edit' })"
+            );
+            expect(generateLocator(deleteButtons[1])).toBe(
+                "getByRole('row').filter({ hasText: 'Bob' }).getByRole('button', { name: 'Delete' })"
+            );
+        });
+    });
+
+    // ─── generateLocatorPair ──────────────────────────────────────────────
+
+    describe('generateLocatorPair', () => {
+        it('returns same locator for both modes when no disambiguation needed', () => {
+            document.body.innerHTML = '<button>Submit</button>';
+            const btn = document.querySelector('button')!;
+            const pair = generateLocatorPair(btn);
+            expect(pair.js).toBe(pair.pw);
+            expect(pair.js).toBe("getByRole('button', { name: 'Submit' })");
+        });
+
+        it('returns ancestor context for JS and .nth() for PW', () => {
+            document.body.innerHTML = `
+                <ul>
+                    <li><span>reading</span><button>Delete</button></li>
+                    <li><span>shopping</span><button>Delete</button></li>
+                </ul>`;
+            const buttons = document.querySelectorAll('button');
+            const pair = generateLocatorPair(buttons[1]);
+            expect(pair.js).toContain('.filter(');
+            expect(pair.js).toContain('shopping');
+            expect(pair.pw).toContain('.nth(1)');
+        });
+    });
+
     // ─── locatorToPwArgs ───────────────────────────────────────────────────
 
     describe('locatorToPwArgs', () => {
@@ -665,6 +802,19 @@ describe('locator', () => {
         it('returns null for unknown action', () => {
             const el = document.createElement('div');
             expect(buildCommands('unknown', el)).toBeNull();
+        });
+
+        it('uses ancestor context in JS and .nth() in PW for click', () => {
+            document.body.innerHTML = `
+                <ul>
+                    <li><span>reading</span><button>Delete</button></li>
+                    <li><span>shopping</span><button>Delete</button></li>
+                </ul>`;
+            const buttons = document.querySelectorAll('button');
+            const cmds = buildCommands('click', buttons[1]);
+            expect(cmds!.js).toContain(".filter({ hasText: 'shopping' })");
+            expect(cmds!.js).toContain('.click()');
+            expect(cmds!.pw).toContain('--nth 1');
         });
     });
 


### PR DESCRIPTION
## Summary
- When multiple visible elements share the same role+name, uses ancestor container context (listitem, row, article, group) to generate readable chained locators instead of `.nth()` indexes
- JS mode generates `getByRole('listitem').filter({ hasText: 'reading' }).getByRole('button', { name: 'Delete' })` 
- PW mode stays with `.nth()` (no `--in` flag in engine yet)
- Added `ARTICLE` to implicit roles map

## Test plan
- [x] 10 new unit tests (ancestor context, generateLocatorPair, buildCommands)
- [x] All 619 tests pass
- [x] Manual test: TodoMVC checkboxes produce `.filter({ hasText })` chains in JS mode

Closes #187

🤖 Generated with [Claude Code](https://claude.com/claude-code)