### PR TITLE
feat: support role-based commands in CLI standalone mode

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,7 +49,7 @@ jobs:
         working-directory: packages/extension
 
       - name: Run CLI E2E tests
-        run: node dist/playwright-repl.js --replay examples/ --silent
+        run: node dist/playwright-repl.js --replay examples/
         working-directory: packages/cli
 
       - name: Run extension E2E tests

--- a/packages/cli/examples/01-add-todos.pw
+++ b/packages/cli/examples/01-add-todos.pw
@@ -4,11 +4,11 @@
 goto https://demo.playwright.dev/todomvc/
 localstorage-clear
 reload
-fill "What needs to be done?" "Buy groceries"
+fill textbox "What needs to be done?" "Buy groceries"
 press Enter
-fill "What needs to be done?" "Write tests"
+fill textbox "What needs to be done?" "Write tests"
 press Enter
-fill "What needs to be done?" "Deploy to production"
+fill textbox "What needs to be done?" "Deploy to production"
 press Enter
 verify-text "Buy groceries"
 verify-text "Write tests"

--- a/packages/cli/examples/02-complete-and-filter.pw
+++ b/packages/cli/examples/02-complete-and-filter.pw
@@ -4,21 +4,21 @@
 goto https://demo.playwright.dev/todomvc/
 localstorage-clear
 reload
-fill "What needs to be done?" "Buy groceries"
+fill textbox "What needs to be done?" "Buy groceries"
 press Enter
-fill "What needs to be done?" "Write tests"
+fill textbox "What needs to be done?" "Write tests"
 press Enter
-fill "What needs to be done?" "Deploy to production"
+fill textbox "What needs to be done?" "Deploy to production"
 press Enter
 check "Buy groceries"
 verify-text "2 items left"
-click "Active"
+click link "Active"
 verify-text "Write tests"
 verify-text "Deploy to production"
-click "Completed"
+click link "Completed"
 verify-text "Buy groceries"
-click "All"
-click "Clear completed"
+click link "All"
+click button "Clear completed"
 verify-text "Write tests"
 verify-text "Deploy to production"
 

--- a/packages/cli/examples/03-record-session.pw
+++ b/packages/cli/examples/03-record-session.pw
@@ -5,13 +5,13 @@
 goto https://demo.playwright.dev/todomvc/
 localstorage-clear
 reload
-fill "What needs to be done?" "Buy groceries"
+fill textbox "What needs to be done?" "Buy groceries"
 press Enter
-fill "What needs to be done?" "Write tests"
+fill textbox "What needs to be done?" "Write tests"
 press Enter
 check "Buy groceries"
 verify-text "1 item left"
-click "Clear completed"
+click button "Clear completed"
 verify-text "Write tests"
 
 # Cleanup

--- a/packages/cli/examples/04-replay-session.pw
+++ b/packages/cli/examples/04-replay-session.pw
@@ -6,11 +6,11 @@
 goto https://demo.playwright.dev/todomvc/
 localstorage-clear
 reload
-fill "What needs to be done?" "Buy groceries"
+fill textbox "What needs to be done?" "Buy groceries"
 press Enter
-fill "What needs to be done?" "Write tests"
+fill textbox "What needs to be done?" "Write tests"
 press Enter
-fill "What needs to be done?" "Deploy to production"
+fill textbox "What needs to be done?" "Deploy to production"
 press Enter
 verify-text "3 items left"
 check "Buy groceries"

--- a/packages/cli/examples/05-ci-pipe.pw
+++ b/packages/cli/examples/05-ci-pipe.pw
@@ -5,11 +5,11 @@
 goto https://demo.playwright.dev/todomvc/
 localstorage-clear
 reload
-fill "What needs to be done?" "Buy groceries"
+fill textbox "What needs to be done?" "Buy groceries"
 press Enter
 verify-text "Buy groceries"
 verify-text "1 item left"
-fill "What needs to be done?" "Write tests"
+fill textbox "What needs to be done?" "Write tests"
 press Enter
 verify-text "2 items left"
 check "Buy groceries"

--- a/packages/cli/examples/06-edit-todo.pw
+++ b/packages/cli/examples/06-edit-todo.pw
@@ -4,7 +4,7 @@
 goto https://demo.playwright.dev/todomvc/
 localstorage-clear
 reload
