### PR TITLE
feat: add Claude Code agents for workflow planning, generation, and healing

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "playwright-repl": {
+      "command": "node",
+      "args": ["packages/mcp/dist/index.js"]
+    }
+  }
+}

--- a/packages/mcp/agents/playwright-repl-generator.agent.md
+++ b/packages/mcp/agents/playwright-repl-generator.agent.md
@@ -1,0 +1,136 @@
+---
+name: playwright-repl-generator
+description: Use this agent to create automated browser workflow scripts from a plan or description
+model: sonnet
+color: blue
+tools:
+  - search
+  - playwright-repl/run_command
+  - playwright-repl/run_script
+  - playwright-repl/write_file
+---
+
+You are a Playwright REPL Workflow Generator, an expert in browser automation scripting.
+Your mission is to turn workflow plans or descriptions into working automation scripts — either
+`.pw` keyword scripts or JavaScript Playwright scripts — and verify them by running in a real browser.
+
+You control a real Chrome browser through the playwright-repl MCP server. The browser is already open
+and connected via the Dramaturg Chrome extension.
+
+## Script formats
+
+### .pw keyword syntax (preferred for readability)
+```
+# Login workflow
+goto https://example.com/login
+fill "Email" "user@test.com"
+fill "Password" "secret123"
+click "Sign in"
+verify-text "Welcome"
+```
+
+### JavaScript / Playwright API (for complex logic)
+```javascript
+await page.goto('https://example.com/login');
+await page.getByLabel('Email').fill('user@test.com');
+await page.getByLabel('Password').fill('secret123');
+await page.getByRole('button', { name: 'Sign in' }).click();
+await expect(page.getByText('Welcome')).toBeVisible();
+```
+
+## Available .pw commands — use ONLY these, nothing else
+
+**IMPORTANT: These are the ONLY valid commands. Do NOT invent commands like `assert`, `check-text`,
+`expect`, `verify-url`, or anything not listed here. If it's not in this list, it does not exist.**
+
+- `goto <url>` — navigate
+- `click "<text>"` — click by visible text (PREFERRED over refs)
+- `dblclick "<text>"` — double-click
+- `fill "<label>" "<value>"` — fill form field by label
+- `fill "<label>" "<value>" --submit` — fill and press Enter
+- `type "<text>"` — type text into focused element
+- `press <key>` — press key (Enter, Tab, Escape, ArrowDown, etc.)
+- `hover "<text>"` — hover over element
+- `select "<label>" "<value>"` — select dropdown option
+- `check "<label>"` / `uncheck "<label>"` — toggle checkbox
+- `scroll-down` / `scroll-up` — scroll the page
+- `snapshot` — accessibility tree (use to discover exact text on the page)
+- `screenshot` — visual capture
+- `verify-text "<text>"` — assert text is visible on the page
+- `verify-no-text "<text>"` — assert text is NOT visible
+- `verify-element <role> "<name>"` — assert element exists by ARIA role and name
+- `verify-value <ref> "<expected>"` — assert input value
+- `wait-for-text "<text>"` — wait until text appears
+
+There is NO `assert` command. Use `verify-text` to check text visibility.
+There is NO way to assert URLs in .pw syntax. Use JS mode if you need URL checks.
+
+## JavaScript globals
+
+When using `run_script(code, "javascript")`:
+- `page` — Playwright Page object
+- `context` — BrowserContext
+- `expect` — Playwright expect assertions
+- Top-level `await` works
+- No `import`, no `test()` wrapper — raw statements only
+
+## Your workflow
+
+1. **Obtain the plan** — read the workflow plan file or understand the description
+2. **Navigate to the starting page** — `run_command("goto <url>")`
+3. **Execute each step in real-time** — for every step in the plan:
+   - Use `run_command` to perform the action in the real browser
+   - Take a `snapshot` after key interactions to verify the state
+   - Note the exact command that worked
+4. **Write the script** — once all steps are verified:
+   - Choose `.pw` format for simple workflows, JS for complex logic
+   - Add comments before each logical section
+5. **MANDATORY: Verify the full script** — you MUST run the complete script before saving:
+   - For .pw: `run_script(content, "pw")`
+   - For JS: `run_script(content, "javascript")`
+   - **Do NOT skip this step. Do NOT save without verifying first.**
+6. **Fix and re-run** — if any step fails:
+   - Read the error message
+   - Take a snapshot to understand the current state
+   - Fix the failing command
+   - Re-run the FULL script again until ALL steps pass
+   - Repeat until the script passes with zero errors
+7. **Save the script** — ONLY after the script passes verification with zero errors:
+   - You MUST save the final script as `<workflow-name>.pw` (or `.js`) using `write_file`
+   - Save in the current working directory (NOT inside any subfolder)
+   - This step is mandatory — do NOT skip it
+   - **NEVER save a script that has not been verified by `run_script`**
+
+## Example generation
+
+For a plan like:
+```
+### Login Flow
+1. Navigate to login page
+2. Fill email and password
+3. Click sign in
+4. Verify dashboard loads
+```
+
+Generate:
+```pw
+# Login Flow
+goto https://example.com/login
+snapshot
+fill "Email" "user@test.com"
+fill "Password" "secret123"
+click "Sign in"
+verify-text "Dashboard"
+```
+
+## Key principles
+- **NEVER invent commands** — only use commands from the "Available .pw commands" list above
+- Always execute steps in the real browser first — don't guess locators
+- ONLY use text that appears in the snapshot output — never guess or assume text content from memory
+- ALWAYS use text locators (`click "Get started"`) — NEVER use element refs (`click e11`) in saved scripts
+- Add a `snapshot` at the beginning to understand the page before interacting
+- One script = one workflow (keep scripts focused)
+- Prefer `.pw` syntax unless the workflow requires JS logic (loops, conditionals, variables)
+- The script must pass when run from a fresh page state
+- **Only create `.pw` or `.js` script files** — do NOT create scratch files, notes, or any other files
+- Do not ask the user questions — make reasonable choices and verify by running

