### PR TITLE
feat: locator picker — pick element in browser, insert at cursor

### DIFF
--- a/packages/extension/src/background.ts
+++ b/packages/extension/src/background.ts
@@ -432,6 +432,7 @@ async function handleBridgeCommand(msg: {
 }): Promise<BridgeResult> {
   // Recording/picker commands — handled before currentPage check
   const cmd = msg.command.trim();
+  console.log('[bridge] command:', JSON.stringify(cmd), 'type:', msg.scriptType);
   if (cmd === 'record-start') {
     const r = await startRecording();
     return { text: r.ok ? `Recording started${r.url ? ': ' + r.url : ''}` : (r.error || 'Failed'), isError: !r.ok };
@@ -439,6 +440,14 @@ async function handleBridgeCommand(msg: {
   if (cmd === 'record-stop') {
     const r = await stopRecording();
     return { text: r.ok ? 'Recording stopped' : 'Failed', isError: !r.ok };
+  }
+  if (cmd === 'pick-start') {
+    const r = await startPicking();
+    return { text: r.ok ? 'Pick mode started' : (r.error || 'Failed'), isError: !r.ok };
+  }
+  if (cmd === 'pick-stop') {
+    const r = await stopPicking();
+    return { text: r.ok ? 'Pick mode stopped' : 'Failed', isError: !r.ok };
   }
 
   if (!currentPage) {

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -41,6 +41,10 @@
       {
         "command": "playwright-ide.stopRecording",
         "title": "Playwright IDE: Stop Recording"
+      },
+      {
+        "command": "playwright-ide.pickLocator",
+        "title": "Playwright IDE: Pick Locator"
       }
     ],
     "configuration": {

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -3,11 +3,13 @@ import { BrowserManager } from './browser.js';
 import { PlaywrightRepl } from './repl.js';
 import { TestExplorer } from './test-explorer.js';
 import { Recorder } from './recorder.js';
+import { Picker } from './picker.js';
 
 let browserManager: BrowserManager | undefined;
 let repl: PlaywrightRepl | undefined;
 let testExplorer: TestExplorer | undefined;
 let recorder: Recorder | undefined;
+let picker: Picker | undefined;
 let outputChannel: vscode.OutputChannel;
 
 export function activate(context: vscode.ExtensionContext) {
@@ -131,6 +133,35 @@ export function activate(context: vscode.ExtensionContext) {
   context.subscriptions.push(
     vscode.commands.registerCommand('playwright-ide.stopRecording', async () => {
       await recorder!.stop();
+    })
+  );
+
+  // ─── Locator Picker ─────────────────────────────────────────────────────
+  picker = new Picker(browserManager, outputChannel);
+  context.subscriptions.push({ dispose: () => picker?.dispose() });
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand('playwright-ide.pickLocator', async () => {
+      if (picker!.isPicking) {
+        await picker!.stop();
+        return;
+      }
+      // Auto-launch browser if needed
+      if (!browserManager?.isRunning()) {
+        const config = vscode.workspace.getConfiguration('playwright-ide');
+        try {
+          await browserManager!.launch({
+            browser: config.get('browser', 'chromium'),
+            bridgePort: config.get('bridgePort', 9876),
+          });
+        } catch (err: unknown) {
+          vscode.window.showErrorMessage(`Failed to launch browser: ${(err as Error).message}`);
+          return;
+        }
+      }
+      // Stop recording if active
+      if (recorder?.isRecording) await recorder.stop();
+      await picker!.start();
     })
   );
 

--- a/packages/vscode/src/picker.ts
+++ b/packages/vscode/src/picker.ts
@@ -1,0 +1,114 @@
+/**
+ * Locator Picker
+ *
+ * V1: Simple pick and insert.
+ * 1. Click "Pick Locator" → browser enters pick mode (hover highlight)
+ * 2. User clicks an element → locator sent back via bridge event
+ * 3. Locator inserted at cursor in the active editor
+ * 4. Pick mode ends automatically
+ */
+
+import * as vscode from 'vscode';
+import type { BrowserManager } from './browser.js';
+
+export class Picker {
+  private _browserManager: BrowserManager;
+  private _outputChannel: vscode.OutputChannel;
+  private _picking = false;
+  private _statusBarItem: vscode.StatusBarItem;
+
+  constructor(browserManager: BrowserManager, outputChannel: vscode.OutputChannel) {
+    this._browserManager = browserManager;
+    this._outputChannel = outputChannel;
+
+    // Status bar button
+    this._statusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 99);
+    this._statusBarItem.text = '$(target) Pick';
+    this._statusBarItem.tooltip = 'Playwright IDE: Pick Locator';
+    this._statusBarItem.command = 'playwright-ide.pickLocator';
+    this._statusBarItem.show();
+  }
+
+  get isPicking() { return this._picking; }
+
+  dispose() {
+    this._statusBarItem.dispose();
+  }
+
+  async start() {
+    if (this._picking) return;
+    if (!this._browserManager.isRunning()) {
+      vscode.window.showWarningMessage('Launch browser first.');
+      return;
+    }
+
+    const editor = vscode.window.activeTextEditor;
+    if (!editor) {
+      vscode.window.showWarningMessage('Open a file first.');
+      return;
+    }
+
+    // Start pick mode
+    const result = await this._browserManager.runCommand('pick-start');
+    if (result.isError) {
+      vscode.window.showErrorMessage(`Pick failed: ${result.text}`);
+      return;
+    }
+
+    this._picking = true;
+    this._statusBarItem.text = '$(target) Picking...';
+    this._statusBarItem.tooltip = 'Click an element in the browser';
+    this._statusBarItem.backgroundColor = new vscode.ThemeColor('statusBarItem.warningBackground');
+    this._outputChannel.appendLine('Pick mode started. Click an element in the browser.');
+
+    // Remember which editor and position to insert into
+    const targetEditor = editor;
+    const targetPosition = editor.selection.active;
+
+    // Listen for pick events
+    this._browserManager.onEvent(async (event) => {
+      if (!this._picking) return;
+
+      if (event.type === 'element-picked-raw') {
+        const info = event.info as { locator?: string };
+        const locator = info?.locator;
+        if (locator) {
+          await this._insertLocator(targetEditor, targetPosition, `page.${locator}`);
+        }
+        this._stop();
+      }
+
+      if (event.type === 'pick-cancelled') {
+        this._stop();
+      }
+    });
+  }
+
+  async stop() {
+    if (!this._picking) return;
+    await this._browserManager.runCommand('pick-stop');
+    this._stop();
+  }
+
+  private _stop() {
+    this._picking = false;
+    this._statusBarItem.text = '$(target) Pick';
+    this._statusBarItem.tooltip = 'Playwright IDE: Pick Locator';
+    this._statusBarItem.command = 'playwright-ide.pickLocator';
+    this._statusBarItem.backgroundColor = undefined;
+    this._browserManager.onEvent(null);
+    this._outputChannel.appendLine('Pick mode ended.');
+  }
+
+  private async _insertLocator(editor: vscode.TextEditor, position: vscode.Position, locator: string) {
+    // Bring editor back to focus first
+    await vscode.window.showTextDocument(editor.document, editor.viewColumn);
+    await editor.edit(editBuilder => {
+      editBuilder.insert(position, locator);
+    });
+    // Move cursor to end of inserted text
+    const newPos = new vscode.Position(position.line, position.character + locator.length);
+    editor.selection = new vscode.Selection(newPos, newPos);
+    this._outputChannel.appendLine(`Picked: ${locator}`);
+  }
+}


### PR DESCRIPTION
## Summary
- Pick Locator command + 🎯 status bar button
- Click "Pick" → hover elements in browser (highlight) → click → locator inserted at cursor in editor
- Auto-launches browser if not running, stops recording if active

## Flow
```
Click 🎯 Pick → browser enters pick mode → click element
→ extension generates locator (getByRole, getByText, etc.)
→ bridge event → VS Code refocuses editor → inserts at cursor
```

## Test plan
- [x] Pick element → `page.getByRole('link', { name: 'Get started' })` inserted at cursor
- [x] Editor refocuses after picking
- [x] Status bar toggles Pick/Picking state
- [x] Auto-launch browser if not running

🤖 Generated with [Claude Code](https://claude.com/claude-code)