### PR TITLE
feat: add file-based logging to MCP server

### DIFF
--- a/packages/mcp/src/bridge.ts
+++ b/packages/mcp/src/bridge.ts
@@ -5,6 +5,7 @@
 import { BridgeServer, UPDATE_COMMANDS, parseInput } from '@playwright-repl/core';
 import type { EngineResult } from '@playwright-repl/core';
 import type { RunnerModule, SnapshotCache } from './types.js';
+import { logEvent } from './logger.js';
 
 export const descriptions = {
     runCommandInput: `A keyword command ('snapshot', 'goto https://example.com', 'click Submit', \
@@ -60,8 +61,9 @@ export async function createBridgeRunner(
         throw err;
     }
     console.error(`playwright-repl bridge listening on ws://localhost:${port}`);
-    srv.onConnect(() => console.error('Extension connected'));
-    srv.onDisconnect(() => console.error('Extension disconnected'));
+    logEvent(`Bridge listening on ws://localhost:${port}`);
+    srv.onConnect(() => { console.error('Extension connected'); logEvent('Extension connected'); });
+    srv.onDisconnect(() => { console.error('Extension disconnected'); logEvent('Extension disconnected'); });
 
     return {
         descriptions,

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -6,6 +6,7 @@ import { COMMANDS, CATEGORIES, refToLocator } from '@playwright-repl/core';
 import pkg from '../package.json' with { type: 'json' };
 import { createBridgeRunner } from './bridge.js';
 import { createStandaloneRunner } from './standalone.js';
+import { logStartup, logEvent, logToolCall, logToolResult, logError, LOG_FILE } from './logger.js';
 import type { SnapshotCache } from './types.js';
 
 const argv = process.argv.slice(2);
@@ -20,6 +21,8 @@ const { runner, descriptions } = standalone
     ? createStandaloneRunner(headed, snapshotCache)
     : await createBridgeRunner(argv, snapshotCache);
 
+logStartup(standalone ? 'standalone' : 'bridge', `log → ${LOG_FILE}`);
+
 // ─── MCP server ──────────────────────────────────────────────────────────────
 
 const server = new McpServer({ name: 'playwright-repl', version: pkg.version });
@@ -33,11 +36,14 @@ server.registerTool(
         },
     },
     async ({ command }) => {
+        const start = Date.now();
+        logToolCall('run_command', { command });
         const trimmed = command.trim().toLowerCase();
         if (trimmed === 'help') {
             const lines = Object.entries(CATEGORIES)
                 .map(([cat, cmds]) => `  ${cat}: ${cmds.join(', ')}`)
                 .join('\n');
+            logToolResult('run_command', false, 'help', Date.now() - start);
             return { content: [{ type: 'text' as const, text: `Available commands:\n${lines}\n\nType "help <command>" for details.` }] };
         }
         if (trimmed.startsWith('locator ')) {
@@ -65,16 +71,22 @@ server.registerTool(
             }
             return { content: [{ type: 'text' as const, text: parts.join('\n') }] };
         }
-        const result = await runner.runCommand(command);
-        if (result.image) {
-            const [header, data] = result.image.split(',');
-            const mimeType = (header.match(/data:(.*);base64/) ?? [])[1] ?? 'image/png';
-            return { content: [{ type: 'image' as const, data, mimeType }] };
+        try {
+            const result = await runner.runCommand(command);
+            logToolResult('run_command', !!result.isError, result.text, Date.now() - start);
+            if (result.image) {
+                const [header, data] = result.image.split(',');
+                const mimeType = (header.match(/data:(.*);base64/) ?? [])[1] ?? 'image/png';
+                return { content: [{ type: 'image' as const, data, mimeType }] };
+            }
+            return {
+                content: [{ type: 'text' as const, text: result.text || 'Done' }],
+                isError: result.isError,
+            };
+        } catch (err) {
+            logError('run_command', err);
+            throw err;
         }
-        return {
-            content: [{ type: 'text' as const, text: result.text || 'Done' }],
-            isError: result.isError,
-        };
     }
 );
 
@@ -90,15 +102,28 @@ server.registerTool(
             },
     },
     async (params: Record<string, unknown>) => {
+        const start = Date.now();
         const script = params.script as string;
         const language = (params.language as 'pw' | 'javascript') || 'pw';
-        const result = await runner.runScript(script, language);
-        return {
-            content: [{ type: 'text' as const, text: result.text || 'Done' }],
-            isError: result.isError,
-        };
+        logToolCall('run_script', { language, script });
+        try {
+            const result = await runner.runScript(script, language);
+            logToolResult('run_script', !!result.isError, result.text, Date.now() - start);
+            return {
+                content: [{ type: 'text' as const, text: result.text || 'Done' }],
+                isError: result.isError,
+            };
+        } catch (err) {
+            logError('run_script', err);
+            throw err;
+        }
     }
 );
