### PR TITLE
chore: release v0.20.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,35 @@
 # Changelog
 
+## v0.20.0 — MCP & Standalone Mode
+
+**2026-03-22**
+
+### Features
+
+- **MCP standalone mode**: New `--standalone` flag launches an in-process Playwright engine — no Chrome extension needed. ([#316](https://github.com/stevez/playwright-repl/pull/316))
+- **MCP snapshot in responses**: Update commands (click, fill, goto, etc.) automatically include accessibility snapshots in MCP responses, reducing round-trips. ([#319](https://github.com/stevez/playwright-repl/issues/319), [#320](https://github.com/stevez/playwright-repl/pull/320))
+- **MCP file-based logging**: Tool calls, results, and lifecycle events are written to `~/.playwright-repl/mcp.log` for debugging in any MCP host. ([#322](https://github.com/stevez/playwright-repl/issues/322), [#324](https://github.com/stevez/playwright-repl/pull/324))
+- **Role-based commands in standalone mode**: CLI standalone now supports role prefixes like `click button "Submit"`. ([#267](https://github.com/stevez/playwright-repl/issues/267), [#313](https://github.com/stevez/playwright-repl/pull/313))
+- **wait-for-text in standalone mode**: Added missing `wait-for-text` command to standalone. ([#317](https://github.com/stevez/playwright-repl/pull/317))
+
+### Fixes
+
+- **CLI standalone command alignment**: Standalone commands now match bridge mode behavior. ([#302](https://github.com/stevez/playwright-repl/issues/302), [#315](https://github.com/stevez/playwright-repl/pull/315))
+- **Snapshot values inline**: Fixed snapshot values to show inline with refs kept in text. ([#310](https://github.com/stevez/playwright-repl/pull/310))
+- **Complex chained locators**: Fixed picker derivation for complex chained locators. ([#306](https://github.com/stevez/playwright-repl/pull/306))
+- **Recording selector injection**: Removed pw-selector.js injection, switched to custom locator. ([#308](https://github.com/stevez/playwright-repl/issues/308), [#309](https://github.com/stevez/playwright-repl/pull/309))
+- **Pick result rendering**: Element pick results now render as an expandable ObjectTree instead of raw text. ([#295](https://github.com/stevez/playwright-repl/issues/295), [#300](https://github.com/stevez/playwright-repl/pull/300))
+
+### Docs
+
+- **Help role syntax**: Added `[role]` prefix to help usage for interaction commands (click, fill, check, etc.). ([#323](https://github.com/stevez/playwright-repl/pull/323))
+
+### Tests
+
+- **Bridge replay E2E**: Added bridge replay E2E test to CI. ([#318](https://github.com/stevez/playwright-repl/pull/318))
+
+---
+
 ## v0.19.0 — Playwright Selector Integration
 
 **2026-03-21**

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "playwright-repl",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "description": "Interactive REPL for Playwright browser automation — keyword-driven testing from your terminal",
   "type": "module",
   "bin": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@playwright-repl/core",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "type": "module",
   "main": "./dist/index.js",
   "exports": {

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@playwright-repl/extension",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "private": true,
   "description": "Chrome DevTools panel extension for Playwright REPL",
   "type": "module",

--- a/packages/extension/public/manifest.json
+++ b/packages/extension/public/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Dramaturg",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "description": "Playwright engineer's companion — console, editor, runner, debugger, and recorder in a Chrome side panel.",
   "permissions": [
     "activeTab",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@playwright-repl/mcp",
-    "version": "0.19.0",
+    "version": "0.20.0",
     "type": "module",
     "bin": {
         "playwright-repl-mcp": "./dist/index.js"


### PR DESCRIPTION
## Summary
- Version bump 0.19.0 → 0.20.0 across all packages
- CHANGELOG updated with 16 commits worth of features, fixes, docs, and tests

## Highlights
- **MCP standalone mode** — `--standalone` flag for in-process Playwright (no extension needed)
- **MCP snapshot in responses** — update commands auto-include accessibility snapshots
- **MCP file-based logging** — `~/.playwright-repl/mcp.log` for debugging in any host
- **Role-based commands** — `click button "Submit"` works in standalone/MCP
- **JS autocompletion** — `page.*`, `expect()` completions in JS mode

## Publish checklist
- [ ] `npm publish ./packages/core --access public`
- [ ] `npm publish ./packages/cli`
- [ ] Merge PR
- [ ] `git tag v0.20.0 && git push origin v0.20.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)