### PR TITLE
feat: bundle Chrome extension into VS Code package

### DIFF
--- a/packages/vscode/.gitignore
+++ b/packages/vscode/.gitignore
@@ -1,0 +1,2 @@
+dist/
+chrome-extension/

--- a/packages/vscode/build.mjs
+++ b/packages/vscode/build.mjs
@@ -1,4 +1,6 @@
 import * as esbuild from 'esbuild';
+import fs from 'fs';
+import path from 'path';
 
 const watch = process.argv.includes('--watch');
 
@@ -21,5 +23,16 @@ if (watch) {
   console.log('Watching for changes...');
 } else {
   await esbuild.build(options);
+
+  // Copy Chrome extension dist into VSIX bundle
+  const src = path.resolve('..', 'extension', 'dist');
+  const dest = path.resolve('chrome-extension');
+  if (fs.existsSync(src)) {
+    fs.cpSync(src, dest, { recursive: true });
+    console.log('Chrome extension copied to chrome-extension/');
+  } else {
+    console.warn('Warning: extension/dist not found — skipping chrome-extension copy');
+  }
+
   console.log('Build complete.');
 }

--- a/packages/vscode/src/browser.ts
+++ b/packages/vscode/src/browser.ts
@@ -35,12 +35,14 @@ export class BrowserManager {
   async launch(opts: LaunchOptions) {
     const _require = createRequire(__filename);
 
-    // 1. Find the extension dist path (sibling package in monorepo)
+    // 1. Find Chrome extension: bundled (VSIX) first, then monorepo fallback
+    const bundledExt = path.resolve(path.dirname(__filename), '..', 'chrome-extension');
     const coreMain = _require.resolve('@playwright-repl/core');
     const coreDir = coreMain.replace(/[\\/]dist[\\/].*$/, '');
-    const extPath = path.resolve(coreDir, '../extension/dist');
+    const monorepoExt = path.resolve(coreDir, '../extension/dist');
+    const extPath = fs.existsSync(path.join(bundledExt, 'manifest.json')) ? bundledExt : monorepoExt;
     if (!fs.existsSync(path.join(extPath, 'manifest.json')))
-      throw new Error(`Extension not built. Run "pnpm run build" first. Expected: ${extPath}`);
+      throw new Error(`Chrome extension not found. Run "pnpm run build" first.`);
     this._log.appendLine(`Extension: ${extPath}`);
 
     // 2. Start BridgeServer (WebSocket)


### PR DESCRIPTION
## Summary
Bundle the Chrome extension (playwright-crx) inside the VS Code extension so it works outside the monorepo.

- `build.mjs`: copies `packages/extension/dist/` → `chrome-extension/` after esbuild
- `browser.ts`: resolves bundled `chrome-extension/` first, falls back to monorepo path
- `.gitignore`: excludes `chrome-extension/` (build artifact)

## Before / After
```
Before: Extension: .../packages/extension/dist (monorepo only)
After:  Extension: .../packages/vscode/chrome-extension (bundled, works standalone)
```

## Test plan
- [x] Build: `chrome-extension/manifest.json` exists after build
- [x] F5: output shows `Extension: .../chrome-extension` (bundled path)
- [x] Test runs successfully with bundled extension

Closes #379

🤖 Generated with [Claude Code](https://claude.com/claude-code)