### PR TITLE
feat: pw-run improvements + VS Code extension fixes

### DIFF
--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -70,7 +70,9 @@ export async function run(args: string[]): Promise<number> {
     const results = await executeTestFile(file, bridge, runOpts, context, nodePage);
     allResults.push(...results);
     for (const r of results) {
-      if (r.passed) {
+      if (r.skipped) {
+        console.log(`  - ${r.name} (skipped)`);
+      } else if (r.passed) {
         console.log(`  \u2713 ${r.name} (${r.duration}ms)`);
       } else {
         console.log(`  \u2717 ${r.name} (${r.duration}ms)`);
@@ -82,7 +84,7 @@ export async function run(args: string[]): Promise<number> {
 
   // Summary
   const totalTime = ((Date.now() - startTime) / 1000).toFixed(1);
-  const passed = allResults.filter(r => r.passed).length;
+  const passed = allResults.filter(r => r.passed && !r.skipped).length;
   const skipped = allResults.filter(r => r.skipped).length;
   console.log(`\n  ${passed} passed, ${failed} failed, ${skipped} skipped (${totalTime}s)\n`);
 

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -56,12 +56,7 @@
           "enum": ["chromium", "chrome", "msedge"],
           "description": "Browser to launch (chromium = Playwright's bundled Chromium)"
         },
-        "playwright-ide.bridgePort": {
-          "type": "number",
-          "default": 9876,
-          "description": "WebSocket bridge port for extension communication"
-        },
-        "playwright-ide.headless": {
+"playwright-ide.headless": {
           "type": "boolean",
           "default": false,
           "description": "Run browser in headless mode (no visible window)"

--- a/packages/vscode/src/browser.ts
+++ b/packages/vscode/src/browser.ts
@@ -11,7 +11,7 @@ declare const __filename: string;
 
 export interface LaunchOptions {
   browser: string;
-  bridgePort: number;
+  bridgePort?: number;
   headless?: boolean;
 }
 
@@ -43,7 +43,7 @@ export class BrowserManager {
 
     // 2. Start BridgeServer (WebSocket)
     const bridge = new BridgeServer();
-    await bridge.start(opts.bridgePort || 9876);
+    await bridge.start(opts.bridgePort || 0);
     this._bridge = bridge;
     this._log.appendLine(`BridgeServer on port ${bridge.port}`);
 
@@ -75,11 +75,19 @@ export class BrowserManager {
     });
     this._log.appendLine('Chromium launched.');
 
-    // 4. Navigate initial page so extension can attach
+    // 4. Set bridge port via service worker so extension knows where to connect
+    let sw = this._browserContext.serviceWorkers()[0];
+    if (!sw) sw = await this._browserContext.waitForEvent('serviceworker', { timeout: 10000 });
+    await sw.evaluate((port: number) => {
+      chrome.storage.local.set({ bridgePort: port });
+    }, bridge.port);
+    this._log.appendLine(`Bridge port ${bridge.port} set via service worker.`);
+
+    // 5. Navigate initial page so extension can attach
     const page = this._browserContext.pages()[0];
     if (page) await page.goto('https://www.google.com');
 
-    // 5. Wait for offscreen document to connect via WebSocket
+    // 6. Wait for offscreen document to connect via WebSocket
     this._log.appendLine('Waiting for extension to connect...');
     await bridge.waitForConnection(30000);
     this._running = true;

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -32,7 +32,6 @@ export function activate(context: vscode.ExtensionContext) {
         const config = vscode.workspace.getConfiguration('playwright-ide');
         await browserManager!.launch({
           browser: config.get('browser', 'chromium'),
-          bridgePort: config.get('bridgePort', 9876),
         });
         outputChannel.show();
         vscode.window.showInformationMessage('Playwright IDE: Browser launched.');
@@ -87,8 +86,7 @@ export function activate(context: vscode.ExtensionContext) {
           outputChannel.appendLine('Auto-launching browser for test run...');
           await browserManager!.launch({
             browser: config.get('browser', 'chromium'),
-            bridgePort: config.get('bridgePort', 9876),
-            headless: config.get('headless', false),
+              headless: config.get('headless', false),
           });
           outputChannel.show();
         }
@@ -133,8 +131,7 @@ export function activate(context: vscode.ExtensionContext) {
         try {
           await browserManager!.launch({
             browser: config.get('browser', 'chromium'),
-            bridgePort: config.get('bridgePort', 9876),
-          });
+            });
         } catch (err: unknown) {
           vscode.window.showErrorMessage(`Failed to launch browser: ${(err as Error).message}`);
           return;
@@ -166,8 +163,7 @@ export function activate(context: vscode.ExtensionContext) {
         try {
           await browserManager!.launch({
             browser: config.get('browser', 'chromium'),
-            bridgePort: config.get('bridgePort', 9876),
-          });
+            });
         } catch (err: unknown) {
           vscode.window.showErrorMessage(`Failed to launch browser: ${(err as Error).message}`);
           return;

--- a/packages/vscode/src/mode-detect.ts
+++ b/packages/vscode/src/mode-detect.ts
@@ -59,11 +59,26 @@ export async function detectTestMode(testFilePath: string): Promise<TestMode> {
       }
     }
 
-    // Also check the source for process.env / __dirname (not import-based)
+    // Check source + local imports for Node globals and Playwright Node-only APIs
     const fs = await import('fs');
-    const source = fs.default.readFileSync(testFilePath, 'utf-8');
-    if (/process\.env\b|process\.cwd\b|process\.argv\b|__dirname\b|__filename\b/.test(source)) {
-      return 'compiler';
+    const NODE_PATTERNS = [
+      /\bprocess\.env\b/, /\bprocess\.cwd\b/, /\bprocess\.argv\b/,
+      /\b__dirname\b/, /\b__filename\b/, /\bBuffer\.\b/,
+      // Playwright APIs that need Node (callbacks, non-serializable)
+      /\.route\s*\(/, /\.unroute\s*\(/, /\.routeFromHAR\s*\(/,
+      /\.waitForEvent\s*\(/, /\.waitForResponse\s*\(/, /\.waitForRequest\s*\(/,
+      /\.\$eval\s*\(/, /\.\$\$eval\s*\(/,
+    ];
+
+    // Check all resolved source files (not just the entry)
+    for (const inputPath of Object.keys(result.metafile!.inputs)) {
+      if (inputPath.includes('node_modules')) continue;
+      try {
+        const src = fs.default.readFileSync(inputPath, 'utf-8');
+        for (const pattern of NODE_PATTERNS) {
+          if (pattern.test(src)) return 'compiler';
+        }
+      } catch { /* skip unreadable files */ }
     }
 
     return 'browser';

--- a/packages/vscode/src/shim/test-runner.ts
+++ b/packages/vscode/src/shim/test-runner.ts
@@ -91,6 +91,43 @@ test.afterAll = (fn: HookFn) => { currentSuite.afterAll.push(fn); };
 test.beforeEach = (fn: HookFn) => { currentSuite.beforeEach.push(fn); };
 test.afterEach = (fn: HookFn) => { currentSuite.afterEach.push(fn); };
 
+/* eslint-disable @typescript-eslint/no-explicit-any */
+test.extend = (fixtures: Record<string, any>) => {
+  const extendedTest = (name: string, fn: TestFn) => {
+    currentSuite.tests.push({
+      name, only: false, skip: false,
+      fn: async (baseFixtures: any) => {
+        const extended = { ...baseFixtures };
+        for (const [key, fixtureFn] of Object.entries(fixtures)) {
+          if (typeof fixtureFn === 'function') {
+            await new Promise<void>((resolve, reject) => {
+              const useCallback = async (value: any) => {
+                extended[key] = value;
+                resolve();
+              };
+              Promise.resolve(fixtureFn(
+                { ...extended, [key]: extended[key] },
+                useCallback,
+              )).catch(reject);
+            });
+          }
+        }
+        await fn(extended);
+      },
+    });
+  };
+  extendedTest.only = test.only;
+  extendedTest.skip = test.skip;
+  extendedTest.describe = test.describe;
+  extendedTest.beforeAll = test.beforeAll;
+  extendedTest.afterAll = test.afterAll;
+  extendedTest.beforeEach = test.beforeEach;
+  extendedTest.afterEach = test.afterEach;
+  extendedTest.extend = test.extend;
+  return extendedTest;
+};
+/* eslint-enable @typescript-eslint/no-explicit-any */
+
 // ─── Runner ────────────────────────────────────────────────────────────────
 
 // These globals are provided by playwright-crx's service worker scope.

--- a/packages/vscode/src/test-explorer.ts
+++ b/packages/vscode/src/test-explorer.ts
@@ -11,7 +11,6 @@
 
 import * as vscode from 'vscode';
 import path from 'node:path';
-import fs from 'node:fs';
 import { parseTestFile, type ParsedTest } from './test-parser.js';
 import type { BrowserManager } from './browser.js';
 
@@ -83,8 +82,13 @@ export class TestExplorer {
       this._outputChannel.appendLine(`  Parsed ${uri.fsPath}: ${parsed.length} top-level items`);
       if (parsed.length === 0) return;
 
-      const fileName = uri.path.replace(/.*[\\/]/, '');
-      const fileItem = this._controller.createTestItem(uri.toString(), fileName, uri);
+      // Show relative path as label for better navigation
+      const workspaceFolder = vscode.workspace.getWorkspaceFolder(uri);
+      const label = workspaceFolder
+        ? path.relative(workspaceFolder.uri.fsPath, uri.fsPath).replace(/\\/g, '/')
+        : path.basename(uri.fsPath);
+
+      const fileItem = this._controller.createTestItem(uri.toString(), label, uri);
       this._buildTree(fileItem, parsed, uri);
       this._controller.items.add(fileItem);
     } catch (err: unknown) {
@@ -139,7 +143,6 @@ export class TestExplorer {
         this._outputChannel.appendLine('Auto-launching browser for test run...');
         await this._browserManager.launch({
           browser: config.get('browser', 'chromium'),
-          bridgePort: config.get('bridgePort', 9876),
           headless: config.get('headless', false),
         });
       } catch (err: unknown) {
@@ -163,20 +166,23 @@ export class TestExplorer {
         this._outputChannel.appendLine(`Mode: ${mode === 'browser' ? '⚡ browser (fast)' : '🔧 compiler (Node.js)'}`);
 
         let resultText: string;
+        this._outputChannel.appendLine(`Running: ${fileUri.fsPath}`);
         if (mode === 'browser') {
           const { bundleTestFile } = await import('./bundler.js');
           const script = await bundleTestFile(fileUri.fsPath);
+          this._outputChannel.appendLine(`Bundled: ${script.length} chars`);
           const result = await this._browserManager.runScript(script);
+          this._outputChannel.appendLine(`Result: isError=${result.isError}, text=${(result.text || '').substring(0, 200)}`);
           resultText = result.text || '';
         } else {
-          // Compiler mode: run in Node.js with bridge
-          const { compileTestFile, executeCompiledTest } = await import('./compiler.js');
-          const compiled = await compileTestFile(fileUri.fsPath);
-          this._outputChannel.appendLine('Running in Node.js with bridge...');
-          resultText = await executeCompiledTest(compiled, (cmd) => this._browserManager.runCommand(cmd));
+          // Node mode: run via pw-cli (handles bridge/Node routing internally)
+          this._outputChannel.appendLine('Node mode: running via pw-cli...');
+          const testNames = fileItems.map(i => i.label);
+          resultText = await this._runViaPw(fileUri.fsPath, testNames);
         }
 
         // Parse structured results and map to test items
+        this._outputChannel.appendLine(`Results:\n${resultText}`);
         this._mapResults(run, fileItems, resultText);
       } catch (err: unknown) {
         for (const item of fileItems) {
@@ -236,6 +242,32 @@ export class TestExplorer {
     }
   }
 
+  private async _runViaPw(filePath: string, testNames?: string[]): Promise<string> {
+    const { spawn } = await import('node:child_process');
+
+    // Resolve pw from monorepo (packages/vscode/dist → ../../runner/dist/cli.js)
+    const pwPath = path.resolve(path.dirname(__filename), '..', '..', 'runner', 'dist', 'cli.js');
+    const parts = ['node', `"${pwPath}"`, 'test', `"${filePath}"`];
+    if (testNames && testNames.length > 0) {
+      const grepPattern = testNames.map(n => n.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')).join('|');
+      parts.push('--grep', `"${grepPattern}"`);
+    }
+
+    const cmd = parts.join(' ');
+    this._outputChannel.appendLine(`[pw] ${cmd}`);
+
+    return new Promise((resolve) => {
+      let output = '';
+      const child = spawn(cmd, [], {
+        cwd: path.dirname(filePath),
+        shell: true,
+      });
+      child.stdout?.on('data', (data: Buffer) => { output += data.toString(); });
+      child.stderr?.on('data', (data: Buffer) => { this._outputChannel.appendLine(data.toString()); });
+      child.on('exit', () => resolve(output));
+    });
+  }
+
   private _getFileUri(item: vscode.TestItem): vscode.Uri | undefined {
     if (item.uri) return item.uri;
     if (item.parent) return this._getFileUri(item.parent);
@@ -268,9 +300,9 @@ export class TestExplorer {
 
     // Map results to test items
     for (const item of items) {
-      // Build full name: "Suite > Test"
+      // Try full name first ("Suite > Test"), then just test name ("Test")
       const fullName = this._getFullTestName(item);
-      const result = results.get(fullName);
+      const result = results.get(fullName) || results.get(item.label);
 
       if (!result) {
         run.skipped(item);


### PR DESCRIPTION
## Summary
- **pw-run**: fix grep output (skipped vs passed), fix summary count
- **VS Code extension**: random bridge port, test.extend in shim, mode detection for Node-only APIs, node-mode tests via pw-run with grep
- Closes #347 (random bridge port)

## Changes

### pw-run (runner.ts)
- Skipped tests show as `- name (skipped)` instead of `✓ name (0ms)`
- Summary excludes skipped from passed count: `1 passed, 0 failed, 2 skipped`

### VS Code extension
- `bridge.start(0)` — random port, no more hardcoded 9876
- Set bridge port via service worker (`chrome.storage.local`)
- Removed `bridgePort` setting from package.json
- Added `test.extend` to VS Code shim (fixes fixture-based tests like todomvc)
- Mode detection checks for `page.route()`, `routeFromHAR()`, `waitForEvent()`, `$eval()` across all source files
- Test explorer: relative path labels, node-mode tests run via pw-run with `--grep`
- Result matching falls back to `item.label` when full describe path doesn't match

## Test plan
- [x] Browser-mode tests (todomvc) — pass in VS Code Test Explorer
- [x] Node-mode tests (api-mocking) — pass via pw-run with grep
- [x] Random bridge port — verified in output channel
- [x] Grep filtering — `1 passed, 0 failed, 2 skipped`

🤖 Generated with [Claude Code](https://claude.com/claude-code)