### PR TITLE
fix: handle complex chained locators in picker PW command/assertion derivation (#299)

### DIFF
--- a/packages/extension/src/content/picker.ts
+++ b/packages/extension/src/content/picker.ts
@@ -65,7 +65,7 @@ export function onClick(e: MouseEvent) {
 
     if (!currentElement) return;
     const info = gatherInfo(currentElement);
-    // Mark element so main-world script can find it for Playwright locator generation
+    // Mark element so CDP can find it for _generateLocatorString()
     const pickId = Math.random().toString(36).slice(2);
     currentElement.setAttribute('data-pw-pick-id', pickId);
     cleanup();

--- a/packages/extension/src/panel/components/Toolbar.tsx
+++ b/packages/extension/src/panel/components/Toolbar.tsx
@@ -292,8 +292,8 @@ function Toolbar({ editorContent, editorMode, stepLine, attachedUrl, attachedTab
         const listener = (msg: any) => {
             if (msg.type === 'element-picked-raw') {
                 setIsPicking(false);
-                resolvePlaywrightLocator(msg.pickId).then(async pwLocator => {
-                    const pickResult = buildPickResult({ ...msg.info, pwLocator });
+                resolvePlaywrightLocator(msg.pickId).then(cdpLocator => {
+                    const pickResult = buildPickResult(msg.info, cdpLocator);
                     dispatch({ type: 'ADD_LINE', line: { text: '', type: 'info', pickResult } });
                 });
             }

--- a/packages/extension/src/panel/lib/pick-info.ts
+++ b/packages/extension/src/panel/lib/pick-info.ts
@@ -68,28 +68,25 @@ function parsePwCommand(locator: string, nth: string, role?: string | null): str
 
 /**
  * Derive a .pw keyword command from element info.
- * Tries content script's locator first, then Playwright's jsLocator as fallback.
- * Returns null if no suitable name/text can be extracted.
+ * Returns null when the locator uses chains (.filter, locator()) that
+ * can't be accurately expressed in PW keyword syntax.
  */
-function derivePwCommand(info: ElementPickInfo, jsLocator?: string): string | null {
-    // Prefer nth from content script's locator (globally correct)
-    // Fall back to Playwright's locator nth only when content script has none
-    const contentNth = extractNth(info.locator);
-    const nth = contentNth || extractNth(jsLocator ?? info.locator);
-    const role = tagToRole(info);
+function derivePwCommand(info: ElementPickInfo): string | null {
+    const nth = extractNth(info.locator);
+    const isComplex = /\.filter\(/.test(info.locator) || /^locator\(/.test(info.locator);
 
-    // Try content script's locator first
-    const fromContentScript = parsePwCommand(info.locator, nth, role);
-    if (fromContentScript) return fromContentScript;
-
-    // Fallback: try Playwright's locator (may have better name for long-text elements)
-    if (jsLocator && jsLocator !== info.locator) {
-        const fromPlaywright = parsePwCommand(jsLocator, nth, role);
-        if (fromPlaywright) return fromPlaywright;
+    // For simple getBy* locators, parse the PW command from the locator string
+    if (!isComplex) {
+        const role = tagToRole(info);
+        const fromLocator = parsePwCommand(info.locator, nth, role);
+        if (fromLocator) return fromLocator;
     }
 
-    // Last resort: use element text content
-    if (info.text && info.text.length <= 80) return `highlight "${info.text}"${nth}`;
+    // Fall back to element role + text from element info
+    const role = info.attributes?.role || tagToRole(info);
+    const text = info.text?.trim();
+    if (role && text && text.length <= 80) return `highlight ${role} "${text}"${nth}`;
+    if (text && text.length <= 80) return `highlight "${text}"${nth}`;
 
     return null;
 }
@@ -130,9 +127,8 @@ function deriveAssertion(info: ElementPickInfo, locator: string, pwCommand: stri
     // Extract name from pw command, falling back to JS locator string
     const name = (pwCommand ? extractPwName(pwCommand) : null) ?? extractLocatorName(locator);
     const quotedName = name ? `"${name}"` : null;
-    // Extract role and nth from locator for pw assertions
-    const roleMatch = locator.match(/getByRole\(['"](.+?)['"]/);
-    const role = roleMatch ? roleMatch[1] : null;
+    // Extract role from element attributes (more reliable than regex on chained locators)
+    const role = info.attributes?.role || tagToRole(info);
     const nth = extractNth(locator);
 
     // Checkbox/radio → checked assertion
@@ -196,15 +192,14 @@ function deriveAssertion(info: ElementPickInfo, locator: string, pwCommand: stri
 
 /**
  * Build a PickResultData from element info gathered by the content script.
- * Prefer content script's locator (simpler, disambiguated with .nth()).
- * Fall back to Playwright's locator only when content script uses CSS fallback.
+ * Uses CDP _generateLocatorString() when available (cleaner locators),
+ * falls back to content script's locator (from data-pw-locator or custom logic).
  */
-export function buildPickResult(info: ElementPickInfo): PickResultData {
-    const isCssFallback = /^locator\(/.test(info.locator);
-    const jsLocator = isCssFallback ? (info.pwLocator ?? info.locator) : info.locator;
+export function buildPickResult(info: ElementPickInfo, cdpLocator?: string | null): PickResultData {
+    const jsLocator = cdpLocator ?? info.locator;
     const locator = `page.${jsLocator}`;
     const jsExpression = `await page.${jsLocator}.highlight();`;
-    const pwCommand = derivePwCommand(info, jsLocator);
+    const pwCommand = derivePwCommand({ ...info, locator: jsLocator });
     const { assertJs, assertPw } = deriveAssertion(info, locator, pwCommand);
 
     return {
@@ -274,7 +269,7 @@ export function pickResultToSerialized(data: PickResultData): SerializedValue {
 }
 
 /**
- * Resolve Playwright's locator for a picked element via swDebugEval.
+ * Resolve Playwright's locator for a picked element via CDP _generateLocatorString().
  * The element must be marked with data-pw-pick-id by the content script.
  */
 export async function resolvePlaywrightLocator(pickId: string): Promise<string | null> {
@@ -288,3 +283,4 @@ export async function resolvePlaywrightLocator(pickId: string): Promise<string |
         return null;
     }
 }
+

--- a/packages/extension/src/panel/types.ts
+++ b/packages/extension/src/panel/types.ts
@@ -30,7 +30,6 @@ export type PickResultData = {
 
 export type ElementPickInfo = {
     locator: string;
-    pwLocator?: string | null;
     tag: string;
     text: string;
     html: string;

--- a/packages/extension/test/lib/pick-info.test.ts
+++ b/packages/extension/test/lib/pick-info.test.ts
@@ -29,17 +29,18 @@ describe('buildPickResult', () => {
         expect(result.jsExpression).toBe("await page.getByRole('button', { name: 'Submit' }).highlight();");
     });
 
-    it('prefers content script locator over pwLocator for getByRole', () => {
-        const result = buildPickResult(makeInfo({ pwLocator: "getByRole('button', { name: 'Submit' }).first()" }));
+    it('uses cdpLocator when provided (cleaner than content script locator)', () => {
+        const result = buildPickResult(
+            makeInfo({ locator: "locator('div').filter({ hasText: /^Submit$/ }).getByRole('button')" }),
+            "getByRole('button', { name: 'Submit' })",
+        );
         expect(result.locator).toBe("page.getByRole('button', { name: 'Submit' })");
+        expect(result.jsExpression).toBe("await page.getByRole('button', { name: 'Submit' }).highlight();");
     });
 
-    it('uses pwLocator when content script locator is CSS fallback', () => {
-        const result = buildPickResult(makeInfo({
-            locator: "locator('div.content')",
-            pwLocator: "getByText('Cross-browser')",
-        }));
-        expect(result.locator).toBe("page.getByText('Cross-browser')");
+    it('falls back to content script locator when cdpLocator is null', () => {
+        const result = buildPickResult(makeInfo(), null);
+        expect(result.locator).toBe("page.getByRole('button', { name: 'Submit' })");
     });
 
     it('derives pw command from role + name', () => {
@@ -113,14 +114,12 @@ describe('buildPickResult', () => {
         expect(result.pwCommand).toBe('highlight "Hello"');
     });
 
-    it('derives pw command from Playwright locator when content script locator is CSS', () => {
+    it('derives pw command from getByText locator', () => {
         const result = buildPickResult(makeInfo({
-            locator: "locator('p.hero')",
-            pwLocator: "getByText('Cross-browser. Playwright')",
+            locator: "getByText('Cross-browser. Playwright')",
             tag: 'p',
             text: 'Cross-browser. Playwright supports all modern rendering engines including Chromium, WebKit, and Firefox.',
         }));
-        // pw command should come from Playwright's locator, not the CSS fallback
         expect(result.pwCommand).toBe('highlight "Cross-browser. Playwright"');
         // getByText locator → toBeVisible (toContainText would be redundant)
         expect(result.assertJs).toBe("await expect(page.getByText('Cross-browser. Playwright')).toBeVisible();");


### PR DESCRIPTION
## Summary

- Fix `derivePwCommand()` producing wrong PW commands for complex chained locators (`.filter()`, `locator()`) by using element info (role attr + text) instead of regex parsing
- Fix `deriveAssertion()` extracting role via regex on locator string (breaks on chains) — now uses `info.attributes?.role || tagToRole(info)`
- Simplify `buildPickResult()`: remove `isCssFallback` / `pwLocator` branching, accept optional `cdpLocator` parameter directly

## Test plan

- [x] Unit tests pass (679)
- [x] Component tests pass (164)
- [ ] Pick element with simple locator → verify correct PW command
- [ ] Pick element with complex chained locator → verify PW command uses role + text from element info

Closes #299

🤖 Generated with [Claude Code](https://claude.com/claude-code)