### PR TITLE
feat: Playwright test discovery for accurate Test Explorer matching

### DIFF
--- a/packages/runner/src/run-test.ts
+++ b/packages/runner/src/run-test.ts
@@ -13,7 +13,7 @@ import path from 'node:path';
 import fs from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import type { BridgeServer } from '@playwright-repl/core';
-import type { TestResult } from './types.js';
+import type { TestResult, DiscoveredTest } from './types.js';
 
 const __filename = fileURLToPath(import.meta.url);
 
@@ -257,33 +257,97 @@ async function executeNode(
   });
 }
 
+// ─── Test Discovery ──────────────────────────────────────────────────────────
+
+// Discover tests by running `playwright test --list` in a subprocess.
+// Evaluates the file through Playwright's loader — resolves template literals,
+// expands parameterized tests, and returns accurate test names + line numbers.
+//
+// Why subprocess instead of TestServerDispatcher API:
+// The in-process API fails under pnpm because the forked loader worker resolves
+// @playwright/test to a different physical copy than the one that set the
+// currentFileSuite global — same version, two module instances, broken singleton.
+// The CLI boots from a single entry point so resolution is consistent.
+export async function listTests(filePath: string): Promise<DiscoveredTest[]> {
+  const { spawn } = await import('node:child_process');
+  const { createRequire } = await import('node:module');
+
+  const require = createRequire(__filename);
+  const pwCliPath = require.resolve('@playwright/test/cli');
+  const configDir = findConfigDir(path.dirname(filePath));
+  const relPath = path.relative(configDir, filePath).replace(/\\/g, '/');
+  const args = [pwCliPath, 'test', '--list', relPath, '--reporter', 'list'];
+
+  const nodePath = process.env.NVM_SYMLINK
+    ? path.join(process.env.NVM_SYMLINK, 'node')
+    : 'node';
+
+  return new Promise((resolve) => {
+    let buffer = '';
+    const tests: DiscoveredTest[] = [];
+
+    const child = spawn(nodePath, args, {
+      cwd: configDir,
+      stdio: ['ignore', 'pipe', 'pipe'],
+      shell: true,
+      env: (() => {
+        const env = { ...process.env };
+        delete env.ELECTRON_RUN_AS_NODE;
+        delete env.NODE_OPTIONS;
+        return env;
+      })(),
+    });
+
+    child.stdout?.on('data', (d: Buffer) => { buffer += d.toString(); });
+
+    child.on('close', () => {
+      // Parse lines: "  [project] › file.spec.ts:LINE:COL › [describe ›] test name"
+      for (const line of buffer.split('\n')) {
+        const m = line.match(/›\s+\S+?:(\d+):(\d+)\s+›\s+(.+)/);
+        if (!m) continue;
+        const lineNum = parseInt(m[1]);
+        const col = parseInt(m[2]);
+        const namePath = m[3].trim();
+        const parts = namePath.split(/\s+›\s+/);
+        const title = parts[parts.length - 1];
+        tests.push({ title, fullName: parts.join(' > '), line: lineNum, column: col });
+      }
+      resolve(tests);
+    });
+  });
+}
+
 // Parse Playwright list reporter line:
 //   ✓  1 [chromium] › file.spec.ts:10:1 › describe › test name (1.2s)
 //   ✗  2 [chromium] › file.spec.ts:20:1 › test name (3.4s)
 //   -  3 [chromium] › file.spec.ts:30:1 › test name
 function parseListLine(line: string, filePath: string): TestResult | null {
+  // Extract line number from file location: "file.spec.ts:23:1"
+  const locMatch = line.match(/›\s+\S+?:(\d+):\d+\s+›/);
+  const sourceLine = locMatch ? parseInt(locMatch[1]) : undefined;
+
   // Match passed: ✓ or ok
   const passMatch = line.match(/^\s*[✓✔].*?›\s+.*?›\s+(.+?)\s+\(([0-9.]+)(m?s)\)/);
   if (passMatch) {
     const dur = passMatch[3] === 's' ? parseFloat(passMatch[2]) * 1000 : parseFloat(passMatch[2]);
-    return { name: passMatch[1].trim(), file: filePath, passed: true, skipped: false, duration: dur };
+    return { name: passMatch[1].trim(), file: filePath, passed: true, skipped: false, duration: dur, line: sourceLine };
   }
   // Match passed (plain text): "  ok N [project] › ..."
   const okMatch = line.match(/^\s*ok\s+\d+.*?›\s+.*?›\s+(.+?)\s+\(([0-9.]+)(m?s)\)/);
   if (okMatch) {
     const dur = okMatch[3] === 's' ? parseFloat(okMatch[2]) * 1000 : parseFloat(okMatch[2]);
-    return { name: okMatch[1].trim(), file: filePath, passed: true, skipped: false, duration: dur };
+    return { name: okMatch[1].trim(), file: filePath, passed: true, skipped: false, duration: dur, line: sourceLine };
   }
   // Match failed: ✗ or x
   const failMatch = line.match(/^\s*[✗✘×].*?›\s+.*?›\s+(.+?)\s+\(([0-9.]+)(m?s)\)/);
   if (failMatch) {
     const dur = failMatch[3] === 's' ? parseFloat(failMatch[2]) * 1000 : parseFloat(failMatch[2]);
-    return { name: failMatch[1].trim(), file: filePath, passed: false, skipped: false, duration: dur };
+    return { name: failMatch[1].trim(), file: filePath, passed: false, skipped: false, duration: dur, line: sourceLine };
   }
   // Match skipped: -
   const skipMatch = line.match(/^\s*-\s+\d+.*?›\s+.*?›\s+(.+)/);
   if (skipMatch) {
-    return { name: skipMatch[1].trim(), file: filePath, passed: true, skipped: true, duration: 0 };
+    return { name: skipMatch[1].trim(), file: filePath, passed: true, skipped: true, duration: 0, line: sourceLine };
   }
   return null;
 }