+
+server.server.oninitialized = () => {
+    const client = server.server.getClientVersion();
+    if (client) logEvent(`Client: ${client.name} ${client.version}`);
+};
 
 const transport = new StdioServerTransport();
 await server.connect(transport);

--- a/packages/mcp/src/logger.ts
+++ b/packages/mcp/src/logger.ts
@@ -1,0 +1,79 @@
+/**
+ * File-based logger for the MCP server.
+ *
+ * Writes to ~/.playwright-repl/mcp.log so tool calls are visible
+ * regardless of whether the host (Claude Desktop, Claude Code, etc.)
+ * captures stderr.
+ */
+
+import { mkdirSync, appendFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { homedir } from 'node:os';
+
+const LOG_DIR = join(homedir(), '.playwright-repl');
+const LOG_FILE = join(LOG_DIR, 'mcp.log');
+
+/** Maximum characters kept from a result text in the log. */
+const MAX_RESULT_LENGTH = 200;
+
+let enabled = true;
+
+try {
+    mkdirSync(LOG_DIR, { recursive: true });
+} catch {
+    enabled = false;
+}
+
+function ts(): string {
+    const d = new Date();
+    const pad = (n: number) => String(n).padStart(2, '0');
+    return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}`;
+}
+
+function write(level: string, message: string): void {
+    if (!enabled) return;
+    try {
+        appendFileSync(LOG_FILE, `${ts()} [${level}] ${message}\n`);
+    } catch {
+        // Silently ignore — logging should never break the server.
+    }
+}
+
+/** Truncate a string for log readability. */
+function truncate(text: string, max = MAX_RESULT_LENGTH): string {
+    if (text.length <= max) return text;
+    return text.slice(0, max) + `... (${text.length} chars)`;
+}
+
+// ─── Public API ──────────────────────────────────────────────────────────────
+
+export function logStartup(mode: string, detail: string): void {
+    write('info', `Server started [${mode}] ${detail}`);
+}
+
+export function logEvent(event: string): void {
+    write('info', event);
+}
+
+export function logToolCall(tool: string, input: Record<string, unknown>): void {
+    const args = Object.entries(input)
+        .map(([k, v]) => {
+            const s = typeof v === 'string' ? v : JSON.stringify(v);
+            return `${k}=${truncate(s, 120)}`;
+        })
+        .join(' ');
+    write('info', `→ ${tool}(${args})`);
+}
+
+export function logToolResult(tool: string, isError: boolean, text: string | undefined, durationMs: number): void {
+    const status = isError ? 'ERROR' : 'OK';
+    const summary = text ? truncate(text.replace(/\n/g, '\\n')) : '(empty)';
+    write('info', `← ${tool} [${status}] ${durationMs}ms ${summary}`);
+}
+
+export function logError(context: string, err: unknown): void {
+    const msg = err instanceof Error ? err.message : String(err);
+    write('error', `${context}: ${msg}`);
+}
+
+export { LOG_FILE };


### PR DESCRIPTION
## Summary
- Adds `logger.ts` module that writes to `~/.playwright-repl/mcp.log`
- Logs tool calls (`→ run_command(command=snapshot)`), results with timing (`← run_command [OK] 42ms ...`), errors, and lifecycle events (startup, extension connect/disconnect)
- Works regardless of MCP host — Claude Desktop captures stderr to its own logs, but Claude Code doesn't expose MCP stderr anywhere

## Motivation
When debugging MCP tool usage in Claude Code, there was no way to see what commands were sent or what results came back. Claude Desktop has `mcp-server-playwright-repl.log` but Claude Code has nothing.

## Test plan
- [x] Build passes
- [x] Smoke test: logger creates file and writes correct format
- [ ] Restart Claude Desktop → run a command → verify `~/.playwright-repl/mcp.log` shows the call

Closes #322

🤖 Generated with [Claude Code](https://claude.com/claude-code)