### PR TITLE
chore: bump mcp package version to 0.19.0

### DIFF
--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@playwright-repl/mcp",
-    "version": "0.18.1",
+    "version": "0.19.0",
     "type": "module",
     "bin": {
         "playwright-repl-mcp": "./dist/index.js"


### PR DESCRIPTION
## Summary
- Bump `@playwright-repl/mcp` version from 0.18.1 to 0.19.0 to match other packages

Missed in #296.

🤖 Generated with [Claude Code](https://claude.com/claude-code)