-fill "What needs to be done?" "Buy groceries"
+fill textbox "What needs to be done?" "Buy groceries"
 press Enter
 dblclick "Buy groceries"
 press Control+a

--- a/packages/cli/examples/07-test-click-nth.pw
+++ b/packages/cli/examples/07-test-click-nth.pw
@@ -1,17 +1,20 @@
+# Click tabs by role on Playwright docs
+# Demonstrates role-based commands with --nth
+
 goto https://playwright.dev/
-click "Get started"
-click "npm" --nth 0
-click "yarn" --nth 0
-click "pnpm" --nth 0
-click "npm" --nth 1
-click "yarn" --nth 1
-click "pnpm" --nth 1
-click "npm" --nth 2
-click "yarn" --nth 2
-click "pnpm" --nth 2
-click "npm" --nth 3
-click "yarn" --nth 3
-click "pnpm" --nth 3
-click "npm" --nth 4
-click "yarn" --nth 4
-click "pnpm" --nth 4
+click link "Get started"
+click tab "npm" --nth 0
+click tab "yarn" --nth 0
+click tab "pnpm" --nth 0
+click tab "npm" --nth 1
+click tab "yarn" --nth 1
+click tab "pnpm" --nth 1
+click tab "npm" --nth 2
+click tab "yarn" --nth 2
+click tab "pnpm" --nth 2
+click tab "npm" --nth 3
+click tab "yarn" --nth 3
+click tab "pnpm" --nth 3
+click tab "npm" --nth 4
+click tab "yarn" --nth 4
+click tab "pnpm" --nth 4

--- a/packages/cli/examples/08-localstorage.pw
+++ b/packages/cli/examples/08-localstorage.pw
@@ -4,9 +4,9 @@
 goto https://demo.playwright.dev/todomvc/
 localstorage-clear
 reload
-fill "What needs to be done?" "Buy groceries"
+fill textbox "What needs to be done?" "Buy groceries"
 press Enter
-fill "What needs to be done?" "Write tests"
+fill textbox "What needs to be done?" "Write tests"
 press Enter
 verify-text "2 items left"
 
@@ -19,7 +19,7 @@ localstorage-list
 reload
 
 # After reload with empty storage, todos should be gone
-fill "What needs to be done?" "Fresh todo"
+fill textbox "What needs to be done?" "Fresh todo"
 press Enter
 verify-text "1 item left"
 

--- a/packages/cli/src/repl.ts
+++ b/packages/cli/src/repl.ts
@@ -13,6 +13,7 @@ import {
   buildRunCode, verifyText, verifyElement, verifyValue, verifyList,
   verifyTitle, verifyUrl, verifyNoText, verifyNoElement,
   actionByText, fillByText, selectByText, checkByText, uncheckByText,
+  actionByRole, fillByRole, selectByRole, pressKeyByRole,
   Engine, CommandServer, BridgeServer, COMMANDS, CATEGORIES, JS_CATEGORIES, refToLocator,
   filterResponse as filterResponseBase,
 } from '@playwright-repl/core';
@@ -382,12 +383,46 @@ export async function processLine(ctx: ReplContext, line: string): Promise<void>
     }
   }
 
