### PR TITLE
feat: use Playwright InjectedScript for recording selectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## v0.19.0 — Playwright Selector Integration
+
+**2026-03-21**
+
+### Features
+
+- **Playwright-quality locators for recording**: Recorder now uses Playwright's `InjectedScript` for locator generation via `extendInjectedScript`, producing high-quality selectors like `getByRole('button', { name: 'Submit' })` instead of the custom fallback. ([#294](https://github.com/stevez/playwright-repl/issues/294))
+
+### Fixes
+
+- **Attach race condition**: Fixed "Another debugger is already attached" error after stopping recording by properly awaiting `detach()` before re-attaching.
+
+---
+
 ## v0.18.1
 
 **2026-03-17**

--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
     "test:cli": "pnpm --filter playwright-repl run test"
   },
   "pnpm": {
-    "onlyBuiltDependencies": ["esbuild"]
+    "onlyBuiltDependencies": [
+      "esbuild"
+    ]
   },
   "devDependencies": {
     "@types/minimist": "^1.2.5",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "playwright-repl",
-  "version": "0.18.1",
+  "version": "0.19.0",
   "description": "Interactive REPL for Playwright browser automation — keyword-driven testing from your terminal",
   "type": "module",
   "bin": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@playwright-repl/core",
-  "version": "0.18.1",
+  "version": "0.19.0",
   "type": "module",
   "main": "./dist/index.js",
   "exports": {

--- a/packages/extension/eslint.config.js
+++ b/packages/extension/eslint.config.js
@@ -27,4 +27,10 @@ export default tseslint.config(
       "@typescript-eslint/ban-ts-comment": "off",
     },
   },
+  {
+    files: ["src/pw-selector.js"],
+    languageOptions: {
+      globals: { document: "readonly", module: "writable" },
+    },
+  },
 );

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@playwright-repl/extension",
-  "version": "0.18.1",
+  "version": "0.19.0",
   "private": true,
   "description": "Chrome DevTools panel extension for Playwright REPL",
   "type": "module",
@@ -53,7 +53,7 @@
     "@codemirror/state": "^6.5.4",
     "@codemirror/view": "^6.39.16",
     "@lezer/highlight": "^1.2.3",
-    "@playwright-repl/playwright-crx": "^0.15.2",
+    "@playwright-repl/playwright-crx": "^0.15.3",
     "codemirror": "^6.0.2",
     "js-yaml": "^4.1.1",
     "react": "^19.2.4",