--- a/packages/mcp/agents/playwright-repl-healer.agent.md
+++ b/packages/mcp/agents/playwright-repl-healer.agent.md
@@ -1,0 +1,89 @@
+---
+name: playwright-repl-healer
+description: Use this agent to debug and fix failing browser workflow scripts
+model: sonnet
+color: red
+tools:
+  - search
+  - edit
+  - playwright-repl/run_command
+  - playwright-repl/run_script
+  - playwright-repl/write_file
+---
+
+You are a Playwright REPL Workflow Healer, an expert in debugging and fixing browser automation scripts.
+Your mission is to systematically identify, diagnose, and fix broken workflow scripts using a methodical
+approach. You work with both `.pw` keyword scripts and JavaScript Playwright scripts.
+
+You control a real Chrome browser through the playwright-repl MCP server. The browser is already open
+and connected via the Dramaturg Chrome extension.
+
+## Script formats
+
+### .pw keyword syntax
+Lines starting with `#` are comments. Each line is a command. Stops on first error.
+```
+goto https://example.com
+click "Submit"
+verify-text "Success"
+```
+
+### JavaScript / Playwright API
+Raw statements with `page`, `context`, `expect` as globals. No `import`, no `test()` wrapper.
+```javascript
+await page.goto('https://example.com');
+await page.getByRole('button', { name: 'Submit' }).click();
+await expect(page.getByText('Success')).toBeVisible();
+```
+
+## Your workflow
+
+1. **Read the script** — use file tools to read the workflow script
+2. **Detect the language** — `.pw` files use keyword syntax, `.js` files use Playwright JS
+3. **Run the script** — execute it in the real browser:
+   - For .pw: `run_script(content, "pw")`
+   - For JS: `run_script(content, "javascript")`
+4. **Analyze failures** — when a script fails:
+   - Read the error message carefully (it includes the failing line)
+   - Take a snapshot: `run_command("snapshot")` to see the current page state
+   - Take a screenshot if the visual state matters: `run_command("screenshot")`
+   - Check the page URL: `run_command("await page.url()")`
+5. **Diagnose the root cause**:
+   - **Element not found** — the text or locator changed. Use snapshot to find the correct text
+   - **Assertion failed** — the expected text/value changed. Check what's actually on the page
+   - **Navigation issue** — the URL or page structure changed. Verify the current URL
+   - **Timing issue** — add `wait-for-text` before the failing step, or use `await expect().toBeVisible()` in JS
+   - **State dependency** — the script assumes prior state. Ensure it starts from a clean state
+6. **Fix the script** — edit the SAME file (do not create a new file) to address the issue:
+   - Use the `edit` tool to update the original script file in place
+   - Update selectors to match current page content
+   - Fix assertions and expected values
+   - Add waits where needed for dynamic content
+   - For text locators, prefer exact visible text from the snapshot
+7. **Re-run** — execute the fixed script again
+8. **Iterate** — repeat steps 4-7 until the script passes cleanly
+
+## Debugging commands
+
+Use these `run_command` calls to investigate failures:
+
+| Command | Purpose |
+|---------|---------|
+| `snapshot` | See the accessibility tree — all interactive elements with their text |
+| `screenshot` | Visual capture of current page state |
+| `await page.url()` | Check current URL |
+| `await page.title()` | Check page title |
+| `await page.locator('selector').count()` | Count matching elements |
+| `await page.locator('selector').textContent()` | Get element text |
+| `verify-text "expected"` | Quick check if text exists |
+
+## Key principles
+- Be systematic — understand the error before attempting a fix
+- Fix one issue at a time and re-run after each fix
+- Use `snapshot` to ground your fixes in the real page state — don't guess
+- Prefer robust text locators over fragile element refs
+- If a step consistently fails and the page behavior has genuinely changed, update the script
+  to match the new behavior and add a comment explaining the change
+- If the error is transient (timing), add appropriate waits rather than changing logic
+- Do not ask the user questions — do the most reasonable thing to make the script pass
+- Never use deprecated APIs like `waitForNavigation` or `waitForLoadState`

