### PR TITLE
fix: e2e test — JS mode has debug button, not step button

### DIFF
--- a/packages/extension/e2e/panel/panel.spec.ts
+++ b/packages/extension/e2e/panel/panel.spec.ts
@@ -403,10 +403,10 @@ test.describe("Panel page test", () => {
     await expect(toggle.getByText('.pw')).not.toHaveAttribute('data-active');
   });
 
-  test('step button is enabled in JS mode (starts debug session)', async ({ panelPage }) => {
+  test('debug button is enabled in JS mode', async ({ panelPage }) => {
     await fillEditor(panelPage, 'goto https://example.com');
     await panelPage.getByTestId('mode-toggle').getByText('JS').click(); // pw → js
-    await expect(panelPage.locator('#step-btn')).toBeEnabled();
+    await expect(panelPage.getByTestId('debug-btn')).toBeEnabled();
   });
 
   test('step button is enabled when switching back to pw mode', async ({ panelPage }) => {


### PR DESCRIPTION
## Summary
- The step button (`#step-btn`) is only rendered in PW mode
- JS mode shows a debug button (`#debug-btn`) instead, added in #220
- The E2E test was never updated to match, causing flaky CI failures since #220

## Test plan
- [x] Fix changes `#step-btn` → `debug-btn` in the JS mode test assertion
- [x] Existing test for switching back to PW mode still checks `#step-btn` (correct)

🤖 Generated with [Claude Code](https://claude.com/claude-code)