### PR TITLE
feat: expand/collapse all toggle for console trees

### DIFF
--- a/packages/extension/src/panel/components/Console/ObjectTree.tsx
+++ b/packages/extension/src/panel/components/Console/ObjectTree.tsx
@@ -1,6 +1,7 @@
 import { useState, useRef, useEffect } from 'react';
 import type { SerializedValue } from './types';
 import { fromCdpGetProperties } from './cdpToSerialized';
+import { useTreeExpand } from './TreeExpandContext';
 
 const MAX_DEPTH = 8;
 
@@ -67,6 +68,11 @@ export function ObjectTree({ data, label, depth = 0, getProperties }: Props) {
     const [childProps, setChildProps] = useState<Record<string, SerializedValue> | null>(null);
     const [loading, setLoading] = useState(false);
     const fetchedRef = useRef(false);
+    const { generation, expanded } = useTreeExpand();
+
+    useEffect(() => {
+        if (generation > 0) setOpen(expanded);
+    }, [generation]);
 
     const objectId =
         depth < MAX_DEPTH && (data.__type === 'object' || data.__type === 'array' || data.__type === 'ref')

--- a/packages/extension/src/panel/components/Console/SnapshotTree.tsx
+++ b/packages/extension/src/panel/components/Console/SnapshotTree.tsx
@@ -1,9 +1,15 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { SnapshotNode } from "@/lib/snapshot-parser";
+import { useTreeExpand } from "./TreeExpandContext";
 
 export function SnapshotTree({node, depth}: { node: SnapshotNode, depth: number}) {
     const [open, setOpen] = useState(depth < 2);
     const hasChildren = node.children.length > 0;
+    const { generation, expanded } = useTreeExpand();
+
+    useEffect(() => {
+        if (generation > 0) setOpen(expanded);
+    }, [generation]);
 
     return (
         <div>

--- a/packages/extension/src/panel/components/Console/TreeExpandContext.tsx
+++ b/packages/extension/src/panel/components/Console/TreeExpandContext.tsx
@@ -1,0 +1,12 @@
+import { createContext, useContext } from 'react';
+
+interface TreeExpandSignal {
+    generation: number;
+    expanded: boolean;
+}
+
+export const TreeExpandContext = createContext<TreeExpandSignal>({ generation: 0, expanded: false });
+
+export function useTreeExpand() {
+    return useContext(TreeExpandContext);
+}

--- a/packages/extension/src/panel/components/Console/index.tsx
+++ b/packages/extension/src/panel/components/Console/index.tsx
@@ -1,7 +1,8 @@
-import { useImperativeHandle, useRef, useEffect, useMemo, type Ref } from 'react';
+import { useImperativeHandle, useRef, useEffect, useMemo, useState, type Ref } from 'react';
 import { useConsole } from './useConsole';
 import { ConsoleOutput } from './ConsoleOutput';
 import { ConsoleInput, type ConsoleInputHandle } from './ConsoleInput';
+import { TreeExpandContext } from './TreeExpandContext';
 import type { ConsoleHandle, ConsoleProps, ConsoleEntry, SerializedValue } from './types';
 import type { OutputLine } from '@/types';
 
@@ -75,10 +76,15 @@ export function Console({ outputLines, dispatch, className, ref }: Props) {
     const inputRef = useRef<ConsoleInputHandle>(null);
     const bottomRef = useRef<HTMLDivElement>(null);
     const entries = useMemo(() => outputLinesToEntries(outputLines ?? []), [outputLines]);
+    const [treeExpand, setTreeExpand] = useState({ generation: 0, expanded: false });
 
     function clearAll() {
         dispatch({ type: 'CLEAR_CONSOLE' });
         inputRef.current?.clear();
+    }
+
+    function toggleExpand() {
+        setTreeExpand(prev => ({ generation: prev.generation + 1, expanded: !prev.expanded }));
     }
 
     function handleExecute(input: string) {
@@ -96,15 +102,18 @@ export function Console({ outputLines, dispatch, className, ref }: Props) {
         <div className={`flex flex-col flex-1 min-h-20 overflow-hidden ${className ?? ''}`} data-testid="console-pane">
             <div className="flex items-center gap-1 px-1 py-0.5 border-b border-(--border-primary) shrink-0">
                 <button className="console-clear-btn" onClick={clearAll} title="Clear console (Ctrl+L)">⊘</button>
+                <button className="console-clear-btn" onClick={toggleExpand} title={treeExpand.expanded ? "Collapse all trees" : "Expand all trees"}>{treeExpand.expanded ? '⊟' : '⊞'}</button>
             </div>
-            <div className="flex-1 overflow-y-auto py-1 px-2" data-testid="output">
-                <ConsoleOutput entries={entries} />
-                <div className="flex items-start gap-1 py-0.5">
-                    <span className="text-(--color-prompt) shrink-0" data-testid="prompt">&gt;</span>
-                    <ConsoleInput ref={inputRef} onSubmit={handleExecute} onClear={clearAll} />
+            <TreeExpandContext.Provider value={treeExpand}>
+                <div className="flex-1 overflow-y-auto py-1 px-2" data-testid="output">
+                    <ConsoleOutput entries={entries} />
+                    <div className="flex items-start gap-1 py-0.5">
+                        <span className="text-(--color-prompt) shrink-0" data-testid="prompt">&gt;</span>
+                        <ConsoleInput ref={inputRef} onSubmit={handleExecute} onClear={clearAll} />
+                    </div>
+                    <div ref={bottomRef} />
                 </div>
-                <div ref={bottomRef} />
-            </div>
+            </TreeExpandContext.Provider>
         </div>
     );
 }


### PR DESCRIPTION
## Summary
- Adds a toolbar toggle button (⊞/⊟) that expands or collapses all ObjectTree and SnapshotTree nodes in the console output
- Uses a React context (`TreeExpandContext`) with a generation counter pattern to signal all tree nodes without lifting state
- Single toggle button cycles between expand all and collapse all

## Test plan
- [x] `npx vite build` passes
- [x] 630 vitest tests pass
- [ ] Load extension in Chrome, run `snapshot` → click ⊞ to expand all nodes → click ⊟ to collapse
- [ ] Run a JS expression returning a deep object → toggle works on ObjectTree too
- [ ] Individual node clicks still work after bulk toggle

Closes #257

🤖 Generated with [Claude Code](https://claude.com/claude-code)