--- a/packages/mcp/agents/playwright-repl-planner.agent.md
+++ b/packages/mcp/agents/playwright-repl-planner.agent.md
@@ -1,0 +1,113 @@
+---
+name: playwright-repl-planner
+description: Use this agent to explore a web page and create a comprehensive workflow plan
+model: sonnet
+color: green
+tools:
+  - search
+  - playwright-repl/run_command
+  - playwright-repl/write_file
+---
+
+You are a Playwright REPL Workflow Planner, an expert in web application analysis and workflow design.
+Your mission is to systematically explore a web page and produce a detailed workflow plan that can be
+turned into automated scripts.
+
+You control a real Chrome browser through the playwright-repl MCP server. The browser is already open
+and connected via the Dramaturg Chrome extension.
+
+## Available commands
+
+Use `run_command` to send commands to the browser. Two modes:
+
+**Keyword (.pw) commands** — concise, human-readable:
+- `goto <url>` — navigate to a URL
+- `snapshot` — get the page's accessibility tree (use this to understand page structure)
+- `click "<text>"` — click an element by visible text
+- `fill "<label>" "<value>"` — fill a form field by label
+- `press <key>` — press a keyboard key (Enter, Tab, Escape, etc.)
+- `hover "<text>"` — hover over an element
+- `select "<label>" "<value>"` — select a dropdown option
+- `screenshot` — capture a visual screenshot
+- `scroll-down` / `scroll-up` — scroll the page
+- `verify-text "<text>"` — assert text is visible on the page
+- `verify-no-text "<text>"` — assert text is NOT visible
+
+**Playwright JS** — for complex interactions:
+- `await page.url()` — get current URL
+- `await page.title()` — get page title
+- `await page.locator('selector').count()` — count elements
+
+## Your workflow
+
+1. **Navigate and Explore**
+   - Navigate to the target URL: `run_command("goto <url>")`
+   - Take a snapshot to understand the page: `run_command("snapshot")`
+   - Do not take screenshots unless absolutely necessary — snapshots are more informative
+   - Explore interactive elements by clicking through pages, opening menus, and navigating links
+   - Thoroughly map the interface: forms, buttons, navigation paths, tabs, modals
+
+2. **Analyze User Flows**
+   - Map out primary user journeys and critical paths
+   - Consider different user types and their typical behaviors
+   - Identify forms, multi-step processes, and state transitions
+
+3. **Design Comprehensive Scenarios**
+
+   Create detailed workflow scenarios that cover:
+   - Happy path scenarios (normal user behavior)
+   - Edge cases and boundary conditions
+   - Error handling and validation
+
+4. **Structure the Workflow Plan**
+
+   Each scenario must include:
+   - Clear, descriptive title
+   - Starting URL or precondition
+   - Detailed step-by-step instructions (specific enough for any engineer to follow)
+   - Expected outcomes and success criteria
+   - Assumptions about starting state (always assume fresh/blank state)
+
+5. **Save the Plan**
+
+   Save the workflow plan as a single markdown file named `<app-name>.plan.md` in the current
+   working directory (NOT inside any subfolder).
+   Use `write_file` to create the file. Overwrite if the file already exists.
+   Do NOT create multiple files or use Claude's internal plan mode.
+
+## Output format
+
+Save the plan as a markdown file:
+
+````markdown
+# Workflow Plan: <Application Name>
+
+## Overview
+<Brief description of the application and what was explored>
+
+## Workflows
+
+### 1. <Workflow Name>
+**URL:** <starting URL>
+**Preconditions:** <any required state>
+
+**Steps:**
+1. Navigate to the page
+2. Click the "<exact text from snapshot>" link/button
+3. Fill in the "<exact label>" field with a value
+4. Verify "<exact text from snapshot>" is visible
+
+**Expected outcome:** <what the user should see after completing the flow>
+
+**Notes:** <edge cases, assumptions, or observations>
+````
+
+## Key principles
+- **NEVER use write_file except for the final `<app-name>.plan.md` file** — do NOT create scratch files, exploration notes, .pw files, .js files, or any other files
+- Be systematic — explore every section before writing
+- Prefer `snapshot` over `screenshot` for understanding page structure
+- ONLY use text that appears in the snapshot output — never guess or assume text content from memory
+- When describing steps, quote the exact text/labels from the snapshot (e.g. the exact link text, button label, heading)
+- Each workflow should be independent and startable from a fresh state
+- Include both the action and the expected result for each step
+- Do NOT include `.pw` scripts or code — describe flows in plain English

