### PR TITLE
feat: harden context reuse — unrouteAll + dynamic viewport reset

### DIFF
--- a/packages/runner/src/pw-preload.cts
+++ b/packages/runner/src/pw-preload.cts
@@ -13,6 +13,7 @@ import path = require('path');
 
 let sharedContext: any = null;
 let sharedPage: any = null;
+let defaultViewport: { width: number; height: number } | null = null;
 let browserPatched = false;
 
 const origLoad = (Module as any)._load;
@@ -49,12 +50,15 @@ const origLoad = (Module as any)._load;
         if (!sharedContext) {
           sharedContext = await origNewContext(contextOptions);
           sharedPage = sharedContext.pages()[0] || await sharedContext.newPage();
+          defaultViewport = sharedPage.viewportSize();
         } else {
-          // Reuse: reset page state + viewport to Playwright default (1280×720)
+          // Reuse: reset page state + viewport to original default
           try {
             await sharedContext.clearCookies();
             await sharedContext.clearPermissions().catch(() => {});
-            await sharedPage.setViewportSize({ width: 1280, height: 720 });
+            await sharedContext.unrouteAll({ behavior: 'ignoreErrors' }).catch(() => {});
+            await sharedPage.unrouteAll({ behavior: 'ignoreErrors' }).catch(() => {});
+            if (defaultViewport) await sharedPage.setViewportSize(defaultViewport);
             await sharedPage.goto('about:blank', { waitUntil: 'commit' });
           } catch {}
         }


### PR DESCRIPTION
## Summary
- Add `unrouteAll()` for both context and page to prevent route/mock leaks between tests
- Save original viewport from first context creation, restore on reuse (replaces hardcoded 1280×720)

## Results
- 192 passed (29.3s) — no regression from added cleanup

Closes #394

🤖 Generated with [Claude Code](https://claude.com/claude-code)