### PR TITLE
fix: MCP snapshot caching + agent docs for locator command

### DIFF
--- a/packages/mcp/agents/playwright-repl-generator.agent.md
+++ b/packages/mcp/agents/playwright-repl-generator.agent.md
@@ -54,6 +54,7 @@ await expect(page.getByText('Welcome')).toBeVisible();
 - `check "<label>"` / `uncheck "<label>"` — toggle checkbox
 - `scroll-down` / `scroll-up` — scroll the page
 - `snapshot` — accessibility tree (use to discover exact text on the page)
+- `locator <ref>` — convert a snapshot ref to a Playwright locator (run `snapshot` first)
 - `screenshot` — visual capture
 - `verify-text "<text>"` — assert text is visible on the page
 - `verify-no-text "<text>"` — assert text is NOT visible
@@ -88,16 +89,18 @@ Use `run_command("help verify")` to discover available assertion commands (verif
 
 1. **Read the plan** — read the workflow plan file or understand the description
 2. **Explore** — `run_command("goto <url>")`, then `run_command("snapshot")` to see the page
-3. **Step through** — execute each action with `run_command`, snapshot after key interactions
-4. **Assemble the script** — collect the working commands into a `.pw` or `.js` script
+3. **Step through** — execute each action with `run_command` using text from the snapshot. Use `snapshot` after key interactions to see the updated page.
+4. **Assemble the script** — collect the working commands into a `.pw` or `.js` script using text locators (e.g. `click "Sign in"`, not `click e5`)
 5. **Run the full script** — call `run_script(script, "pw")` or `run_script(script, "javascript")`
-   - If errors: fix, then call `run_script` again. Repeat until zero errors.
-6. **Save** — use `write_file` to save as `<workflow-name>.pw` (or `.js`)
+   - If errors: snapshot the page, fix, and re-run. Repeat until zero errors.
+   - If a text locator doesn't match, use `locator <ref>` to find the correct one.
+6. **Output the script** — return the final tested script in your response so the user can save it
 
-**CRITICAL — you MUST do steps 5 and 6 every time. Never skip them:**
-- Do NOT show the script without calling `run_script` first
-- Do NOT end the conversation without saving the file
-- Do NOT save a script that has not passed `run_script`
+**CRITICAL — you MUST run the script before outputting it. Never skip this:**
+- Do NOT skip `run_script` — you MUST call it and verify the output shows no errors
+- Do NOT claim a script works without actually running it via `run_script`
+- Do NOT output a script that has not passed `run_script`
+- Pick ONE format (.pw or .js) — NEVER mix them in the same script
 
 ## Example generation
 
@@ -125,10 +128,11 @@ verify-text "Dashboard"
 - **NEVER invent commands** — only use commands from the "Available .pw commands" list above
 - Always execute steps in the real browser first — don't guess locators
 - ONLY use text that appears in the snapshot output — never guess or assume text content from memory
-- ALWAYS use text locators (`click "Get started"`) — NEVER use element refs (`click e11`) in saved scripts
+- Use text locators in scripts (`click "Sign in"`) — NEVER use refs (`click e5`) in the final script
+- Use `locator <ref>` only as a fallback when you can't determine the right text locator from the snapshot
 - Add a `snapshot` at the beginning to understand the page before interacting
 - One script = one workflow (keep scripts focused)
 - Prefer `.pw` syntax unless the workflow requires JS logic (loops, conditionals, variables)
 - The script must pass when run from a fresh page state
-- **Only create `.pw` or `.js` script files** — do NOT create scratch files, notes, or any other files
+- Output only the final script — do NOT create scratch files, notes, or any other output
 - Do not ask the user questions — make reasonable choices and verify by running

--- a/packages/mcp/agents/playwright-repl-healer.agent.md
+++ b/packages/mcp/agents/playwright-repl-healer.agent.md
@@ -55,7 +55,7 @@ Use `run_command("help verify")` to discover available assertion commands (verif
    - Take a screenshot if the visual state matters: `run_command("screenshot")`
    - Check the page URL: `run_command("await page.url()")`
 5. **Diagnose the root cause**:
-   - **Element not found** — the text or locator changed. Use snapshot to find the correct text
+   - **Element not found** — the text or locator changed. Use `snapshot` then `locator <ref>` to get the correct locator
    - **Assertion failed** — the expected text/value changed. Check what's actually on the page
    - **Navigation issue** — the URL or page structure changed. Verify the current URL
    - **Timing issue** — add `wait-for-text` before the failing step, or use `await expect().toBeVisible()` in JS
@@ -76,6 +76,7 @@ Use these `run_command` calls to investigate failures:
 | Command | Purpose |
 |---------|---------|
 | `snapshot` | See the accessibility tree — all interactive elements with their text |
+| `locator <ref>` | Convert a snapshot ref to a `page.getByRole(...)` locator (run `snapshot` first) |
 | `screenshot` | Visual capture of current page state |
 | `await page.url()` | Check current URL |
 | `await page.title()` | Check page title |

--- a/packages/mcp/agents/playwright-repl-planner.agent.md
+++ b/packages/mcp/agents/playwright-repl-planner.agent.md
@@ -22,7 +22,7 @@ Use `run_command` to send commands to the browser. Two modes:
 **Keyword (.pw) commands** — concise, human-readable:
 - `goto <url>` — navigate to a URL
 - `snapshot` — get the page's accessibility tree (use this to understand page structure)
-- `click "<text>"` — click an element by visible text
+- `click "<text>"` or `click <ref>` — click by visible text or snapshot ref
 - `fill "<label>" "<value>"` — fill a form field by label
 - `press <key>` — press a keyboard key (Enter, Tab, Escape, etc.)
 - `hover "<text>"` — hover over an element
@@ -50,7 +50,7 @@ Use `run_command("help verify")` to discover available assertion commands (verif
    - Navigate to the target URL: `run_command("goto <url>")`
    - Take a snapshot to understand the page: `run_command("snapshot")`
    - Do not take screenshots unless absolutely necessary — snapshots are more informative
-   - Explore interactive elements by clicking through pages, opening menus, and navigating links
+   - Use refs from the snapshot to explore quickly (`click e5`, `fill e8 "value"`) — refs are faster than text locators for exploration
    - Thoroughly map the interface: forms, buttons, navigation paths, tabs, modals
 
 2. **Analyze User Flows**
@@ -74,12 +74,9 @@ Use `run_command("help verify")` to discover available assertion commands (verif
    - Expected outcomes and success criteria
    - Assumptions about starting state (always assume fresh/blank state)
 
-5. **Save the Plan**
+5. **Output the Plan**
 
-   Save the workflow plan as a single markdown file named `<app-name>.plan.md` in the current
-   working directory (NOT inside any subfolder).
-   Use `write_file` to create the file. Overwrite if the file already exists.
-   Do NOT create multiple files or use Claude's internal plan mode.
+   Return the workflow plan in your response so the user can save it as `<app-name>.plan.md`.
 
 ## Output format
 
@@ -109,7 +106,7 @@ Save the plan as a markdown file:
 ````
 
 ## Key principles
-- **NEVER use write_file except for the final `<app-name>.plan.md` file** — do NOT create scratch files, exploration notes, .pw files, .js files, or any other files
+- Output only the final plan — do NOT create scratch files, exploration notes, .pw files, .js files, or any other output
 - Be systematic — explore every section before writing
 - Prefer `snapshot` over `screenshot` for understanding page structure
 - ONLY use text that appears in the snapshot output — never guess or assume text content from memory

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -101,10 +101,10 @@ server.registerTool(
             };
         }
         const result = await srv.run(command);
-        const snapshotMatch = result.text?.match(/### Snapshot\n([\s\S]*?)(?=\n### |$)/);
-        if (snapshotMatch) {
-            const urlMatch = result.text?.match(/### Page\n-\s*\[.*?\]\((.*?)\)/);
-            lastSnapshot = { url: urlMatch?.[1] ?? '', snapshotString: snapshotMatch[1].trim() };
+        // Cache snapshot for locator command
+        // Bridge mode: snapshot returns raw YAML (no ### headers)
+        if (trimmed.startsWith('snapshot') && result.text && !result.isError) {
+            lastSnapshot = { url: '', snapshotString: result.text.trim() };
         }
         if (result.image) {
             const [header, data] = result.image.split(',');


### PR DESCRIPTION
## Summary
- **Bug fix**: MCP `locator` command was broken because snapshot caching used a regex expecting `### Snapshot\n` headers, but bridge mode returns raw YAML. Fixed to match CLI bridge approach (check command name instead).
- **Agent docs**: Updated all three agents (generator, healer, planner) — added `locator <ref>` command, removed `write_file` references, added "never mix formats" rule.

## Test plan
- [x] Tested `locator` command via MCP: `snapshot` → `locator e5` returns correct locator
- [x] Tested generator agent end-to-end: produced clean .pw script for TodoMVC

🤖 Generated with [Claude Code](https://claude.com/claude-code)