### PR TITLE
feat: add --server mode for HTTP API + deprecate --extension

### DIFF
--- a/packages/cli/src/playwright-repl.ts
+++ b/packages/cli/src/playwright-repl.ts
@@ -16,7 +16,7 @@ import { minimist } from '@playwright-repl/core';
 import { startRepl } from './repl.js';
 
 const args = minimist(process.argv.slice(2), {
-  boolean: ['headed', 'persistent', 'extension', 'help', 'step', 'silent', 'spawn', 'bridge'],
+  boolean: ['headed', 'persistent', 'extension', 'help', 'step', 'silent', 'spawn', 'bridge', 'server'],
   string: ['session', 'browser', 'profile', 'config', 'replay', 'record', 'connect', 'port', 'cdp-port', 'bridge-port'],
   alias: { s: 'session', h: 'help', b: 'browser', q: 'silent' },
   default: { session: 'default' },
@@ -40,12 +40,12 @@ Options:
   --persistent           Use persistent browser profile
   --profile <dir>        Persistent profile directory
   --connect [port]       Connect to existing Chrome via CDP (default: 9222)
-  --extension            Connect to Chrome with side panel extension
-  --spawn                Spawn Chrome automatically (default: connect to existing)
+  --server               Start HTTP server mode (no interactive REPL)
   --bridge               Connect to extension via WebSocket bridge (no CDP required)
   --bridge-port <port>   WebSocket bridge port (default: 9876)
-  --port <number>        Extension server port (default: 6781)
+  --port <number>        HTTP server port (default: 6781)
   --cdp-port <number>    Chrome CDP port (default: 9222)
+  --extension            (deprecated) Use --server or --bridge instead
   --config <file>        Path to config file
   --replay <files...>   Replay .pw file(s) or folder(s)
   --record <file>        Start REPL with recording to file
@@ -70,10 +70,9 @@ Examples:
   playwright-repl --headed               # start with visible browser
   playwright-repl --connect              # connect to Chrome on port 9222
   playwright-repl --connect 9333         # connect to Chrome on custom port
-  playwright-repl --extension            # connect to existing Chrome + side panel
-  playwright-repl --extension --spawn    # spawn Chrome automatically
-  playwright-repl --extension --port 7000  # custom server port
-  playwright-repl --extension --cdp-port 9333  # custom CDP port
+  playwright-repl --server               # HTTP server mode (for AI agents)
+  playwright-repl --server --headed      # HTTP server + visible browser
+  playwright-repl --server --port 8080   # custom server port
   playwright-repl --bridge               # connect to extension via WebSocket bridge
   playwright-repl --bridge --bridge-port 9877  # custom bridge port
   playwright-repl --replay login.pw      # replay a session
@@ -108,6 +107,7 @@ startRepl({
   record: args.record as string,
   step: args.step as boolean,
   silent: args.silent as boolean,
+  server: args.server as boolean,
   bridge: args.bridge as boolean,
   bridgePort: args['bridge-port'] ? parseInt(args['bridge-port'] as string, 10) : undefined,
 }).catch((err: Error) => {

--- a/packages/cli/src/repl.ts
+++ b/packages/cli/src/repl.ts
@@ -13,7 +13,7 @@ import {
   buildRunCode, verifyText, verifyElement, verifyValue, verifyList,
   verifyTitle, verifyUrl, verifyNoText, verifyNoElement,
   actionByText, fillByText, selectByText, checkByText, uncheckByText,
-  Engine, BridgeServer, COMMANDS, CATEGORIES, JS_CATEGORIES, refToLocator,
+  Engine, CommandServer, BridgeServer, COMMANDS, CATEGORIES, JS_CATEGORIES, refToLocator,
 } from '@playwright-repl/core';
 import type { EngineOpts, ParsedArgs, EngineResult } from '@playwright-repl/core';
 import { SessionManager } from './recorder.js';
@@ -27,6 +27,7 @@ export interface ReplOpts extends EngineOpts {
   record?: string;
   step?: boolean;
   silent?: boolean;
+  server?: boolean;
   bridge?: boolean;
   bridgePort?: number;
 }
@@ -1070,6 +1071,12 @@ export async function startRepl(opts: ReplOpts = {}): Promise<void> {
 
   log(`${c.bold}${c.magenta}🎭 Playwright REPL${c.reset} ${c.dim}v${replVersion}${c.reset}`);
 
+  // ─── Deprecation warning ─────────────────────────────────────────
+
+  if (opts.extension) {
+    console.log(`${c.yellow}Warning: --extension is deprecated. Use --server for HTTP API or --bridge for extension.${c.reset}`);
+  }
+
   // ─── Bridge mode ─────────────────────────────────────────────────
 
   if (opts.bridge) {
@@ -1091,7 +1098,7 @@ export async function startRepl(opts: ReplOpts = {}): Promise<void> {
   if (opts.extension) {
     log(`${c.dim}Extension mode: starting CDP relay server...${c.reset}`);
     log('');
-  } else {
+  } else if (!opts.server) {
     log(`${c.dim}Type .help for commands${c.reset}\n`);
   }
 
@@ -1105,6 +1112,29 @@ export async function startRepl(opts: ReplOpts = {}): Promise<void> {
   } catch (err: unknown) {
     console.error(`${c.red}✗${c.reset} Failed to start: ${(err as Error).message}`);
     process.exit(1);
+  }
+
+  // ─── Server mode (HTTP-only, no REPL) ─────────────────────────────
+
+  if (opts.server) {
+    const serverPort = opts.port || 6781;
+    const cmdServer = new CommandServer(conn);
+    await cmdServer.start(serverPort);
+    log(`${c.green}✓${c.reset} HTTP server listening on http://localhost:${serverPort}`);
+    log(`${c.dim}  POST /run     — execute a command${c.reset}`);
+    log(`${c.dim}  GET  /health  — server status${c.reset}`);
+    log(`${c.dim}  Ctrl+C to stop${c.reset}\n`);
+
+    // Keep process alive — clean shutdown on SIGINT
+    process.on('SIGINT', async () => {
+      log(`\n${c.dim}Shutting down...${c.reset}`);
+      await cmdServer.close();
+      await conn.close();
+      process.exit(0);
+    });
+    // Block forever (SIGINT handler will exit)
+    await new Promise(() => {});
+    return;
   }
 
   // ─── Session + readline ──────────────────────────────────────────

--- a/packages/core/src/extension-server.ts
+++ b/packages/core/src/extension-server.ts
@@ -1,9 +1,11 @@
 /**
- * CommandServer — HTTP server for the side panel extension.
+ * CommandServer — HTTP server for external command execution.
+ *
+ * Used by --server mode (AI agents) and --extension mode (side panel).
  *
  * Endpoints:
- *   POST /run     Panel commands → engine.run()
- *   GET  /health  Panel checks if server is running
+ *   POST /run     Execute a command → engine.run()
+ *   GET  /health  Server status check
  */
 
 import { createServer, type IncomingMessage, type ServerResponse, type Server } from 'node:http';


### PR DESCRIPTION
## Summary
- Add `--server` flag that starts Engine + HTTP server (no interactive REPL) — AI agents send commands via `POST /run`
- Deprecate `--extension` flag with warning — use `--server` or `--bridge` instead
- Update help text and examples

## Usage
```bash
playwright-repl --server              # headless browser + HTTP on :6781
playwright-repl --server --headed     # headed browser + HTTP
playwright-repl --server --port 8080  # custom port
```

```bash
curl POST /run -d '{"raw":"goto https://example.com"}' -H 'Content-Type: application/json'
curl GET /health
```

## Test plan
- [x] `pnpm build` compiles
- [x] `playwright-repl --server` starts Engine + HTTP server
- [x] `GET /health` returns status
- [x] `POST /run` executes commands (goto, snapshot, fill)
- [x] Ctrl+C cleanly shuts down
- [x] `playwright-repl --extension` shows deprecation warning

Closes #255

🤖 Generated with [Claude Code](https://claude.com/claude-code)