### PR TITLE
feat: inject pw-preload for context reuse + bridge mode (Phase 2)

### DIFF
--- a/packages/vscode/src/playwrightTestServer.ts
+++ b/packages/vscode/src/playwrightTestServer.ts
@@ -15,6 +15,7 @@
  */
 
 import path from 'path';
+import fs from 'fs';
 import { ConfigFindRelatedTestFilesReport, ConfigListFilesReport } from './listTests';
 import * as vscodeTypes from './vscodeTypes';
 import * as reporterTypes from './upstream/reporter';
@@ -25,6 +26,20 @@ import { escapeRegex, pathSeparator } from './utils';
 import { debugSessionName } from './debugSessionName';
 import type { TestModel } from './testModel';
 import { TestServerInterface } from './upstream/testServerInterface';
+
+// ─── pw-preload injection for context reuse + bridge mode ─────────────────────
+const _preloadPath = path.resolve(__dirname, '../../runner/dist/pw-preload.cjs');
+const _extPath = path.resolve(__dirname, '../chrome-extension');
+const _hasPreload = fs.existsSync(_preloadPath);
+
+function preloadEnv(): Record<string, string | undefined> {
+  if (!_hasPreload) return {};
+  const existing = process.env.NODE_OPTIONS || '';
+  return {
+    NODE_OPTIONS: `${existing} --require ${_preloadPath}`.trim(),
+    PW_EXT_PATH: _extPath,
+  };
+}
 
 export type TestConfig = {
   workspaceFolder: string;
@@ -317,6 +332,8 @@ export class PlaywrightTestServer {
           PW_TEST_SOURCE_TRANSFORM: this._model.config.version < kMinTestPausedVersion ? require.resolve('./debugTransform') : undefined,
           PW_TEST_SOURCE_TRANSFORM_SCOPE: this._model.config.version < kMinTestPausedVersion ? testDirs.join(pathSeparator) : undefined,
           PWDEBUG: 'console',
+          // Inject pw-preload for context reuse + bridge mode
+          ...preloadEnv(),
         },
         program: paths.cli,
         args: ['test-server', '-c', paths.config],
@@ -416,6 +433,8 @@ export class PlaywrightTestServer {
           FORCE_COLOR: '1',
           // Reset VSCode's options that affect nested Electron.
           ELECTRON_RUN_AS_NODE: undefined,
+          // Inject pw-preload for context reuse + bridge mode
+          ...preloadEnv(),
         };
       },
       dumpIO: false,


### PR DESCRIPTION
## Summary

Inject `pw-preload.cjs` into the Playwright test server via `NODE_OPTIONS`. This enables context reuse (3.8x speedup) and bridge mode for compatible tests — all through the forked Playwright extension's test infrastructure.

## Changes

One file: `playwrightTestServer.ts`
- Add `preloadEnv()` helper that returns `NODE_OPTIONS` + `PW_EXT_PATH`
- Inject into `_createTestServer()` envProvider (normal test runs)
- Inject into `debugTests()` env block (debug runs)
- Graceful fallback: no-op if `pw-preload.cjs` not found

## Test plan

- [ ] F5 in VS Code → run tests → check Output for `[pw-worker]` logs
- [ ] Verify context reuse working (node-mode tests should be faster)
- [ ] Verify bridge mode working (bridge-compatible tests show `[pw-worker] bridge mode`)
- [ ] Debug mode still works

Phase 2 of #403

🤖 Generated with [Claude Code](https://claude.com/claude-code)