### PR TITLE
fix: CI — run all 192 tests via pw-cli

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,10 +60,10 @@ jobs:
         run: pnpm exec playwright install --with-deps chrome
         working-directory: packages/runner
 
-      - name: Run runner E2E tests (todomvc via pw-cli)
-        run: node ../dist/pw-cli.js test todomvc/ --workers 1
+      - name: Run runner E2E tests (192 tests via pw-cli)
+        run: node ../dist/pw-cli.js test --workers 2
         working-directory: packages/runner/examples
-        timeout-minutes: 5
+        timeout-minutes: 10
 
       - name: Run extension E2E tests
         run: pnpm exec playwright test


### PR DESCRIPTION
## Summary
Run full 192 test suite in CI instead of todomvc-only. Now that `--with-deps` fixed the Chrome launch issue.

- All 192 tests (bridge + node) with `--workers 2`
- 10 minute timeout

Closes #380

🤖 Generated with [Claude Code](https://claude.com/claude-code)