### PR TITLE
fix: exclude popup window from tab switcher dropdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## v0.18.1
+
+**2026-03-17**
+
+### Fixes
+
+- **Popup tab filter**: Tab switcher dropdown no longer shows the extension's own popup window URL. ([#251](https://github.com/stevez/playwright-repl/pull/251))
+
+---
+
 ## v0.18.0 — Stability & Recording
 
 **2026-03-17**

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "playwright-repl",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "description": "Interactive REPL for Playwright browser automation — keyword-driven testing from your terminal",
   "type": "module",
   "bin": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@playwright-repl/core",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "type": "module",
   "main": "./dist/index.js",
   "exports": {

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@playwright-repl/extension",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "private": true,
   "description": "Chrome DevTools panel extension for Playwright REPL",
   "type": "module",

--- a/packages/extension/public/manifest.json
+++ b/packages/extension/public/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Dramaturg",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "description": "Playwright engineer's companion — console, editor, runner, and recorder in a Chrome side panel.",
   "permissions": [
     "activeTab",

--- a/packages/extension/src/panel/components/Toolbar.tsx
+++ b/packages/extension/src/panel/components/Toolbar.tsx
@@ -45,9 +45,11 @@ function Toolbar({ editorContent, editorMode, stepLine, attachedUrl, attachedTab
     async function loadTabs() {
         if (!chrome.tabs?.query) return;
         const tabs = await chrome.tabs.query({});
-        // Keep chrome:// tabs (to preserve tab order) but exclude chrome-extension:// and about: tabs
+        // Keep chrome:// tabs (to preserve tab order) but exclude other extensions' and about: tabs.
+        // Allow our own extension pages (newtab) but exclude the panel/popup itself.
         const ownOrigin = `chrome-extension://${chrome.runtime.id}/`;
-        setAvailableTabs(tabs.filter(t => t?.url && !t.url.startsWith('about:') && (!t.url.startsWith('chrome-extension://') || t.url.startsWith(ownOrigin))));
+        const panelUrl = `${ownOrigin}panel/panel.html`;
+        setAvailableTabs(tabs.filter(t => t?.url && !t.url.startsWith('about:') && !t.url.startsWith(panelUrl) && (!t.url.startsWith('chrome-extension://') || t.url.startsWith(ownOrigin))));
     }
 
     async function checkActiveTab() {

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@playwright-repl/mcp",
-    "version": "0.18.0",
+    "version": "0.18.1",
     "type": "module",
     "bin": {
         "playwright-repl-mcp": "./dist/index.js"


### PR DESCRIPTION
## Summary
- Tab switcher dropdown no longer shows the extension's own popup window (`chrome-extension://.../panel/panel.html`) in popup mode
- Bumps version to 0.18.1

## Test plan
- [x] Open extension in popup mode
- [ ] Verify popup URL does not appear in tab dropdown
- [ ] Verify newtab page still appears in dropdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)