### PR TITLE
chore: release v0.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## v0.18.0 — Stability & Recording
+
+**2026-03-17**
+
+### Features
+
+- **Ancestor context disambiguation**: Recorder and PW mode now use ancestor context to disambiguate ambiguous locators (e.g. `click "Save" --in "Settings"`). ([#187](https://github.com/stevez/playwright-repl/issues/187), [#240](https://github.com/stevez/playwright-repl/pull/240), [#243](https://github.com/stevez/playwright-repl/pull/243))
+- **Inline variable values**: Debug mode shows inline variable values on the paused line. ([#224](https://github.com/stevez/playwright-repl/issues/224), [#231](https://github.com/stevez/playwright-repl/pull/231))
+
+### Fixes
+
+- **Tab close stability**: Added `chrome.tabs.onRemoved` listener to clear stale `currentPage` when a tab is closed. ([#247](https://github.com/stevez/playwright-repl/issues/247), [#249](https://github.com/stevez/playwright-repl/pull/249))
+- **Stale page recovery**: Commands that hit `TargetClosedError` now auto-reattach and retry. ([#247](https://github.com/stevez/playwright-repl/issues/247), [#249](https://github.com/stevez/playwright-repl/pull/249))
+- **Command serialization**: Bridge commands now execute sequentially via a promise queue, preventing concurrent race conditions. ([#248](https://github.com/stevez/playwright-repl/issues/248), [#249](https://github.com/stevez/playwright-repl/pull/249))
+- **Attach reliability**: Fixed attach failing after tab switching by using `playwright-crx` 0.15.2. ([#242](https://github.com/stevez/playwright-repl/issues/242), [#245](https://github.com/stevez/playwright-repl/pull/245))
+- **Auto-stop recording**: Recording now auto-stops when run/debug starts. ([#234](https://github.com/stevez/playwright-repl/issues/234), [#237](https://github.com/stevez/playwright-repl/pull/237))
+- **Record hover before click**: Hover is now recorded before click on hover-revealed elements. ([#235](https://github.com/stevez/playwright-repl/pull/235))
+- **Record Enter as press command**: Enter is now recorded as a separate `press Enter` instead of `--submit` flag. ([#232](https://github.com/stevez/playwright-repl/pull/232))
+- **Skip noise keys in recorder**: Backspace, Tab, arrows, and other noise keys are no longer recorded. ([#239](https://github.com/stevez/playwright-repl/pull/239))
+
+---
+
 ## v0.17.0 — JS Debugger
 
 **2026-03-16**

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "playwright-repl",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "description": "Interactive REPL for Playwright browser automation — keyword-driven testing from your terminal",
   "type": "module",
   "bin": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@playwright-repl/core",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "type": "module",
   "main": "./dist/index.js",
   "exports": {

--- a/packages/extension/README.md
+++ b/packages/extension/README.md
@@ -6,7 +6,8 @@ Chrome side panel extension that runs the full Playwright API directly inside yo
 |---------|-------------|
 | 🧠 **Mode Detection** | Console auto-detects input type — `.pw` keyword or Playwright API / JavaScript (`await page.*`, `1 + 1`) — no prefix needed |
 | 🎬 **Record** | Capture clicks, fills, and navigations — generates `.pw` commands and JS Playwright code, inserted into the editor live |
-| ▶ **Run / Step Into** | Run scripts line-by-line with pass/fail gutter indicators; step debugger pauses at each line |
+| ▶ **Run** | Run scripts line-by-line with pass/fail gutter indicators |
+| 🐛 **Debug** | Step Over / Step Into / Step Out / Continue with breakpoints, inline variable values, and a Variables tab showing scope variables |
 | 📂 **Load / Save** | Open `.pw` or `.js` files from disk; save editor content with one click |
 | 🔗 **Auto-attach** | Automatically attaches to the active tab when the panel opens |
 | 🗂 **Tab Switcher** | Switch the active browser target to any open tab from the toolbar dropdown |
@@ -93,16 +94,18 @@ Write and run multi-line `.pw` scripts or JavaScript (Playwright API, DOM) direc
 - **Auto-closing brackets** — parentheses, brackets, and quotes close automatically
 - **Pass/fail gutter** — ✓/✗ markers per line after execution
 - **Run / Step / Stop** — run all lines, step through one at a time, or abort
-- **JS step debugger** — pauses at each line, resumes on Step
+- **JS step debugger** — pauses at each line with inline variable values, resumes on Step
 - **Open / Save** — load `.pw` or `.js` files from disk; save with timestamp filename
 - **Ctrl+Enter** — run the script from keyboard
 
 ### Recording
 
-Click **Record**, interact with the page — clicks, fills, and navigations are captured automatically and inserted into the editor at the cursor in two formats:
+Click **Record**, interact with the page — clicks, hovers, fills, and navigations are captured automatically and inserted into the editor at the cursor in two formats:
 
 - **`.pw` commands** — `goto`, `click`, `fill`, `press` — ready to replay with the CLI or extension
 - **JS Playwright code** — `await page.click(...)` — ready to paste into a Playwright test
+
+Ambiguous elements are automatically disambiguated with ancestor context (e.g. `click "Save" --in "Settings"`).
 
 > Recording captures only human interactions — not AI-driven or programmatic commands.
 

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@playwright-repl/extension",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "private": true,
   "description": "Chrome DevTools panel extension for Playwright REPL",
   "type": "module",

--- a/packages/extension/public/manifest.json
+++ b/packages/extension/public/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Dramaturg",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "description": "Playwright engineer's companion — console, editor, runner, and recorder in a Chrome side panel.",
   "permissions": [
     "activeTab",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@playwright-repl/mcp",
-    "version": "0.17.0",
+    "version": "0.18.0",
     "type": "module",
     "bin": {
         "playwright-repl-mcp": "./dist/index.js"


### PR DESCRIPTION
## Summary
- Bump version to 0.18.0 across all packages (core, cli, extension, mcp) + manifest.json
- Add v0.18.0 changelog entry — "Stability & Recording" (2 features, 8 fixes)
- Update extension README with debug feature, inline variable values, hover recording, ancestor context disambiguation

## Changes since v0.17.0
### Features
- Ancestor context disambiguation for recorder and PW mode (#240, #243)
- Inline variable values on paused line during debug (#231)

### Fixes
- Tab close stability — `chrome.tabs.onRemoved` listener (#247, #249)
- Stale page recovery — `TargetClosedError` auto-reattach (#247, #249)
- Command serialization — promise queue (#248, #249)
- Attach reliability after tab switching (#242, #245)
- Auto-stop recording when run/debug starts (#237)
- Record hover before click (#235)
- Record Enter as separate press command (#232)
- Skip noise keys in recorder (#239)

🤖 Generated with [Claude Code](https://claude.com/claude-code)