### PR TITLE
fix: include ARIA role in pick/recorder PW commands (#292)

### DIFF
--- a/packages/extension/src/content/locator.ts
+++ b/packages/extension/src/content/locator.ts
@@ -232,7 +232,7 @@ export function isHoverRevealed(el: Element): boolean {
  * Parse a JS locator string into PW keyword args.
  * e.g. `getByRole('tab', { name: 'npm', exact: true }).nth(1)` → `tab "npm" --nth 1`
  */
-export function locatorToPwArgs(locator: string): string {
+export function locatorToPwArgs(locator: string, role?: string | null): string {
     const q = (s: string) => `"${s}"`;
 
     // Extract nth modifier
@@ -244,17 +244,24 @@ export function locatorToPwArgs(locator: string): string {
         if (nthMatch) nth = ` --nth ${nthMatch[1]}`;
     }
 
-    // getByRole with name
+    // getByRole with name — already has role
     const roleNameMatch = locator.match(/getByRole\(['"](.+?)['"],\s*\{[^}]*name:\s*['"](.+?)['"]/);
     if (roleNameMatch) return `${roleNameMatch[1]} ${q(roleNameMatch[2])}${nth}`;
 
-    // getByRole without name
+    // getByRole without name — already has role
     const roleMatch = locator.match(/getByRole\(['"](.+?)['"]\)/);
     if (roleMatch) return `${roleMatch[1]}${nth}`;
 
-    // getByTestId / getByLabel / getByText / getByPlaceholder / getByTitle / getByAltText
+    // getByTestId — test ID is not an accessible name, don't add role
+    const testIdMatch = locator.match(/getByTestId\(['"](.+?)['"]\)/);
+    if (testIdMatch) return `${q(testIdMatch[1])}${nth}`;
+
+    // getByLabel / getByText / getByPlaceholder / getByTitle / getByAltText — prepend role if available
     const getByMatch = locator.match(/getBy\w+\(['"](.+?)['"]\)/);
-    if (getByMatch) return `${q(getByMatch[1])}${nth}`;
+    if (getByMatch) {
+        const prefix = role ? `${role} ` : '';
+        return `${prefix}${q(getByMatch[1])}${nth}`;
+    }
 
     // locator('css') fallback
     const locatorMatch = locator.match(/locator\(['"](.+?)['"]\)/);
@@ -386,7 +393,8 @@ export function buildCommands(action: string, el: Element, opts?: {
 }): { pw: string; js: string } | null {
     const { js: jsLocator, pw: pwLocator, ancestor } = generateLocatorPair(el);
     const jsLoc = `page.${jsLocator}`;
-    const pwArgs = locatorToPwArgs(pwLocator);
+    const role = getImplicitRole(el);
+    const pwArgs = locatorToPwArgs(pwLocator, role);
     const q = (s: string) => `"${s}"`;
     const inFlag = ancestor ? ` --in ${ancestor.role} ${q(ancestor.text)}` : '';
 

--- a/packages/extension/src/panel/lib/commands.ts
+++ b/packages/extension/src/panel/lib/commands.ts
@@ -132,7 +132,7 @@ import {
   highlightByText, highlightByRole, highlightBySelector, highlightByRef, clearHighlight, chainAction, goBack, goForward,
   gotoUrl, reloadPage, waitMs, getTitle, getUrl,
   evalCode, runCode, takeScreenshot, takeSnapshot,
-  refAction, pressKey, typeText,
+  refAction, pressKey, pressKeyByRole, typeText,
   localStorageGet, localStorageSet, localStorageDelete, localStorageClear, localStorageList,
   sessionStorageGet, sessionStorageSet, sessionStorageDelete, sessionStorageClear, sessionStorageList,
   cookieList, cookieGet, cookieSet, cookieDelete, cookieClear,
@@ -452,6 +452,10 @@ function resolveArgs(args: ParsedArgs): ParsedArgs | DirectExecution {
     }
     if (cmdName === 'select') {
       return { jsExpr: call(selectByRole, role, args._[2], args._.slice(3).join(' ') || '', nth, inRole, inText) };
+    }
+    if (cmdName === 'press') {
+      const key = args._.slice(3).join(' ') || '';
+      return { jsExpr: call(pressKeyByRole, role, args._[2], key, nth, inRole, inText) };
     }
   }
 

--- a/packages/extension/src/panel/lib/page-scripts.ts
+++ b/packages/extension/src/panel/lib/page-scripts.ts
@@ -379,6 +379,17 @@ export async function pressKey(page, target, key) {
   return 'Pressed ' + key;
 }
 
+export async function pressKeyByRole(page, role, name, key, nth, inRole, inText) {
+  let loc = page.getByRole(role, { name, exact: true });
+  if (inRole !== undefined && inText !== undefined) {
+    const cr = ({ list: 'listitem' })[inRole] || inRole;
+    loc = page.getByRole(cr).filter({ hasText: inText }).getByRole(role, { name, exact: true });
+  }
+  if (nth !== undefined) loc = loc.nth(nth);
+  await loc.press(key);
+  return 'Pressed ' + key;
+}
+
 export async function typeText(page, text) {
   await page.keyboard.type(text);
   return 'Typed';

--- a/packages/extension/src/panel/lib/pick-info.ts
+++ b/packages/extension/src/panel/lib/pick-info.ts
@@ -13,27 +13,54 @@ function extractNth(locator: string): string {
 }
 
 /**
+ * Derive ARIA role from element tag + input type (for pick results, no DOM access).
+ */
+function tagToRole(info: ElementPickInfo): string | null {
+    const tag = info.tag.toLowerCase();
+    const type = (info.attributes?.type || '').toLowerCase();
+    if (tag === 'input') {
+        if (type === 'checkbox') return 'checkbox';
+        if (type === 'radio') return 'radio';
+        if (type === 'button' || type === 'submit' || type === 'reset') return 'button';
+        if (type === 'hidden') return null;
+        return 'textbox';
+    }
+    if (tag === 'textarea') return 'textbox';
+    if (tag === 'select') return 'combobox';
+    if (tag === 'button') return 'button';
+    if (tag === 'a') return 'link';
+    if (tag === 'img') return 'img';
+    return null;
+}
+
+/**
  * Try to derive a pw highlight command from a locator string.
+ * When role is provided, non-getByRole patterns include it (e.g. `highlight textbox "text"`).
  * Returns null if no getBy* pattern matches.
  */
-function parsePwCommand(locator: string, nth: string): string | null {
+function parsePwCommand(locator: string, nth: string, role?: string | null): string | null {
+    // getByRole — already has role
     const roleNameMatch = locator.match(/getByRole\(['"](.+?)['"],\s*\{[^}]*name:\s*['"](.+?)['"]/);
     if (roleNameMatch) return `highlight ${roleNameMatch[1]} "${roleNameMatch[2]}"${nth}`;
 
     const roleMatch = locator.match(/getByRole\(['"](.+?)['"]\)/);
     if (roleMatch) return `highlight ${roleMatch[1]}${nth}`;
 
+    // getByTestId — test ID is not an accessible name, don't add role
     const testIdMatch = locator.match(/getByTestId\(['"](.+?)['"]\)/);
     if (testIdMatch) return `highlight "${testIdMatch[1]}"${nth}`;
 
+    // getByLabel / getByText / getByPlaceholder — prepend role if available
+    const prefix = role ? `${role} ` : '';
+
     const labelMatch = locator.match(/getByLabel\(['"](.+?)['"]\)/);
-    if (labelMatch) return `highlight "${labelMatch[1]}"${nth}`;
+    if (labelMatch) return `highlight ${prefix}"${labelMatch[1]}"${nth}`;
 
     const textMatch = locator.match(/getByText\(['"](.+?)['"]\)/);
-    if (textMatch) return `highlight "${textMatch[1]}"${nth}`;
+    if (textMatch) return `highlight ${prefix}"${textMatch[1]}"${nth}`;
 
     const placeholderMatch = locator.match(/getByPlaceholder\(['"](.+?)['"]\)/);
-    if (placeholderMatch) return `highlight "${placeholderMatch[1]}"${nth}`;
+    if (placeholderMatch) return `highlight ${prefix}"${placeholderMatch[1]}"${nth}`;
 
     return null;
 }
@@ -48,14 +75,15 @@ function derivePwCommand(info: ElementPickInfo, jsLocator?: string): string | nu
     // Fall back to Playwright's locator nth only when content script has none
     const contentNth = extractNth(info.locator);
     const nth = contentNth || extractNth(jsLocator ?? info.locator);
+    const role = tagToRole(info);
 
     // Try content script's locator first
-    const fromContentScript = parsePwCommand(info.locator, nth);
+    const fromContentScript = parsePwCommand(info.locator, nth, role);
     if (fromContentScript) return fromContentScript;
 
     // Fallback: try Playwright's locator (may have better name for long-text elements)
     if (jsLocator && jsLocator !== info.locator) {
-        const fromPlaywright = parsePwCommand(jsLocator, nth);
+        const fromPlaywright = parsePwCommand(jsLocator, nth, role);
         if (fromPlaywright) return fromPlaywright;
     }
 

--- a/packages/extension/test/content/locator.test.ts
+++ b/packages/extension/test/content/locator.test.ts
@@ -606,6 +606,38 @@ describe('locator', () => {
             expect(locatorToPwArgs('somethingWeird'))
                 .toBe('"somethingWeird"');
         });
+
+        // ─── Role prefix for non-getByRole patterns ──────────────────────
+
+        it('prepends role for getByPlaceholder when role provided', () => {
+            expect(locatorToPwArgs("getByPlaceholder('Search...')", 'textbox'))
+                .toBe('textbox "Search..."');
+        });
+
+        it('prepends role for getByLabel when role provided', () => {
+            expect(locatorToPwArgs("getByLabel('Email')", 'textbox'))
+                .toBe('textbox "Email"');
+        });
+
+        it('prepends role for getByText when role provided', () => {
+            expect(locatorToPwArgs("getByText('Submit')", 'button'))
+                .toBe('button "Submit"');
+        });
+
+        it('does not prepend role for getByTestId', () => {
+            expect(locatorToPwArgs("getByTestId('my-btn')", 'button'))
+                .toBe('"my-btn"');
+        });
+
+        it('does not prepend role for getByRole (already has role)', () => {
+            expect(locatorToPwArgs("getByRole('button', { name: 'Submit' })", 'button'))
+                .toBe('button "Submit"');
+        });
+
+        it('prepends role with nth modifier', () => {
+            expect(locatorToPwArgs("getByPlaceholder('Search...').first()", 'textbox'))
+                .toBe('textbox "Search..." --nth 0');
+        });
     });
 
     // ─── isTextField ──────────────────────────────────────────────────────

--- a/packages/extension/test/lib/commands.test.ts
+++ b/packages/extension/test/lib/commands.test.ts
@@ -183,3 +183,26 @@ describe("highlight", () => {
     expect(jsExpr).toContain('clearHighlight');
   });
 });
+
+describe("press", () => {
+  it("routes role+name+key to pressKeyByRole", () => {
+    const { jsExpr } = direct('press textbox "What needs to be done?" Enter');
+    expect(jsExpr).toContain('pressKeyByRole');
+    expect(jsExpr).toContain('"textbox"');
+    expect(jsExpr).toContain('"What needs to be done?"');
+    expect(jsExpr).toContain('"Enter"');
+  });
+
+  it("routes global key to pressKey", () => {
+    const { jsExpr } = direct("press Enter");
+    expect(jsExpr).toContain('pressKey');
+    expect(jsExpr).toContain('"Enter"');
+  });
+
+  it("routes text+key to pressKey", () => {
+    const { jsExpr } = direct('press "Email" Tab');
+    expect(jsExpr).toContain('pressKey');
+    expect(jsExpr).toContain('"Email"');
+    expect(jsExpr).toContain('"Tab"');
+  });
+});

--- a/packages/extension/test/lib/pick-info.test.ts
+++ b/packages/extension/test/lib/pick-info.test.ts
@@ -66,6 +66,53 @@ describe('buildPickResult', () => {
         expect(result.assertPw).toBe('verify-element link "Home"');
     });
 
+    it('derives pw command with role for getByPlaceholder on input', () => {
+        const result = buildPickResult(makeInfo({
+            locator: "getByPlaceholder('What needs to be done?')",
+            tag: 'input',
+            text: '',
+            attributes: {},
+        }));
+        expect(result.pwCommand).toBe('highlight textbox "What needs to be done?"');
+    });
+
+    it('derives pw command with role for getByLabel on textarea', () => {
+        const result = buildPickResult(makeInfo({
+            locator: "getByLabel('Notes')",
+            tag: 'textarea',
+            text: '',
+            attributes: {},
+        }));
+        expect(result.pwCommand).toBe('highlight textbox "Notes"');
+    });
+
+    it('derives pw command with role for getByText on button', () => {
+        const result = buildPickResult(makeInfo({
+            locator: "getByText('Submit')",
+            tag: 'button',
+            text: 'Submit',
+        }));
+        expect(result.pwCommand).toBe('highlight button "Submit"');
+    });
+
+    it('does not add role for getByTestId', () => {
+        const result = buildPickResult(makeInfo({
+            locator: "getByTestId('submit-btn')",
+            tag: 'button',
+            text: 'Submit',
+        }));
+        expect(result.pwCommand).toBe('highlight "submit-btn"');
+    });
+
+    it('does not add role for tags without implicit role', () => {
+        const result = buildPickResult(makeInfo({
+            locator: "getByText('Hello')",
+            tag: 'p',
+            text: 'Hello',
+        }));
+        expect(result.pwCommand).toBe('highlight "Hello"');
+    });
+
     it('derives pw command from Playwright locator when content script locator is CSS', () => {
         const result = buildPickResult(makeInfo({
             locator: "locator('p.hero')",


### PR DESCRIPTION
## Summary
- Pick results and recorder now include the element's ARIA role in PW keyword commands (e.g. `fill textbox "Email" "value"` instead of `fill "Email" "value"`)
- Added `pressKeyByRole` to handle role-based press commands (`press textbox "text" Enter`)
- Role is excluded for `getByTestId` (test ID is not an accessible name) and tags without implicit roles (e.g. `<p>`, `<div>`)

## Test plan
- [x] 14 new tests across 3 test files (locator, pick-info, commands)
- [x] All 973 tests pass
- [x] Manual browser testing: pick, record, highlight with roles all work
- [x] `press textbox "What needs to be done?" Enter` executes correctly

Closes #292

🤖 Generated with [Claude Code](https://claude.com/claude-code)