+  // ── Auto-resolve role-based to native Playwright locator ──
+  const ROLE_ACTIONS: Record<string, string> = {
+    click: 'click', dblclick: 'dblclick', hover: 'hover',
+    check: 'check', uncheck: 'uncheck',
+  };
+  if (args._.length >= 3 && args._[1] && /^[a-z]+$/.test(args._[1]) && !args._.some(a => a.includes('>>'))) {
+    const role = args._[1];
+    const nth = args.nth !== undefined ? parseInt(String(args.nth), 10) : undefined;
+    const inRole = args['in-role'] !== undefined ? String(args['in-role']) : undefined;
+    const inText = args['in-text'] !== undefined ? String(args['in-text']) : undefined;
+    const inHint = inRole && inText ? ` --in ${inRole} "${inText}"` : '';
+    const nthHint = nth !== undefined ? ` --nth ${nth}` : '';
+    if (ROLE_ACTIONS[cmdName]) {
+      const name = args._.slice(2).join(' ');
+      args = buildRunCode(actionByRole as PageScriptFn, role, name, ROLE_ACTIONS[cmdName], nth, inRole, inText);
+      ctx.log(`${c.dim}→ ${cmdName} ${role} "${name}"${inHint}${nthHint} (via run-code)${c.reset}`);
+    } else if (cmdName === 'fill') {
+      const name = args._[2];
+      const value = args._.slice(3).join(' ') || '';
+      args = buildRunCode(fillByRole as PageScriptFn, role, name, value, nth, inRole, inText);
+      ctx.log(`${c.dim}→ fill ${role} "${name}" "${value}"${inHint}${nthHint} (via run-code)${c.reset}`);
+    } else if (cmdName === 'select') {
+      const name = args._[2];
+      const value = args._.slice(3).join(' ') || '';
+      args = buildRunCode(selectByRole as PageScriptFn, role, name, value, nth, inRole, inText);
+      ctx.log(`${c.dim}→ select ${role} "${name}" "${value}"${inHint}${nthHint} (via run-code)${c.reset}`);
+    } else if (cmdName === 'press') {
+      const name = args._[2];
+      const key = args._.slice(3).join(' ') || '';
+      args = buildRunCode(pressKeyByRole as PageScriptFn, role, name, key, nth, inRole, inText);
+      ctx.log(`${c.dim}→ press ${role} "${name}" ${key}${inHint}${nthHint} (via run-code)${c.reset}`);
+    }
+  }
+
   // ── Auto-resolve text to native Playwright locator ─────────
   const textFns: Record<string, PageScriptFn> = {
     click: actionByText as PageScriptFn, dblclick: actionByText as PageScriptFn, hover: actionByText as PageScriptFn,
     fill: fillByText as PageScriptFn, select: selectByText as PageScriptFn, check: checkByText as PageScriptFn, uncheck: uncheckByText as PageScriptFn,
   };
