### PR TITLE
feat: pw CLI Phase 2 — extension + bridge + context reuse (5.2s)

### DIFF
--- a/packages/runner/src/pw-cli.ts
+++ b/packages/runner/src/pw-cli.ts
@@ -20,6 +20,10 @@ const require = createRequire(__filename);
 const pwCliPath = require.resolve('@playwright/test/cli');
 const preloadPath = path.resolve(path.dirname(__filename), '..', 'src', 'pw-preload.cjs');
 
+// Find extension path
+const extPkgPath = require.resolve('@playwright-repl/extension/package.json');
+const extPath = path.resolve(path.dirname(extPkgPath), 'dist');
+
 const args = process.argv.slice(2);
 if (args.length === 0 || (args[0] && args[0].startsWith('-'))) {
   args.unshift('test');
@@ -32,6 +36,7 @@ const child = spawn(process.execPath, [pwCliPath, ...args], {
   env: {
     ...process.env,
     PW_REUSE_CONTEXT: '1',
+    PW_EXT_PATH: extPath,
     NODE_OPTIONS: `${existingNodeOptions} --require ${preloadPath}`.trim(),
   },
 });

--- a/packages/runner/src/pw-preload.cjs
+++ b/packages/runner/src/pw-preload.cjs
@@ -1,57 +1,99 @@
 /**
  * Preloaded via NODE_OPTIONS --require.
- * Patches browser.newContext to reuse shared context/page per worker.
- * Works with both launch (standard) and connect (pre-launched) modes.
+ * Patches chromium.launch → launchPersistentContext with extension.
+ * Each worker gets its own bridge on random port (supports parallel).
+ * Sets bridge port via chrome.storage after launch.
+ * Reuses one browser + context + page per worker.
  */
 'use strict';
 
-if (process.env.PW_REUSE_CONTEXT) {
-  let sharedContext = null;
-  let sharedPage = null;
+if (!process.env.PW_REUSE_CONTEXT) return;
 
-  function patchBrowser(browser) {
-    const origNewContext = browser.newContext.bind(browser);
-    browser.newContext = async function(contextOptions) {
-      if (!sharedContext) {
-        sharedContext = await origNewContext(contextOptions);
-        sharedPage = sharedContext.pages()[0] || await sharedContext.newPage();
-        console.error('[pw] shared context created (pid ' + process.pid + ')');
-      } else {
-        try { await sharedPage.goto('about:blank'); } catch {}
+const extPath = process.env.PW_EXT_PATH;
+let sharedBrowser = null;
+let sharedContext = null;
+let sharedPage = null;
+
+const Module = require('module');
+const origLoad = Module._load;
+let patched = false;
+
+Module._load = function(request) {
+  const result = origLoad.apply(this, arguments);
+
+  if (!patched && typeof result === 'object' && result !== null &&
+      result.chromium && result.chromium.launch && !result.chromium.launch._pwPatched) {
+    patched = true;
+    const chromium = result.chromium;
+    const origLaunch = chromium.launch;
+    origLaunch._pwPatched = true;
+
+    chromium.launch = async function(options) {
+      if (sharedBrowser) return sharedBrowser;
+
+      if (extPath) {
+        // Start bridge on random port (each worker gets its own)
+        var coreMain = require.resolve('@playwright-repl/core');
+        var coreUrl = 'file:///' + coreMain.replace(/\\/g, '/');
+        var { BridgeServer } = await import(coreUrl);
+        var bridge = new BridgeServer();
+        await bridge.start(0);
+
+        // Launch with extension
+        var args = (options && options.args || []).concat([
+          '--disable-extensions-except=' + extPath,
+          '--load-extension=' + extPath,
+          '--disable-background-timer-throttling',
+        ]);
+
+        var context = await chromium.launchPersistentContext('', {
+          channel: 'chromium',
+          headless: options ? options.headless : true,
+          args: args,
+        });
+
+        // Set bridge port via service worker
+        var sw = context.serviceWorkers()[0];
+        if (!sw) sw = await context.waitForEvent('serviceworker', { timeout: 10000 });
+        await sw.evaluate(function(port) {
+          chrome.storage.local.set({ bridgePort: port });
+        }, bridge.port);
+
+        // Wait for extension to connect
+        await bridge.waitForConnection(10000);
+        console.error('[pw] bridge port ' + bridge.port + ' connected (pid ' + process.pid + ')');
+
+        sharedContext = context;
+        sharedPage = context.pages()[0] || await context.newPage();
+
+        // Return real browser with patched newContext
+        var browser = context._browser;
+        browser.newContext = async function() {
+          context.newPage = async function() { return sharedPage; };
+          context.close = async function() {};
+          return context;
+        };
+        sharedBrowser = browser;
+        return browser;
       }
-      sharedContext.newPage = async () => sharedPage;
-      sharedContext.close = async () => {};
-      return sharedContext;
+
+      // No extension: regular launch + context reuse
+      var browser = await origLaunch.apply(this, arguments);
+      var origNewContext = browser.newContext.bind(browser);
+      browser.newContext = async function(ctxOpts) {
+        if (!sharedContext) {
+          sharedContext = await origNewContext(ctxOpts);
+          sharedPage = sharedContext.pages()[0] || await sharedContext.newPage();
+          console.error('[pw] context reuse (pid ' + process.pid + ')');
+        }
+        sharedContext.newPage = async () => sharedPage;
+        sharedContext.close = async () => {};
+        return sharedContext;
+      };
+      sharedBrowser = browser;
+      return browser;
     };
-    return browser;
   }
 
-  const Module = require('module');
-  const origLoad = Module._load;
-  let patched = false;
-
-  Module._load = function(request) {
-    const result = origLoad.apply(this, arguments);
-
-    if (!patched && typeof result === 'object' && result !== null && result.chromium) {
-      // Patch both launch and connect
-      if (result.chromium.launch && !result.chromium.launch._pwPatched) {
-        patched = true;
-        const origLaunch = result.chromium.launch;
-        origLaunch._pwPatched = true;
-        result.chromium.launch = async function() {
-          return patchBrowser(await origLaunch.apply(this, arguments));
-        };
-      }
-      if (result.chromium.connect && !result.chromium.connect._pwPatched) {
-        const origConnect = result.chromium.connect;
-        origConnect._pwPatched = true;
-        result.chromium.connect = async function() {
-          return patchBrowser(await origConnect.apply(this, arguments));
-        };
-      }
-    }
-
-    return result;
-  };
-}
+  return result;
+};


### PR DESCRIPTION
## Summary

`pw test` with extension loaded, bridge connected, context reused. One clean commit.

### How it works
- `pw-preload.cjs` patches `chromium.launch` → `launchPersistentContext`
- `channel: 'chromium'` (system Chrome, extensions work in headless)
- Each worker: own browser + BridgeServer on random port
- Bridge port set via `sw.evaluate(chrome.storage.local.set)`
- `context._browser` returned (real Browser for Playwright fixtures)
- Context + page cached per worker (reused across tests)

### Parallel
Each worker: own browser + own bridge + random port. No conflicts.

### Results (23 todomvc)

| Mode | Time |
|------|------|
| Standard Playwright | 52s |
| pw (1 worker) | 6.0s |
| pw (2 workers) | 5.2s |

Per-test: **50-150ms** vs **1.0-1.3s**

Tracks #360

## Test plan
- [x] 23 todomvc tests pass (1, 2, 4 workers)
- [x] Extension + bridge connected per worker
- [x] Random ports, no conflicts
- [x] Headless works
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)