--- a/packages/runner/src/types.ts
+++ b/packages/runner/src/types.ts
@@ -16,6 +16,14 @@ export interface TestResult {
   skipped: boolean;
   error?: string;
   duration: number;
+  line?: number;   // 1-based line number from reporter output
+}
+
+export interface DiscoveredTest {
+  title: string;     // leaf test name (e.g. "test name")
+  fullName: string;  // full path with describes (e.g. "describe > test name")
+  line: number;      // 1-based line number
+  column: number;
 }
 
 export interface PlaywrightConfig {

--- a/packages/vscode/src/test-explorer.ts
+++ b/packages/vscode/src/test-explorer.ts
@@ -264,34 +264,46 @@ export class TestExplorer {
       const fileUri = vscode.Uri.parse(fileKey);
       try {
         const runTestPath = path.resolve(path.dirname(__filename), '..', '..', 'runner', 'dist', 'run-test.js');
-        const { runTestFile, needsNodeMode } = await import(`file://${runTestPath.replace(/\\/g, '/')}`);
+        const { runTestFile, needsNodeMode, listTests } = await import(`file://${runTestPath.replace(/\\/g, '/')}`);
         const bridge = this._browserManager.bridge!;
         const page = this._browserManager.page;
 
+        const isNode = needsNodeMode(fileUri.fsPath);
+
+        // Node mode: use Playwright discovery to get real test names
+        // (resolves template literals, expands parameterized tests)
+        let activeItems = fileItems;
+        if (isNode) {
+          try {
+            const discovered = await listTests(fileUri.fsPath);
+            if (discovered.length > 0) {
+              this._outputChannel.appendLine(`  Discovery: ${discovered.length} tests via --list`);
+              activeItems = this._rebuildFileItems(fileUri, discovered);
+              for (const item of activeItems) run.enqueued(item);
+            }
+          } catch (e: unknown) {
+            this._outputChannel.appendLine(`  Discovery fallback to regex: ${(e as Error).message}`);
+          }
+        }
+
         // Build grep from requested test names
-        const testNames = fileItems.map(i => i.label);
+        const testNames = activeItems.map(i => i.label);
         const grep = testNames.length === 1 ? testNames[0] : undefined;
 
-        const isNode = needsNodeMode(fileUri.fsPath);
         this._outputChannel.appendLine(`Running: ${fileUri.fsPath}${grep ? ` (${grep})` : ''} [${isNode ? 'node' : 'bridge'}]`);
 
         // Bridge mode: mark all started upfront (results come back in batch)
         if (!isNode) {
-          for (const item of fileItems) run.started(item);
+          for (const item of activeItems) run.started(item);
         }
 
         // Stream results: update Test Explorer as each test completes
         const onResult = (r: any) => {
           const icon = r.skipped ? '-' : r.passed ? '✓' : '✗';
           this._outputChannel.appendLine(`  ${icon} ${r.name} (${r.duration}ms)${r.error ? ' — ' + r.error : ''}`);
-          // Find matching item and update immediately
-          const item = fileItems.find(i => {
-            const fullName = this._getFullTestName(i);
-            return fullName === r.name || i.label === r.name
-              || r.name.endsWith(fullName) || r.name.endsWith(i.label);
-          });
+          const item = this._matchItem(activeItems, r);
           if (!item) {
-            this._outputChannel.appendLine(`  [no match] result="${r.name}" items=[${fileItems.map(i => `"${i.label}"`).slice(0, 5).join(', ')}...]`);
+            this._outputChannel.appendLine(`  [no match] result="${r.name}" items=[${activeItems.map(i => `"${i.label}"`).slice(0, 5).join(', ')}...]`);
           }
           if (item) {
             run.started(item);
@@ -309,12 +321,8 @@ export class TestExplorer {
           for (const r of results) {
             this._outputChannel.appendLine(`  ${r.skipped ? '-' : r.passed ? '✓' : '✗'} ${r.name} (${r.duration}ms)${r.error ? ' — ' + r.error : ''}`);
           }
-          for (const item of fileItems) {
-            const fullName = this._getFullTestName(item);
-            const result = results.find((r: any) =>
-              r.name === fullName || r.name === item.label
-              || r.name.endsWith(fullName) || r.name.endsWith(item.label)
-            );
+          for (const item of activeItems) {
+            const result = this._matchResult(results, item);
             if (!result || result.skipped) {
               run.skipped(item);
             } else if (result.passed) {
@@ -327,12 +335,8 @@ export class TestExplorer {
 
         // Node mode: mark any items not matched by streaming as skipped
         if (isNode) {
-          for (const item of fileItems) {
-            const fullName = this._getFullTestName(item);
-            const hasResult = results.some((r: any) =>
-              r.name === fullName || r.name === item.label
-              || r.name.endsWith(fullName) || r.name.endsWith(item.label)
-            );
+          for (const item of activeItems) {
+            const hasResult = results.some((r: any) => this._isMatch(item, r));
             if (!hasResult) {
               run.started(item);
               run.skipped(item);
@@ -482,5 +486,110 @@ export class TestExplorer {
     // Remove the file name (first element after reversal)
     if (parts.length > 1) parts.shift();
     return parts.join(' > ');
+  }
+
+  // ─── Discovery helpers ──────────────────────────────────────────────────────
+
+  /**
+   * Rebuild TestItems for a file from Playwright discovery results.
+   * Replaces regex-parsed items with accurate names from --list.
+   */
+  private _rebuildFileItems(fileUri: vscode.Uri, discovered: any[]): vscode.TestItem[] {
+    // Find the existing file TestItem in the tree
+    let fileItem: vscode.TestItem | undefined;
+    const findFile = (items: vscode.TestItemCollection) => {
+      items.forEach(item => {
+        if (item.id === fileUri.toString()) fileItem = item;
+        else if (item.children.size > 0) findFile(item.children);
+      });
+    };
+    findFile(this._controller.items);
+    if (!fileItem) return [];
+
+    // Clear existing children and rebuild from discovery
+    const oldChildren: string[] = [];
+    fileItem.children.forEach(c => oldChildren.push(c.id));
+    for (const id of oldChildren) fileItem.children.delete(id);
+
+    // Group by describe path to rebuild hierarchy
+    const items: vscode.TestItem[] = [];
+    for (const test of discovered) {
+      const parts = test.fullName.split(' > ');
+      let parent = fileItem;
+
+      // Create describe hierarchy (all parts except last)
+      for (let i = 0; i < parts.length - 1; i++) {
+        const suiteId = `${parent.id}/${parts[i]}`;
+        let suite = parent.children.get(suiteId);
+        if (!suite) {
+          suite = this._controller.createTestItem(suiteId, parts[i], fileUri);
+          suite.range = new vscode.Range(test.line - 1, 0, test.line - 1, 0);
+          parent.children.add(suite);
+        }
+        parent = suite;
+      }
+
+      // Create the leaf test item
+      const testId = `${parent.id}/${test.title}`;
+      const item = this._controller.createTestItem(testId, test.title, fileUri);
+      item.range = new vscode.Range(test.line - 1, 0, test.line - 1, 0);
+      parent.children.add(item);
+      items.push(item);
+    }
+
+    return items;
+  }
+
+  // ─── Matching helpers ───────────────────────────────────────────────────────
+
+  /**
+   * Match a test result to a TestItem. Tries line number first (most reliable),
+   * then falls back to name matching.
+   */
+  private _matchItem(items: vscode.TestItem[], result: any): vscode.TestItem | undefined {
+    // 1. Try exact name match (fast path — works when discovery is accurate)
+    const byName = items.find(i => {
+      const fullName = this._getFullTestName(i);
+      return fullName === result.name || i.label === result.name;
+    });
+    if (byName) return byName;
+
+    // 2. Try line number match (handles name mismatches from template literals)
+    if (result.line) {
+      const byLine = items.find(i =>
+        i.range && i.range.start.line + 1 === result.line
+      );
+      if (byLine) return byLine;
+    }
+
+    // 3. Fuzzy: endsWith (handles describe-prefixed names)
+    return items.find(i => {
+      const fullName = this._getFullTestName(i);
+      return result.name.endsWith(fullName) || result.name.endsWith(i.label);
+    });
+  }
+
+  /** Match a result array against a TestItem (for batch mode). */
+  private _matchResult(results: any[], item: vscode.TestItem): any | undefined {
+    const fullName = this._getFullTestName(item);
+    // 1. Exact name
+    let r = results.find((r: any) => r.name === fullName || r.name === item.label);
+    if (r) return r;
+    // 2. Line number
+    if (item.range) {
+      r = results.find((r: any) => r.line && item.range!.start.line + 1 === r.line);
+      if (r) return r;
+    }
+    // 3. Fuzzy
+    return results.find((r: any) => r.name.endsWith(fullName) || r.name.endsWith(item.label));
+  }
+
+  /** Check if a result matches an item (for has-result checks). */
+  private _isMatch(item: vscode.TestItem, result: any): boolean {
+    const fullName = this._getFullTestName(item);
+    if (fullName === result.name || item.label === result.name) return true;
+    if (result.line && item.range && item.range.start.line + 1 === result.line) return true;
+    if (result.name.endsWith(fullName) || result.name.endsWith(item.label)) return true;
+    return false;
   }
 }


### PR DESCRIPTION
## Summary
- Use `playwright test --list` CLI to discover real test names before running Node-mode tests
- Resolves template literals (`${type}` → `color`, `date`, etc.) and expands parameterized tests that regex parser can't handle
- Improved result matching: exact name → line number → fuzzy endsWith fallback
- `page-fill.spec.ts`: regex found ~30 items (1 with `${type}`), discovery finds 44 (7 parameterized variants)

## Test plan
- [x] `listTests()` returns 44 tests for page-fill.spec.ts with correct resolved names
- [x] `listTests()` returns 6 tests for svgomg/example.spec.ts with describe hierarchy
- [x] Build succeeds
- [ ] Run all examples in VS Code Test Explorer — verify results match

## Follow-up
- #390 — Use TestServerDispatcher API instead of CLI subprocess (faster, avoids per-file process spawn overhead)

🤖 Generated with [Claude Code](https://claude.com/claude-code)