-  if (textFns[cmdName] && args._[1] && !/^e\d+$/.test(args._[1]) && !args._.some(a => a.includes('>>'))) {
+  if (textFns[cmdName] && args._[0] !== 'run-code' && args._[1] && !/^e\d+$/.test(args._[1]) && !args._.some(a => a.includes('>>'))) {
     const textArg = args._[1];
     const extraArgs = args._.slice(2);
     const fn = textFns[cmdName];

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -10,6 +10,7 @@ export {
   buildRunCode, verifyText, verifyElement, verifyValue, verifyList,
   verifyTitle, verifyUrl, verifyNoText, verifyNoElement,
   actionByText, fillByText, selectByText, checkByText, uncheckByText,
+  actionByRole, fillByRole, selectByRole, pressKeyByRole,
 } from './page-scripts.js';
 export { Engine } from './engine.js';
 export type { EngineOpts, EngineResult, ParsedArgs } from './engine.js';

--- a/packages/core/src/page-scripts.ts
+++ b/packages/core/src/page-scripts.ts
@@ -130,3 +130,45 @@ export async function uncheckByText(page, text, nth) {
   if (nth !== undefined) loc = loc.filter({ visible: true }).nth(nth);
   await loc.uncheck();
 }
+
+// ─── Role-based actions ─────────────────────────────────────────────────────
+
+export async function actionByRole(page, role, name, action, nth, inRole, inText) {
+  let loc = page.getByRole(role, { name, exact: true });
+  if (inRole !== undefined && inText !== undefined) {
+    const cr = ({ list: 'listitem' })[inRole] || inRole;
+    loc = page.getByRole(cr).filter({ hasText: inText }).getByRole(role, { name, exact: true });
+  }
+  if (nth !== undefined) loc = loc.nth(nth);
+  await loc[action]();
+}
+
+export async function fillByRole(page, role, name, value, nth, inRole, inText) {
+  let loc = page.getByRole(role, { name, exact: true });
+  if (inRole !== undefined && inText !== undefined) {
+    const cr = ({ list: 'listitem' })[inRole] || inRole;
+    loc = page.getByRole(cr).filter({ hasText: inText }).getByRole(role, { name, exact: true });
+  }
+  if (nth !== undefined) loc = loc.nth(nth);
+  await loc.fill(value);
+}
+
+export async function selectByRole(page, role, name, value, nth, inRole, inText) {
+  let loc = page.getByRole(role, { name, exact: true });
+  if (inRole !== undefined && inText !== undefined) {
+    const cr = ({ list: 'listitem' })[inRole] || inRole;
+    loc = page.getByRole(cr).filter({ hasText: inText }).getByRole(role, { name, exact: true });
+  }
+  if (nth !== undefined) loc = loc.nth(nth);
+  await loc.selectOption(value);
+}
+
+export async function pressKeyByRole(page, role, name, key, nth, inRole, inText) {
+  let loc = page.getByRole(role, { name, exact: true });
+  if (inRole !== undefined && inText !== undefined) {
+    const cr = ({ list: 'listitem' })[inRole] || inRole;
+    loc = page.getByRole(cr).filter({ hasText: inText }).getByRole(role, { name, exact: true });
+  }
+  if (nth !== undefined) loc = loc.nth(nth);
+  await loc.press(key);
+}

--- a/packages/core/src/parser.ts
+++ b/packages/core/src/parser.ts
@@ -128,6 +128,14 @@ export function parseInput(line: string): ParsedArgs | null {
     return rest ? { _: [tokens[0], rest] } : { _: [tokens[0]] };
   }
 
+  // Pre-process --in <role> <text> → --in-role <role> --in-text <text>
+  for (let i = 0; i < tokens.length; i++) {
+    if (tokens[i] === '--in' && i + 2 < tokens.length && !tokens[i + 1].startsWith('--') && !tokens[i + 2].startsWith('--')) {
+      tokens.splice(i, 3, '--in-role', tokens[i + 1], '--in-text', tokens[i + 2]);
+      break;
+    }
+  }
+
   // Parse with minimist (same lib and boolean set as playwright-cli)
   const args = minimist(tokens, { boolean: [...booleanOptions] }) as ParsedArgs;
 

--- a/packages/core/test/page-scripts.test.ts
+++ b/packages/core/test/page-scripts.test.ts
@@ -5,6 +5,7 @@ import {
   verifyTitle, verifyUrl, verifyNoText, verifyNoElement,
   actionByText, fillByText, selectByText,
   checkByText, uncheckByText,
+  actionByRole, fillByRole, selectByRole, pressKeyByRole,
 } from '../src/page-scripts.js';
 
 // ─── buildRunCode ───────────────────────────────────────────────────────────
@@ -288,5 +289,77 @@ describe('uncheckByText', () => {
     const page = mockPage(1);
     await uncheckByText(page, 'Newsletter');
     expect(page._loc.uncheck).toHaveBeenCalled();
+  });
+});
+
+// ─── Role-based actions ─────────────────────────────────────────────────────
+
+describe('actionByRole', () => {
+  it('clicks by role and name', async () => {
+    const page = mockPage(1);
+    await actionByRole(page, 'button', 'Submit', 'click');
+    expect(page.getByRole).toHaveBeenCalledWith('button', { name: 'Submit', exact: true });
+    expect(page._loc.click).toHaveBeenCalled();
+  });
+
+  it('supports nth parameter', async () => {
+    const nthLoc = mockLocator(1);
+    const loc = mockLocator(1);
+    loc.nth = vi.fn().mockReturnValue(nthLoc);
+    const page = { getByRole: vi.fn().mockReturnValue(loc) };
+    await actionByRole(page, 'tab', 'npm', 'click', 0);
+    expect(loc.nth).toHaveBeenCalledWith(0);
+    expect(nthLoc.click).toHaveBeenCalled();
+  });
+
+  it('supports --in container context', async () => {
+    const innerLoc = mockLocator(1);
+    const filterLoc = { ...mockLocator(1), getByRole: vi.fn().mockReturnValue(innerLoc) };
+    const loc = mockLocator(1);
+    loc.filter = vi.fn().mockReturnValue(filterLoc);
+    const page = { getByRole: vi.fn().mockReturnValue(loc) };
+    await actionByRole(page, 'button', 'Save', 'click', undefined, 'dialog', 'Settings');
+    expect(page.getByRole).toHaveBeenCalledWith('dialog');
+    expect(loc.filter).toHaveBeenCalledWith({ hasText: 'Settings' });
+    expect(filterLoc.getByRole).toHaveBeenCalledWith('button', { name: 'Save', exact: true });
+    expect(innerLoc.click).toHaveBeenCalled();
+  });
+
+  it('maps list to listitem for --in', async () => {
+    const innerLoc = mockLocator(1);
+    const filterLoc = { ...mockLocator(1), getByRole: vi.fn().mockReturnValue(innerLoc) };
+    const loc = mockLocator(1);
+    loc.filter = vi.fn().mockReturnValue(filterLoc);
+    const page = { getByRole: vi.fn().mockReturnValue(loc) };
+    await actionByRole(page, 'checkbox', 'Done', 'check', undefined, 'list', 'Tasks');
+    expect(page.getByRole).toHaveBeenCalledWith('listitem');
+  });
+});
+
+describe('fillByRole', () => {
+  it('fills by role and name', async () => {
+    const page = mockPage(1);
+    await fillByRole(page, 'textbox', 'Email', 'test@example.com');
+    expect(page.getByRole).toHaveBeenCalledWith('textbox', { name: 'Email', exact: true });
+    expect(page._loc.fill).toHaveBeenCalledWith('test@example.com');
+  });
+});
+
+describe('selectByRole', () => {
+  it('selects by role and name', async () => {
+    const page = mockPage(1);
+    await selectByRole(page, 'combobox', 'Country', 'US');
+    expect(page.getByRole).toHaveBeenCalledWith('combobox', { name: 'Country', exact: true });
+    expect(page._loc.selectOption).toHaveBeenCalledWith('US');
+  });
+});
+
+describe('pressKeyByRole', () => {
+  it('presses key on element by role', async () => {
+    const page = mockPage(1);
+    page._loc.press = vi.fn().mockResolvedValue(undefined);
+    await pressKeyByRole(page, 'textbox', 'Search', 'Enter');
+    expect(page.getByRole).toHaveBeenCalledWith('textbox', { name: 'Search', exact: true });
+    expect(page._loc.press).toHaveBeenCalledWith('Enter');
   });
 });