--- a/packages/mcp/example/playwright-dev.plan.md
+++ b/packages/mcp/example/playwright-dev.plan.md
@@ -1,0 +1,323 @@
+# Workflow Plan: playwright.dev
+
+## Overview
+
+playwright.dev is the official documentation site for the Playwright browser automation framework. It is a Docusaurus-based static site with a top navigation bar, a left sidebar for section navigation, a right table-of-contents panel for in-page anchors, and a bottom "Previous / Next" page navigator. The site supports multiple programming languages (Node.js, Python, Java, .NET) via a language switcher in the top navbar. A search modal (Algolia DocSearch) is accessible from the navbar. The site has five top-level nav entries: Docs, API, Community, a GitHub icon link, and a language selector.
+
+Key URL patterns:
+- Home: https://playwright.dev
+- Node.js docs: https://playwright.dev/docs/<slug>
+- Python docs: https://playwright.dev/python/docs/<slug>
+- Java docs: https://playwright.dev/java/docs/<slug>
+- .NET docs: https://playwright.dev/dotnet/docs/<slug>
+- API reference: https://playwright.dev/docs/api/class-<classname>
+
+---
+
+## Workflows
+
+### 1. Home Page — Verify Key Content and Navigation Links
+
+**URL:** https://playwright.dev
+**Preconditions:** None — fresh page load.
+
+**Steps:**
+1. Navigate to https://playwright.dev.
+2. Verify the heading "Playwright enables reliable end-to-end testing for modern web apps." is visible.
+3. Verify the "Get started" button is present.
+4. Verify the "Docs" link is visible in the top navigation bar.
+5. Verify the "API" link is visible in the top navigation bar.
+6. Verify the "Community" link is visible in the top navigation bar.
+7. Verify the "Node.js" language selector is visible in the top navigation bar.
+8. Click the "Get started" button.
+9. Verify the URL changes to https://playwright.dev/docs/intro.
+10. Verify the heading "Installation" is visible on the resulting page.
+
+**Expected outcome:** Clicking "Get started" from the home page lands the user on the Installation docs page.
+
+**Notes:** The home page hero section describes cross-browser support (Chromium, Firefox, WebKit) and key features. The "Get started" button is the primary call-to-action.
+
+---
+
+### 2. Docs — Browse the Installation Page
+
+**URL:** https://playwright.dev/docs/intro
+**Preconditions:** None.
+
+**Steps:**
+1. Navigate to https://playwright.dev/docs/intro.
+2. Verify "Installation" heading is visible.
+3. Verify the left sidebar is present with navigation links.
+4. Scroll down to verify the code block for `npm init playwright@latest` is visible.
+5. Scroll down further and verify the "What's installed" section heading is visible.
+6. Scroll to the bottom of the page.
+7. Verify the "Next" navigation link pointing to the next doc page is visible (the link text begins with "Next").
+8. Click the "Next" page navigation link at the bottom of the page.
+9. Verify the URL changes to a new docs page.
+10. Verify the new page has a heading visible.
+
+**Expected outcome:** The user can navigate forward through docs pages using the bottom "Next" pagination link.
+
+**Notes:** The installation page is the entry point for all docs. Code blocks are not interactive. The left sidebar shows "Getting Started", "Writing Tests", "Running and Debugging Tests", and other sections.
+
+---
+
+### 3. Docs — Left Sidebar Navigation to a Specific Section
+
+**URL:** https://playwright.dev/docs/intro
+**Preconditions:** None.
+
+**Steps:**
+1. Navigate to https://playwright.dev/docs/intro.
+2. Verify the left sidebar is present.
+3. In the left sidebar, click the "Writing tests" link.
+4. Verify the URL changes to https://playwright.dev/docs/writing-tests.
+5. Verify the heading "Writing tests" is visible on the page.
+6. Scroll down and verify that the page contains content describing assertions and locators.
+
+**Expected outcome:** Clicking a sidebar link takes the user directly to that documentation section.
+
+**Notes:** The sidebar collapses into a hamburger menu on mobile viewports. On desktop, all sections are expanded by default.
+
+---
+
+### 4. Search — Open Modal and Query for a Topic
+
+**URL:** https://playwright.dev
+**Preconditions:** None.
+
+**Steps:**
+1. Navigate to https://playwright.dev.
+2. Click the "Search" button in the top navigation bar.
+3. Verify the search modal opens and a text input field is focused/visible.
+4. Type "locator" into the search input field.
+5. Verify that search result items appear below the input (the results list becomes populated).
+6. Press the Escape key to close the search modal.
+7. Verify the search modal is no longer visible.
+
+**Expected outcome:** The Algolia DocSearch modal opens, accepts keyboard input, and displays matching results for "locator". Pressing Escape dismisses the modal.
+
+**Notes:** The search keyboard shortcut is Ctrl+K (Windows/Linux) or Cmd+K (Mac). The modal can also be closed by clicking outside it. Search results include page titles and excerpt snippets.
+
+---
+
+### 5. Search — Navigate to a Search Result
+
+**URL:** https://playwright.dev
+**Preconditions:** None.
+
+**Steps:**
+1. Navigate to https://playwright.dev.
+2. Click the "Search" button in the top navigation bar.
+3. Verify the search modal is open.
+4. Type "page object model" into the search input field.
+5. Verify at least one search result item appears.
+6. Click the first search result that appears.
+7. Verify the URL changes to a docs page (URL contains /docs/).
+8. Verify the page heading is visible and the page has loaded successfully.
+
+**Expected outcome:** Selecting a search result navigates the user to the corresponding documentation page.
+
+**Notes:** Results are ranked by relevance. The first result for "page object model" is typically the Page Object Models guide.
+
+---
+
+### 6. Language Switcher — Switch from Node.js to Python
+
+**URL:** https://playwright.dev
+**Preconditions:** None (default language is Node.js).
+
+**Steps:**
+1. Navigate to https://playwright.dev.
+2. Verify "Node.js" is shown in the language selector in the top navigation bar.
+3. Click "Node.js" to open the language dropdown.
+4. Verify a dropdown/popover appears showing language options.
+5. Click "Python" from the dropdown list.
+6. Verify the URL changes to https://playwright.dev/python/docs/intro or similar Python URL.
+7. Verify "Python" now appears in the language selector in the top navigation bar.
+8. Verify the page heading "Installation" is visible.
+
+**Expected outcome:** Selecting a different language from the switcher reloads the documentation in that language's URL namespace. The language selector reflects the active choice.
+
+**Notes:** Language options observed: Node.js, Python, Java, .NET. Each language has its own URL prefix (/python/, /java/, /dotnet/). The default (no prefix) is Node.js.
+
+---
+
+### 7. Language Switcher — Switch from Node.js to Java
+
+**URL:** https://playwright.dev/docs/intro
+**Preconditions:** None.
+
+**Steps:**
+1. Navigate to https://playwright.dev/docs/intro.
+2. Click "Node.js" in the top navigation bar to open the language dropdown.
+3. Click "Java" from the dropdown list.
+4. Verify the URL changes to https://playwright.dev/java/docs/intro.
+5. Verify the heading "Installation" is visible.
+6. Verify the code examples on the page show Java syntax (Maven/Gradle dependency snippets).
+
+**Expected outcome:** Switching to Java takes the user to the Java variant of the same documentation page.
+
+**Notes:** The language switcher preserves the current page slug when switching between languages, so the user lands on the equivalent page in the new language.
+
+---
+
+### 8. API Reference — Browse the Playwright Class
+
+**URL:** https://playwright.dev/docs/api/class-playwright
+**Preconditions:** None.
+
+**Steps:**
+1. Navigate to https://playwright.dev.
+2. Click the "API" link in the top navigation bar.
+3. Verify the URL changes to an API reference page (URL contains /docs/api/).
+4. Verify the heading "API reference" or a class name heading is visible.
+5. Scroll down to verify method listings are visible.
+6. In the left sidebar, locate and click "Locator".
+7. Verify the URL changes to the Locator class API page.
+8. Verify the heading "Locator" is visible.
+9. Scroll down and verify method entries such as "locator.click()" are visible.
+
+**Expected outcome:** The API reference section lists all Playwright classes and their methods. Clicking a class in the sidebar navigates to that class's full API documentation.
+
+**Notes:** The API reference sidebar lists classes alphabetically. Each method entry includes a signature, parameter table, and return type.
+
+---
+
+### 9. API Reference — Expand a Method Entry
+
+**URL:** https://playwright.dev/docs/api/class-locator
+**Preconditions:** None.
+
+**Steps:**
+1. Navigate to https://playwright.dev/docs/api/class-locator.
+2. Verify the heading "Locator" is visible.
+3. Scroll down to find the "locator.click()" method entry.
+4. Verify the method signature "locator.click()" is visible.
+5. Scroll down further and verify that "options" parameter description is visible.
+
+**Expected outcome:** The Locator API page displays all available methods with their full parameter documentation inline (no accordion — all content is expanded by default on Docusaurus API pages).
+
+**Notes:** Each method has an anchor link (e.g., #locator-click) which can be linked to directly. The right-side table of contents lists all methods on the page.
+
+---
+
+### 10. Community Page — Verify Content and External Links
+
+**URL:** https://playwright.dev
+**Preconditions:** None.
+
+**Steps:**
+1. Navigate to https://playwright.dev.
+2. Click "Community" in the top navigation bar.
+3. Verify the URL changes to https://playwright.dev/community/welcome.
+4. Verify a page heading related to the community is visible.
+5. Verify links to external community resources are visible on the page (e.g., Discord, Stack Overflow, GitHub).
+
+**Expected outcome:** The Community page loads and lists links to external resources where users can get help and engage with the Playwright community.
+
+**Notes:** The community page is a simple content page. External links open in a new tab.
+
+---
+
+### 11. Docs — Right-Side Table of Contents Navigation
+
+**URL:** https://playwright.dev/docs/writing-tests
+**Preconditions:** None.
+
+**Steps:**
+1. Navigate to https://playwright.dev/docs/writing-tests.
+2. Verify the heading "Writing tests" is visible.
+3. Verify the right-side table of contents panel is visible, listing in-page sections.
+4. In the right-side table of contents, click one of the section anchor links (e.g., "Assertions").
+5. Verify the page scrolls to the corresponding heading on the page.
+6. Verify the clicked item in the right-side table of contents becomes visually highlighted/active.
+
+**Expected outcome:** Clicking a table-of-contents entry scrolls the main content to that section and highlights the active item in the TOC panel.
+
+**Notes:** The right-side TOC updates its highlighted item as the user scrolls through the page (scroll-spy behavior).
+
+---
+
+### 12. Docs — Keyboard Search Shortcut
+
+**URL:** https://playwright.dev/docs/intro
+**Preconditions:** None.
+
+**Steps:**
+1. Navigate to https://playwright.dev/docs/intro.
+2. Press Ctrl+K (or Cmd+K on Mac) on the keyboard.
+3. Verify the search modal opens.
+4. Verify a text input field is focused.
+5. Type "assertions" into the input.
+6. Verify search results appear.
+7. Press Escape to close the modal.
+8. Verify the search modal is no longer visible and the docs page is still visible.
+
+**Expected outcome:** The keyboard shortcut Ctrl+K opens the search modal from any page on the site.
+
+**Notes:** This is a standard Algolia DocSearch keyboard shortcut. The hint "Ctrl+K" or "Cmd+K" is typically shown in the Search button label.
+
+---
+
+### 13. Docs — Version Indicator Check
+
+**URL:** https://playwright.dev/docs/intro
+**Preconditions:** None.
+
+**Steps:**
+1. Navigate to https://playwright.dev/docs/intro.
+2. Verify the page loads successfully and shows the "Installation" heading.
+3. Locate the version number displayed in the page or navbar (the version label, e.g., "v1.x.x" or "Next").
+4. Verify a version indicator is visible somewhere on the page.
+
+**Expected outcome:** The current stable version of Playwright is shown on the documentation page, confirming the user is on the latest stable docs.
+
+**Notes:** Older versions of the docs may be accessible via a version dropdown. The default URL serves the latest stable version.
+
+---
+
+### 14. Home Page — Feature Sections Visibility
+
+**URL:** https://playwright.dev
+**Preconditions:** None.
+
+**Steps:**
+1. Navigate to https://playwright.dev.
+2. Verify "Playwright enables reliable end-to-end testing for modern web apps." heading is visible.
+3. Scroll down past the hero section.
+4. Verify a section about "Any browser" or cross-browser testing is visible.
+5. Scroll down further.
+6. Verify a section about "Any platform" is visible.
+7. Scroll down further.
+8. Verify a section about "One API" is visible.
+9. Continue scrolling and verify a "Resilient" or "No flaky tests" feature section is visible.
+10. Continue scrolling and verify a section about "Full isolation" or "Fast and reliable execution" is visible.
+11. Scroll to the bottom of the page.
+12. Verify the footer is visible with links to "Docs", "API", and "Community".
+
+**Expected outcome:** All major feature-highlight sections load and are visible as the user scrolls through the home page. The footer is present at the bottom.
+
+**Notes:** The home page uses a single-column layout for feature cards on mobile and a multi-column layout on desktop.
+
+---
+
+### 15. Docs — Navigate Using Previous / Next Links at Page Bottom
+
+**URL:** https://playwright.dev/docs/writing-tests
+**Preconditions:** None.
+
+**Steps:**
+1. Navigate to https://playwright.dev/docs/writing-tests.
+2. Scroll to the bottom of the page.
+3. Verify a "Previous" navigation link is visible (text contains "Previous") pointing to the previous page in the sequence.
+4. Verify a "Next" navigation link is visible (text contains "Next") pointing to the next page in the sequence.
+5. Click the "Next" link at the bottom.
+6. Verify the URL changes to the next docs page in sequence.
+7. Verify the new page has a main heading visible.
+8. Scroll to the bottom of the new page.
+9. Verify a "Previous" link is visible that points back to the "Writing tests" page.
+
+**Expected outcome:** The Previous / Next pagination at the bottom of each docs page allows sequential navigation through the documentation without using the sidebar.
+
+**Notes:** Not all pages have both a Previous and a Next link — the first page in a section only has Next, and the last page only has Previous.

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -2,6 +2,8 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { z } from 'zod';
+import { mkdir, writeFile } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
 import { BridgeServer } from '@playwright-repl/core';
 
 const argv = process.argv.slice(2);
@@ -110,6 +112,27 @@ server.registerTool(
     }
 );
 
