### PR TITLE
fix: support highlight with element refs

### DIFF
--- a/packages/core/src/engine.ts
+++ b/packages/core/src/engine.ts
@@ -218,22 +218,27 @@ export class Engine {
       } else {
         const parts = args._.slice(1);
         if (!parts.length) return { text: 'Usage: highlight <locator>', isError: true };
-        const nth = args.nth !== undefined ? parseInt(String(args.nth), 10) : undefined;
-        let locExpr: string;
-        // highlight <role> "<name>" → getByRole(role, { name })
-        if (parts.length >= 2 && /^[a-z]+$/.test(parts[0])) {
-          const role = parts[0];
-          const name = parts.slice(1).join(' ');
-          locExpr = `page.getByRole(${JSON.stringify(role)}, { name: ${JSON.stringify(name)}, exact: true })`;
+        // highlight <ref> → use aria-ref selector
+        if (parts.length === 1 && /^e\d+$/.test(parts[0])) {
+          args = { _: ['run-code', `async (page) => { await page.locator('aria-ref=${parts[0]}').highlight(); return "Highlighted"; }`] };
         } else {
-          const loc = parts.join(' ');
-          const isSelector = /[.#\[\]>:=]/.test(loc);
-          locExpr = isSelector
-            ? `page.locator(${JSON.stringify(loc)})`
-            : `page.getByText(${JSON.stringify(loc)})`;
+          const nth = args.nth !== undefined ? parseInt(String(args.nth), 10) : undefined;
+          let locExpr: string;
+          // highlight <role> "<name>" → getByRole(role, { name })
+          if (parts.length >= 2 && /^[a-z]+$/.test(parts[0])) {
+            const role = parts[0];
+            const name = parts.slice(1).join(' ');
+            locExpr = `page.getByRole(${JSON.stringify(role)}, { name: ${JSON.stringify(name)}, exact: true })`;
+          } else {
+            const loc = parts.join(' ');
+            const isSelector = /[.#\[\]>:=]/.test(loc);
+            locExpr = isSelector
+              ? `page.locator(${JSON.stringify(loc)})`
+              : `page.getByText(${JSON.stringify(loc)})`;
+          }
+          if (nth !== undefined) locExpr += `.nth(${nth})`;
+          args = { _: ['run-code', `async (page) => { await ${locExpr}.highlight(); return "Highlighted"; }`] };
         }
-        if (nth !== undefined) locExpr += `.nth(${nth})`;
-        args = { _: ['run-code', `async (page) => { await ${locExpr}.highlight(); return "Highlighted"; }`] };
       }
     }
 

--- a/packages/extension/src/panel/lib/commands.ts
+++ b/packages/extension/src/panel/lib/commands.ts
@@ -129,7 +129,7 @@ import {
   verifyVisible, verifyInputValue, waitForText,
   actionByText, fillByText, selectByText, checkByText, uncheckByText,
   actionByRole, fillByRole, selectByRole,
-  highlightByText, highlightByRole, highlightBySelector, clearHighlight, chainAction, goBack, goForward,
+  highlightByText, highlightByRole, highlightBySelector, highlightByRef, clearHighlight, chainAction, goBack, goForward,
   gotoUrl, reloadPage, waitMs, getTitle, getUrl,
   evalCode, runCode, takeScreenshot, takeSnapshot,
   refAction, pressKey, typeText,
@@ -394,6 +394,8 @@ function resolveArgs(args: ParsedArgs): ParsedArgs | DirectExecution {
     if (args.clear) return { jsExpr: call(clearHighlight) };
     const loc = args._[1];
     if (loc) {
+      // highlight <ref> → use aria-ref selector
+      if (/^e\d+$/.test(loc)) return { jsExpr: call(highlightByRef, loc) };
       const nth = args.nth !== undefined ? parseInt(String(args.nth), 10) : undefined;
       const exact = args.exact ? true : undefined;
       const isSelector = /[.#[\]>:=]/.test(loc);

--- a/packages/extension/src/panel/lib/page-scripts.ts
+++ b/packages/extension/src/panel/lib/page-scripts.ts
@@ -241,6 +241,12 @@ export async function highlightBySelector(page, selector, nth?) {
     : 'Highlighted ' + count + ' element' + (count !== 1 ? 's' : '');
 }
 
+export async function highlightByRef(page, ref) {
+  const loc = page.locator('aria-ref=' + ref);
+  await loc.highlight();
+  return 'Highlighted';
+}
+
 export async function clearHighlight(page) {
   // Highlight a non-matching locator — Playwright replaces the current highlight
   // with nothing (0 elements), clearing it visually while keeping internal state valid.

--- a/packages/extension/test/lib/commands.test.ts
+++ b/packages/extension/test/lib/commands.test.ts
@@ -143,3 +143,43 @@ describe("existing verify commands", () => {
     expect(jsExpr).toContain('"dashboard"');
   });
 });
+
+// ─── highlight ───────────────────────────────────────────────────────────────
+
+describe("highlight", () => {
+  it("routes ref to highlightByRef", () => {
+    const { jsExpr } = direct("highlight e8");
+    expect(jsExpr).toContain('highlightByRef');
+    expect(jsExpr).toContain('"e8"');
+  });
+
+  it("routes ref e1 to highlightByRef", () => {
+    const { jsExpr } = direct("highlight e1");
+    expect(jsExpr).toContain('highlightByRef');
+    expect(jsExpr).toContain('"e1"');
+  });
+
+  it("routes role+name to highlightByRole", () => {
+    const { jsExpr } = direct('highlight textbox "Email"');
+    expect(jsExpr).toContain('highlightByRole');
+    expect(jsExpr).toContain('"textbox"');
+    expect(jsExpr).toContain('"Email"');
+  });
+
+  it("routes text to highlightByText", () => {
+    const { jsExpr } = direct('highlight "Submit"');
+    expect(jsExpr).toContain('highlightByText');
+    expect(jsExpr).toContain('"Submit"');
+  });
+
+  it("routes CSS selector to highlightBySelector", () => {
+    const { jsExpr } = direct("highlight .btn-primary");
+    expect(jsExpr).toContain('highlightBySelector');
+    expect(jsExpr).toContain('".btn-primary"');
+  });
+
+  it("routes --clear to clearHighlight", () => {
+    const { jsExpr } = direct("highlight --clear");
+    expect(jsExpr).toContain('clearHighlight');
+  });
+});


### PR DESCRIPTION
## Summary
- Add ref support to `highlight` command — `highlight e8` now works using Playwright's `aria-ref` selector engine
- Extension: new `highlightByRef` page script + ref detection in command handler
- CLI: ref detection in `engine.ts` highlight-to-run-code translation
- Pick result pw commands (`highlight eN`) are now functional

## Test plan
- [x] `pnpm run build` compiles
- [x] All 956 tests pass (6 new highlight routing tests)
- [x] Manual: `snapshot` → `highlight e8` highlights the element in browser
- [ ] Manual: pick element → verify pw command `highlight eN` works
- [ ] Manual CLI: `snapshot` → `highlight e5` highlights the element

Closes #288

🤖 Generated with [Claude Code](https://claude.com/claude-code)