### PR TITLE
feat: pw CLI Phase 3 — custom bridge worker with process reuse

### DIFF
--- a/packages/runner/examples/pw.config.ts
+++ b/packages/runner/examples/pw.config.ts
@@ -3,6 +3,7 @@ import { defineConfig } from '@playwright/test';
 export default defineConfig({
   testDir: './todomvc',
   timeout: 15000,
+  workers: 2,
   fullyParallel: true,
   projects: [
     {

--- a/packages/runner/src/pw-cli.ts
+++ b/packages/runner/src/pw-cli.ts
@@ -2,11 +2,9 @@
 /**
  * pw — drop-in replacement for npx playwright test
  *
- * Spawns Playwright CLI with context reuse patch.
- * Each worker launches its own browser (local CDP, fast).
- * pw-preload.cjs patches newContext to reuse one context/page per worker.
- *
- * Test files stay unchanged.
+ * 1. Spawns Playwright CLI with custom worker via --require preload
+ * 2. Each worker lazily launches its own browser + bridge (reused across test groups)
+ * 3. Worker compiles test → sends to bridge (one call) → results back
  */
 
 import { spawn } from 'node:child_process';
@@ -19,8 +17,6 @@ const require = createRequire(__filename);
 
 const pwCliPath = require.resolve('@playwright/test/cli');
 const preloadPath = path.resolve(path.dirname(__filename), '..', 'src', 'pw-preload.cjs');
-
-// Find extension path
 const extPkgPath = require.resolve('@playwright-repl/extension/package.json');
 const extPath = path.resolve(path.dirname(extPkgPath), 'dist');
 
@@ -35,7 +31,7 @@ const child = spawn(process.execPath, [pwCliPath, ...args], {
   cwd: process.cwd(),
   env: {
     ...process.env,
-    PW_REUSE_CONTEXT: '1',
+    PW_BRIDGE_WORKER: '1',
     PW_EXT_PATH: extPath,
     NODE_OPTIONS: `${existingNodeOptions} --require ${preloadPath}`.trim(),
   },

--- a/packages/runner/src/pw-preload.cjs
+++ b/packages/runner/src/pw-preload.cjs
@@ -1,99 +1,23 @@
 /**
  * Preloaded via NODE_OPTIONS --require.
- * Patches chromium.launch → launchPersistentContext with extension.
- * Each worker gets its own bridge on random port (supports parallel).
- * Sets bridge port via chrome.storage after launch.
- * Reuses one browser + context + page per worker.
+ * Intercepts require('workerMain') → our pw-worker.cjs.
+ * Our worker compiles tests + sends to bridge (one call per test file).
  */
 'use strict';
 
-if (!process.env.PW_REUSE_CONTEXT) return;
+if (!process.env.PW_BRIDGE_WORKER) return;
 
-const extPath = process.env.PW_EXT_PATH;
-let sharedBrowser = null;
-let sharedContext = null;
-let sharedPage = null;
+const customWorkerPath = require('path').resolve(__dirname, 'pw-worker.cjs');
 
+// Intercept: when process.js requires workerMain, return our worker
 const Module = require('module');
 const origLoad = Module._load;
-let patched = false;
 
-Module._load = function(request) {
-  const result = origLoad.apply(this, arguments);
-
-  if (!patched && typeof result === 'object' && result !== null &&
-      result.chromium && result.chromium.launch && !result.chromium.launch._pwPatched) {
-    patched = true;
-    const chromium = result.chromium;
-    const origLaunch = chromium.launch;
-    origLaunch._pwPatched = true;
-
-    chromium.launch = async function(options) {
-      if (sharedBrowser) return sharedBrowser;
-
-      if (extPath) {
-        // Start bridge on random port (each worker gets its own)
-        var coreMain = require.resolve('@playwright-repl/core');
-        var coreUrl = 'file:///' + coreMain.replace(/\\/g, '/');
-        var { BridgeServer } = await import(coreUrl);
-        var bridge = new BridgeServer();
-        await bridge.start(0);
-
-        // Launch with extension
-        var args = (options && options.args || []).concat([
-          '--disable-extensions-except=' + extPath,
-          '--load-extension=' + extPath,
-          '--disable-background-timer-throttling',
-        ]);
-
-        var context = await chromium.launchPersistentContext('', {
-          channel: 'chromium',
-          headless: options ? options.headless : true,
-          args: args,
-        });
-
-        // Set bridge port via service worker
-        var sw = context.serviceWorkers()[0];
-        if (!sw) sw = await context.waitForEvent('serviceworker', { timeout: 10000 });
-        await sw.evaluate(function(port) {
-          chrome.storage.local.set({ bridgePort: port });
-        }, bridge.port);
-
-        // Wait for extension to connect
-        await bridge.waitForConnection(10000);
-        console.error('[pw] bridge port ' + bridge.port + ' connected (pid ' + process.pid + ')');
-
-        sharedContext = context;
-        sharedPage = context.pages()[0] || await context.newPage();
-
-        // Return real browser with patched newContext
-        var browser = context._browser;
-        browser.newContext = async function() {
-          context.newPage = async function() { return sharedPage; };
-          context.close = async function() {};
-          return context;
-        };
-        sharedBrowser = browser;
-        return browser;
-      }
-
-      // No extension: regular launch + context reuse
-      var browser = await origLaunch.apply(this, arguments);
-      var origNewContext = browser.newContext.bind(browser);
-      browser.newContext = async function(ctxOpts) {
-        if (!sharedContext) {
-          sharedContext = await origNewContext(ctxOpts);
-          sharedPage = sharedContext.pages()[0] || await sharedContext.newPage();
-          console.error('[pw] context reuse (pid ' + process.pid + ')');
-        }
-        sharedContext.newPage = async () => sharedPage;
-        sharedContext.close = async () => {};
-        return sharedContext;
-      };
-      sharedBrowser = browser;
-      return browser;
-    };
+Module._load = function(request, parent) {
+  // process.js does: require(runnerScript) where runnerScript includes 'workerMain'
+  if (typeof request === 'string' && request.includes('workerMain')) {
+    console.error('[pw] worker → bridge mode');
+    return origLoad.call(this, customWorkerPath, parent);
   }
-
-  return result;
+  return origLoad.apply(this, arguments);
 };

--- a/packages/runner/src/pw-worker.cjs
+++ b/packages/runner/src/pw-worker.cjs
@@ -1,0 +1,187 @@
+/**
+ * pw-worker — custom Playwright worker that runs tests via bridge.
+ *
+ * Loaded by process.js: const { create } = require(runnerScript);
+ * Each worker lazily launches its own browser + bridge on first runTestGroup,
+ * then reuses them for all subsequent test groups assigned to this worker.
+ *
+ * Flow per test group:
+ * 1. Compile test file with shim (esbuild)
+ * 2. Send compiled code to bridge (one call)
+ * 3. Parse results and dispatch events back to parent
+ */
+'use strict';
+
+class BridgeWorker {
+  constructor(params) {
+    this._params = params;
+    this._bridge = null;
+    this._context = null;
+  }
+
+  async _ensureBridge() {
+    if (this._bridge) return;
+
+    const path = require('path');
+    const coreMain = require.resolve('@playwright-repl/core');
+    const coreUrl = 'file:///' + coreMain.replace(/\\/g, '/');
+    const { BridgeServer } = await import(coreUrl);
+
+    this._bridge = new BridgeServer();
+    await this._bridge.start(0);
+
+    const extPath = process.env.PW_EXT_PATH;
+    const pw = require('playwright-core');
+    this._context = await pw.chromium.launchPersistentContext('', {
+      channel: 'chromium',
+      headless: true,
+      args: [
+        '--disable-extensions-except=' + extPath,
+        '--load-extension=' + extPath,
+        '--disable-background-timer-throttling',
+      ],
+    });
+
+    let sw = this._context.serviceWorkers()[0];
+    if (!sw) sw = await this._context.waitForEvent('serviceworker', { timeout: 10000 });
+    await sw.evaluate(function(port) {
+      chrome.storage.local.set({ bridgePort: port });
+    }, this._bridge.port);
+
+    await this._bridge.waitForConnection(10000);
+    console.error('[pw-worker] bridge ready, port ' + this._bridge.port + ' (pid ' + process.pid + ')');
+  }
+
+  async runTestGroup(runPayload) {
+    await this._ensureBridge();
+
+    const file = runPayload.file;
+    const entries = runPayload.entries;
+
+    const compiled = await this._compile(file);
+
+    const r = await this._bridge.runScript(`
+      globalThis.__resetTestState();
+      ${compiled}
+      await globalThis.__runTests();
+    `, 'javascript');
+
+    const resultText = r.isError ? '' : (r.text || '');
+    const lines = resultText.split('\n');
+
+    for (const entry of entries) {
+      const testId = entry.testId;
+
+      this.dispatchEvent('testBegin', {
+        testId: testId,
+        startWallTime: Date.now(),
+      });
+
+      const testResult = this._findResult(lines, testId, entries);
+
+      this.dispatchEvent('testEnd', {
+        testId: testId,
+        duration: testResult.duration,
+        status: testResult.status,
+        errors: testResult.errors,
+        hasNonRetriableError: false,
+        expectedStatus: 'passed',
+        annotations: [],
+        timeout: this._params.config?.timeout || 30000,
+      });
+    }
+
+    this.dispatchEvent('done', {
+      fatalErrors: r.isError ? [{ message: r.text }] : [],
+      skipTestsDueToSetupFailure: [],
+    });
+    console.error('[pw-worker] group done, keeping bridge alive (pid ' + process.pid + ')');
+  }
+
+  _findResult(lines, testId, entries) {
+    const idx = entries.findIndex(e => e.testId === testId);
+    let currentIdx = -1;
+
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i];
+      if (line.match(/^\s*[✓✔]/)) {
+        currentIdx++;
+        if (currentIdx === idx) {
+          const dur = line.match(/\((\d+)ms\)/);
+          return { status: 'passed', duration: dur ? parseInt(dur[1]) : 0, errors: [] };
+        }
+      } else if (line.match(/^\s*[✗✘]/)) {
+        currentIdx++;
+        if (currentIdx === idx) {
+          const dur = line.match(/\((\d+)ms\)/);
+          const errLine = lines[i + 1] || '';
+          return {
+            status: 'failed',
+            duration: dur ? parseInt(dur[1]) : 0,
+            errors: [{ message: errLine.trim() }],
+          };
+        }
+      } else if (line.match(/^\s*-.*\(skipped\)/)) {
+        currentIdx++;
+        if (currentIdx === idx) {
+          return { status: 'skipped', duration: 0, errors: [] };
+        }
+      }
+    }
+
+    return { status: 'failed', duration: 0, errors: [{ message: 'Test result not found' }] };
+  }
+
+  async _compile(testFilePath) {
+    const esbuild = require('esbuild');
+    const path = require('path');
+    const fs = require('fs');
+
+    const testDir = path.dirname(testFilePath);
+    const testFileName = path.basename(testFilePath);
+
+    const shimPath = path.resolve(__dirname, 'shim', 'alias.ts');
+    const shimPathJs = shimPath.replace('.ts', '.js');
+    const aliasPath = fs.existsSync(shimPath) ? shimPath : shimPathJs;
+
+    const plugin = {
+      name: 'pw-bridge',
+      setup(build) {
+        build.onResolve({ filter: /^__entry__$/ }, () => ({ path: '__entry__', namespace: 'entry' }));
+        build.onLoad({ filter: /.*/, namespace: 'entry' }, () => ({
+          contents: 'import "./' + testFileName + '";',
+          resolveDir: testDir,
+          loader: 'ts',
+        }));
+      },
+    };
+
+    const result = await esbuild.build({
+      entryPoints: ['__entry__'],
+      bundle: true,
+      write: false,
+      format: 'iife',
+      platform: 'neutral',
+      plugins: [plugin],
+      alias: { '@playwright/test': aliasPath },
+    });
+
+    return result.outputFiles[0].text;
+  }
+
+  dispatchEvent(method, params) {
+    const response = { method: method, params: params };
+    process.send({ method: '__dispatch__', params: response });
+  }
+
+  async gracefullyClose() {
+    if (this._context) await this._context.close().catch(() => {});
+    if (this._bridge) await this._bridge.close().catch(() => {});
+  }
+}
+
+function create(params) {
+  return new BridgeWorker(params);
+}
+
+module.exports = { create };


### PR DESCRIPTION
## Summary
- Replace context-patching approach with a custom Playwright worker (`pw-worker.cjs`) that compiles tests via esbuild and sends to bridge in one `runScript()` call
- Fix `fatalUnknownTestIds: []` bug — empty array is truthy, causing Playwright to kill/restart worker after every test file (23 browsers for 23 tests)
- Each worker lazily launches its own browser + bridge, reuses across all test groups

## Results (23 TodoMVC tests)
| Config | Time |
|--------|------|
| vanilla `playwright test` | 27.4s |
| 1 worker bridge | 4.9s (5.6x) |
| 2 workers bridge | 4.2s |

## Test plan
- [x] `workers: 1` — single PID, single bridge port, all 23 tests reuse same process
- [x] `workers: 2` — two PIDs, two bridge ports, tests distributed across both
- [x] All 23 tests pass in both configurations

Closes #364

🤖 Generated with [Claude Code](https://claude.com/claude-code)