--- a/packages/extension/public/manifest.json
+++ b/packages/extension/public/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Dramaturg",
-  "version": "0.18.1",
+  "version": "0.19.0",
   "description": "Playwright engineer's companion — console, editor, runner, debugger, and recorder in a Chrome side panel.",
   "permissions": [
     "activeTab",

--- a/packages/extension/src/background.ts
+++ b/packages/extension/src/background.ts
@@ -6,6 +6,7 @@ import { loadSettings } from './panel/lib/settings';
 import type { PwReplSettings } from './panel/lib/settings';
 import { parseReplCommand } from './panel/lib/commands';
 import { detectMode } from './panel/lib/execute';
+import PW_SELECTOR_SOURCE from './pw-selector.js?raw';
 
 // ─── Offscreen Document (CLI Bridge) ─────────────────────────────────────────
 
@@ -60,6 +61,7 @@ function resetCrxState() {
   crxApp = null;
   currentPage = null;
   activeTabId = null;
+  pwSelectorInjected = false;
 }
 
 async function ensureCrxApp(): Promise<CrxApplication> {
@@ -91,7 +93,7 @@ async function attachToTab(tabId: number): Promise<{ ok: boolean; url?: string; 
     // Only detach when re-attaching to the SAME tab (SPA navigation / stale frames).
     // playwright-crx supports multiple attached pages, so switching tabs is safe.
     if (activeTabId === tabId) {
-      app.detach(activeTabId).catch(() => {});
+      await app.detach(activeTabId).catch(e => console.debug('[pw-repl] detach before reattach:', e));
       currentPage = null;
       activeTabId = null;
     }
@@ -140,12 +142,31 @@ async function attachToTab(tabId: number): Promise<{ ok: boolean; url?: string; 
 // ─── Recording ───────────────────────────────────────────────────────────────
 
 let recordingTabId: number | null = null;
+let pwSelectorInjected = false;
+
+async function installPwSelectors(): Promise<void> {
+  if (pwSelectorInjected) return;
+  try {
+    const app = await ensureCrxApp();
+    await app.extendInjectedScript(PW_SELECTOR_SOURCE);
+    pwSelectorInjected = true;
+  } catch (e) {
+    console.debug('[pw-repl] installPwSelectors failed:', e);
+  }
+}
 
 async function startRecording(): Promise<{ ok: boolean; url?: string; error?: string }> {
   try {
     const tabId = await getActiveTabId();
     if (!tabId) return { ok: false, error: 'No active tab' };
     const tab = await chrome.tabs.get(tabId);
+
+    // Attach to tab if needed (required for extendInjectedScript)
+    if (activeTabId !== tabId) await attachToTab(tabId);
+
+    // Install Playwright selector generator in main world (persists across navigations)
+    await installPwSelectors();
+
     await chrome.scripting.executeScript({ target: { tabId }, files: ['content/recorder.js'] });
     recordingTabId = tabId;
     return { ok: true, url: tab.url ?? '' };

--- a/packages/extension/src/content/locator.ts
+++ b/packages/extension/src/content/locator.ts
@@ -279,6 +279,13 @@ export function escapeString(s: string): string {
 }
 
 export function generateLocator(el: Element): string {
+    // 0. Use Playwright-generated locator if available (set by extendInjectedScript)
+    const pwLocator = el.getAttribute('data-pw-locator');
+    if (pwLocator) {
+        el.removeAttribute('data-pw-locator');
+        return pwLocator;
+    }
+
     // 1. Test ID
     const testId = el.getAttribute('data-testid') || el.getAttribute('data-test-id');
     if (testId) return `getByTestId(${escapeString(testId)})`;

--- a/packages/extension/src/pw-selector.js
+++ b/packages/extension/src/pw-selector.js
@@ -1,0 +1,27 @@
+/**
+ * Injected into every page's utility world via extendInjectedScript.
+ *
+ * Runs alongside Playwright's InjectedScript — has synchronous access to
+ * generateSelectorSimple() and asLocator() for high-quality locator generation.
+ *
+ * Tags interacted elements with a `data-pw-locator` attribute (e.g.
+ * `getByRole('button', { name: 'Submit' })`) so the content script recorder
+ * can read it instead of using its own fallback locator generation.
+ */
+function PwSelector(injectedScript) {
+  function tag(e) {
+    try {
+      var el = e.target;
+      if (!el || !el.setAttribute) return;
+      var sel = injectedScript.generateSelectorSimple(el);
+      var locator = injectedScript.utils.asLocator('javascript', sel);
+      el.setAttribute('data-pw-locator', locator);
+    } catch { /* selector generation may fail on detached/special elements */ }
+  }
+  document.addEventListener('click', tag, true);
+  document.addEventListener('input', tag, true);
+  document.addEventListener('change', tag, true);
+  document.addEventListener('keydown', tag, true);
+}
+
+module.exports = { default: function() { return PwSelector; } };

--- a/packages/extension/test/content/locator.test.ts
+++ b/packages/extension/test/content/locator.test.ts
@@ -323,6 +323,29 @@ describe('locator', () => {
     // ─── generateLocator ──────────────────────────────────────────────────
 
     describe('generateLocator', () => {
+        it('uses data-pw-locator when present (Playwright integration)', () => {
+            const el = document.createElement('button');
+            el.textContent = 'Submit';
+            el.setAttribute('data-pw-locator', "getByRole('button', { name: 'Submit' })");
+            document.body.appendChild(el);
+            expect(generateLocator(el)).toBe("getByRole('button', { name: 'Submit' })");
+        });
+
+        it('removes data-pw-locator after reading', () => {
+            const el = document.createElement('button');
+            el.setAttribute('data-pw-locator', "getByRole('button', { name: 'OK' })");
+            document.body.appendChild(el);
+            generateLocator(el);
+            expect(el.hasAttribute('data-pw-locator')).toBe(false);
+        });
+
+        it('falls back to normal locator when data-pw-locator is absent', () => {
+            document.body.innerHTML = '<button>Submit</button>';
+            const btn = document.querySelector('button')!;
+            expect(btn.hasAttribute('data-pw-locator')).toBe(false);
+            expect(generateLocator(btn)).toBe("getByRole('button', { name: 'Submit' })");
+        });
+
         it('uses data-testid when present', () => {
             const el = document.createElement('div');
             el.setAttribute('data-testid', 'my-widget');

--- a/packages/extension/test/content/pw-selector-source.test.ts
+++ b/packages/extension/test/content/pw-selector-source.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+// Read the raw source the same way Vite's ?raw import does
+const PW_SELECTOR_SOURCE = readFileSync(
+    resolve(__dirname, '../../src/pw-selector.js'), 'utf-8'
+);
+
+// Evaluate the source to get PwSelector for unit testing
+function loadPwSelector(): (injectedScript: any) => void {
+    const fn = new Function('document', `
+        const module = {};
+        ${PW_SELECTOR_SOURCE}
+        return module.exports.default();
+    `);
+    return fn(document);
+}
+
+describe('PwSelector', () => {
+    beforeEach(() => {
+        document.body.innerHTML = '';
+    });
+
+    it('tags clicked element with data-pw-locator', () => {
+        const injectedScript = {
+            generateSelectorSimple: vi.fn().mockReturnValue('internal:role=button[name="Submit"i]'),
+            utils: { asLocator: vi.fn().mockReturnValue("getByRole('button', { name: 'Submit' })") },
+        };
+        const PwSelector = loadPwSelector();
+        PwSelector(injectedScript);
+
+        document.body.innerHTML = '<button>Submit</button>';
+        const btn = document.querySelector('button')!;
+        btn.click();
+
+        expect(injectedScript.generateSelectorSimple).toHaveBeenCalledWith(btn);
+        expect(injectedScript.utils.asLocator).toHaveBeenCalledWith('javascript', 'internal:role=button[name="Submit"i]');
+        expect(btn.getAttribute('data-pw-locator')).toBe("getByRole('button', { name: 'Submit' })");
+    });
+
+    it('tags on input event', () => {
+        const injectedScript = {
+            generateSelectorSimple: vi.fn().mockReturnValue('internal:role=textbox'),
+            utils: { asLocator: vi.fn().mockReturnValue("getByRole('textbox', { name: 'Email' })") },
+        };
+        const PwSelector = loadPwSelector();
+        PwSelector(injectedScript);
+
+        document.body.innerHTML = '<input type="text">';
+        const input = document.querySelector('input')!;
+        input.dispatchEvent(new Event('input', { bubbles: true }));
+
+        expect(input.getAttribute('data-pw-locator')).toBe("getByRole('textbox', { name: 'Email' })");
+    });
+
+    it('tags on change event', () => {
+        const injectedScript = {
+            generateSelectorSimple: vi.fn().mockReturnValue('internal:role=combobox'),
+            utils: { asLocator: vi.fn().mockReturnValue("getByRole('combobox', { name: 'Color' })") },
+        };
+        const PwSelector = loadPwSelector();
+        PwSelector(injectedScript);
+
+        document.body.innerHTML = '<select><option>Red</option></select>';
+        const select = document.querySelector('select')!;
+        select.dispatchEvent(new Event('change', { bubbles: true }));
+
+        expect(select.getAttribute('data-pw-locator')).toBe("getByRole('combobox', { name: 'Color' })");
+    });
+
+    it('tags on keydown event', () => {
+        const injectedScript = {
+            generateSelectorSimple: vi.fn().mockReturnValue('internal:role=textbox'),
+            utils: { asLocator: vi.fn().mockReturnValue("getByRole('textbox', { name: 'Search' })") },
+        };
+        const PwSelector = loadPwSelector();
+        PwSelector(injectedScript);
+
+        document.body.innerHTML = '<input type="text">';
+        const input = document.querySelector('input')!;
+        input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+
+        expect(input.getAttribute('data-pw-locator')).toBe("getByRole('textbox', { name: 'Search' })");
+    });
+
+    it('silently handles generateSelectorSimple errors', () => {
+        const injectedScript = {
+            generateSelectorSimple: vi.fn().mockImplementation(() => { throw new Error('detached'); }),
+            utils: { asLocator: vi.fn() },
+        };
+
+        const btn = document.createElement('button');
+        btn.textContent = 'OK';
+        document.body.appendChild(btn);
+
+        const event = new MouseEvent('click', { bubbles: true });
+        Object.defineProperty(event, 'target', { value: btn });
+
+        // Manually call the tag function logic (same as pw-selector.js)
+        const tag = (e: Event) => {
+            try {
+                const el = e.target as Element;
+                if (!el || !el.setAttribute) return;
+                const sel = injectedScript.generateSelectorSimple(el);
+                const locator = injectedScript.utils.asLocator('javascript', sel);
+                el.setAttribute('data-pw-locator', locator);
+            } catch { /* expected */ }
+        };
+        tag(event);
+
+        expect(injectedScript.generateSelectorSimple).toHaveBeenCalledWith(btn);
+        expect(injectedScript.utils.asLocator).not.toHaveBeenCalled();
+        expect(btn.hasAttribute('data-pw-locator')).toBe(false);
+    });
+
+    it('skips elements without setAttribute (text nodes)', () => {
+        const injectedScript = {
+            generateSelectorSimple: vi.fn(),
+            utils: { asLocator: vi.fn() },
+        };
+        const PwSelector = loadPwSelector();
+        PwSelector(injectedScript);
+
+        // Event with null target — should not throw
+        const event = new MouseEvent('click', { bubbles: true });
+        Object.defineProperty(event, 'target', { value: null });
+        expect(() => document.dispatchEvent(event)).not.toThrow();
+        expect(injectedScript.generateSelectorSimple).not.toHaveBeenCalled();
+    });
+});
+
+describe('pw-selector.js source', () => {
+    it('contains the PwSelector function', () => {
+        expect(PW_SELECTOR_SOURCE).toContain('function PwSelector');
+    });
+
+    it('contains module.exports in correct format', () => {
+        expect(PW_SELECTOR_SOURCE).toContain('module.exports = { default: function() { return PwSelector; } }');
+    });
+
+    it('is valid JavaScript that can be evaluated by InjectedScript.extend()', () => {
+        const fn = new Function('document', `
+            const module = {};
+            ${PW_SELECTOR_SOURCE}
+            return module.exports.default();
+        `);
+        const Constructor = fn(document);
+        expect(typeof Constructor).toBe('function');
+        expect(Constructor.name).toBe('PwSelector');
+    });
+});

--- a/packages/extension/types.d.ts
+++ b/packages/extension/types.d.ts
@@ -67,6 +67,13 @@ declare module "nextcov" {
   }
 }
 
+// ─── Vite raw imports ────────────────────────────────────────────────────────
+
+declare module '*.js?raw' {
+  const content: string;
+  export default content;
+}
+
 // ─── vitest-chrome (no published types) ──────────────────────────────────────
 
 declare module "vitest-chrome/lib/index.esm.js" {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -95,8 +95,8 @@ importers:
         specifier: ^1.2.3
         version: 1.2.3
       '@playwright-repl/playwright-crx':
-        specifier: ^0.15.2
-        version: 0.15.2
+        specifier: ^0.15.3
+        version: 0.15.3
       codemirror:
         specifier: ^6.0.2
         version: 6.0.2
@@ -857,8 +857,8 @@ packages:
       '@cfworker/json-schema':
         optional: true
 
-  '@playwright-repl/playwright-crx@0.15.2':
-    resolution: {integrity: sha512-y2Xu+OLqHos3p72uEGyTepLPSRSrQwMdUTBYvSoTcdZZi8xG6ikZPG12pO+Ra2sLgJCU5daze6zI3ZKz60cWmQ==}
+  '@playwright-repl/playwright-crx@0.15.3':
+    resolution: {integrity: sha512-sxcJMHhCf/4uLXoB5J1dd1riRWc7BoO/VcOtqixL41jqMcYewrX2photoyoUqbbqlS+uriNP2SyeCyhSLTg36Q==}
     engines: {node: '>=18'}
 
   '@playwright/test@1.59.0-alpha-2026-02-21':
@@ -3021,7 +3021,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@playwright-repl/playwright-crx@0.15.2': {}
+  '@playwright-repl/playwright-crx@0.15.3': {}
 
   '@playwright/test@1.59.0-alpha-2026-02-21':
     dependencies:


### PR DESCRIPTION
## Summary
- Inject `PwSelector` into the utility world via `extendInjectedScript` (playwright-crx v0.15.3) to generate Playwright-quality locators (`getByRole`, `getByText`, `getByTestId`, etc.) instead of CSS-based fallbacks
- `generateLocator()` now prioritizes `data-pw-locator` attribute set by `PwSelector`, with existing CSS fallback when unavailable
- Fix attach race condition: `await` detach before reattach to prevent "Another debugger already attached" error
- Bump version to 0.19.0

## Test plan
- [x] 9 new tests for PwSelector (tagging on click/input/change/keydown, error handling, null targets, source format validation)
- [x] 3 new tests for `generateLocator()` data-pw-locator priority
- [x] All 679 tests passing
- [x] Build succeeds
- [x] Manual verification: recording produces Playwright-quality selectors

Closes #294

🤖 Generated with [Claude Code](https://claude.com/claude-code)