--- a/packages/core/test/parser.test.ts
+++ b/packages/core/test/parser.test.ts
@@ -113,6 +113,29 @@ describe('ALIASES', () => {
   });
 });
 
+describe('--in option', () => {
+  it('parses --in role text into in-role and in-text', () => {
+    const args = parseInput('click button "Submit" --in dialog "Settings"');
+    expect(args['in-role']).toBe('dialog');
+    expect(args['in-text']).toBe('Settings');
+    expect(args._).toEqual(['click', 'button', 'Submit']);
+  });
+
+  it('parses --in with --nth', () => {
+    const args = parseInput('click tab "npm" --nth 0 --in article "Getting Started"');
+    expect(args['in-role']).toBe('article');
+    expect(args['in-text']).toBe('Getting Started');
+    expect(args.nth).toBe('0');
+  });
+
+  it('does not parse --in when fewer than 2 values follow', () => {
+    const args = parseInput('click button "Submit" --in dialog');
+    // minimist treats --in as a string option with value "dialog"
+    expect(args.in).toBe('dialog');
+    expect(args).not.toHaveProperty('in-role');
+  });
+});
+
 describe('booleanOptions', () => {
   it('includes expected options', () => {
     expect(booleanOptions.has('headed')).toBe(true);


### PR DESCRIPTION
## Summary
- Add `actionByRole`, `fillByRole`, `selectByRole`, `pressKeyByRole` to core and wire into CLI REPL
- Commands like `click button "Submit"`, `fill textbox "Email" "value"` now resolve via `getByRole()` instead of text search
- Support `--in` container context (`click button "Save" --in dialog "Settings"`) and `--nth`
- Update all 8 example scripts to use role-based syntax
- Remove `--silent` from CI E2E step to show per-command timing

## Test plan
- [x] 144 core unit tests pass (10 new role-based tests)
- [x] 175 CLI unit tests pass (3 new `--in` parser tests)
- [x] All 8 E2E example scripts pass in replay mode
- [ ] Manual test: `click button "Sign in"`, `fill textbox "Email" "user@example.com"`, `click "text"` (text fallback still works)

Closes #267

🤖 Generated with [Claude Code](https://claude.com/claude-code)