+
+server.registerTool(
+    'write_file',
+    {
+        description: 'Write content to a file. Creates the file if it does not exist, overwrites if it does.',
+        inputSchema: {
+            path: z.string().describe('File path (relative to working directory or absolute)'),
+            content: z.string().describe('The content to write'),
+        },
+    },
+    async ({ path, content }) => {
+        try {
+            const resolved = resolve(path);
+            await mkdir(dirname(resolved), { recursive: true });
+            await writeFile(resolved, content, 'utf-8');
+            return { content: [{ type: 'text' as const, text: `Wrote ${resolved}` }] };
+        } catch (err: any) {
+            return { content: [{ type: 'text' as const, text: `Error: ${err.message}` }], isError: true };
+        }
+    }
+);
 
 const GENERATE_TEST_PROMPT = (steps: string, url?: string) => `\
 Generate a passing Playwright test for the following scenario:


### PR DESCRIPTION
## Summary
- Add three Claude Code agents (planner, generator, healer) that use the playwright-repl MCP server to automate browser workflow creation and maintenance
- Add `write_file` MCP tool so agents can save generated scripts and plans
- Include example plan for playwright.dev (15 workflows)

Closes #254

## Agent descriptions
- **planner** — explores a web page, maps out user flows, saves a `.plan.md` file
- **generator** — reads a plan, executes each step in a real browser, produces verified `.pw` scripts
- **healer** — reads a failing `.pw` script, diagnoses errors via snapshot/screenshot, fixes in place

## Test plan
- [ ] Invoke planner agent on a site → verify `.plan.md` is saved with correct workflows
- [ ] Invoke generator agent with a plan → verify `.pw` script is saved and passes `run_script`
- [ ] Break a `.pw` script → invoke healer → verify it fixes and re-runs successfully
- [ ] Verify `write_file` MCP tool creates parent directories automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)