### PR TITLE
feat: auto-open REPL on activation, improve pick locator

### DIFF
--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -96,6 +96,7 @@ export class Extension implements RunHooks {
   private _browserManager?: BrowserManager;
   private _recorder?: Recorder;
   private _picker?: Picker;
+  private _repl?: PlaywrightRepl;
 
   private _modelRebuild?: { result: Promise<void>; token: vscodeTypes.CancellationTokenSource; needsAnother: boolean; };
 
@@ -191,6 +192,8 @@ export class Extension implements RunHooks {
     const vscode = this._vscode;
     this._settingsView = new SettingsView(vscode, this._settingsModel, this._models, this._reusedBrowser, this._context.extensionUri);
     this._locatorsView = new LocatorsView(vscode, this._settingsModel, this._reusedBrowser, this._context.extensionUri);
+    this._repl = new PlaywrightRepl();
+    this._repl.show();
     const messageNoPlaywrightTestsFound = this._vscode.l10n.t('No Playwright tests found.');
     this._disposables = [
       this._debugHighlight,
@@ -315,6 +318,9 @@ export class Extension implements RunHooks {
             browser: 'chromium',
             headless: !showBrowser,
           });
+          // Wire browser manager to REPL
+          if (this._repl)
+            this._repl.setBrowserManager(this._browserManager);
         } catch (e: unknown) {
           vscode.window.showErrorMessage(`Launch failed: ${(e as Error).message}`);
         }
@@ -323,13 +329,12 @@ export class Extension implements RunHooks {
         this._browserManager?.stop();
       }),
       vscode.commands.registerCommand('playwright-ide.openRepl', () => {
-        if (!this._browserManager?.isRunning()) {
-          vscode.window.showWarningMessage('Launch browser first.');
-          return;
+        if (!this._repl || this._repl.disposed) {
+          this._repl = new PlaywrightRepl(this._browserManager);
+          if (this._browserManager)
+            this._repl.setBrowserManager(this._browserManager);
         }
-        const repl = new PlaywrightRepl(this._browserManager);
-        const terminal = vscode.window.createTerminal({ name: 'Playwright REPL', pty: repl });
-        terminal.show();
+        this._repl.show();
       }),
       vscode.commands.registerCommand('playwright-ide.startRecording', async () => {
         if (!this._browserManager?.isRunning()) {

--- a/packages/vscode/src/repl.ts
+++ b/packages/vscode/src/repl.ts
@@ -17,11 +17,15 @@ export class PlaywrightRepl {
   private _buffer = '';
   private _history: string[] = [];
   private _historyIndex = -1;
-  private _browserManager: BrowserManager;
+  private _browserManager: BrowserManager | undefined;
   private _processing = false;
   disposed = false;
 
-  constructor(browserManager: BrowserManager) {
+  constructor(browserManager?: BrowserManager) {
+    this._browserManager = browserManager;
+  }
+
+  setBrowserManager(browserManager: BrowserManager) {
     this._browserManager = browserManager;
   }
 
@@ -177,6 +181,12 @@ export class PlaywrightRepl {
     this._processing = true;
 
     if (this._handleLocal(command)) {
+      this._processing = false;
+      return;
+    }
+
+    if (!this._browserManager?.isRunning()) {
+      this._writeEmitter.fire(`${RED}Browser not running. Use Ctrl+Shift+P → "Playwright IDE: Launch Browser" first.${RESET}\r\n`);
       this._processing = false;
       return;
     }


### PR DESCRIPTION
## Summary
- REPL auto-creates on extension activation (always visible in Terminal panel)
- REPL shows helpful message when browser not running
- BrowserManager wired to REPL when browser launches
- Pick locator removes redundant status bar button
- Pick locator fetches aria snapshot via bridge

## Test plan
- [x] F5 → REPL tab appears in Terminal panel immediately
- [x] Type command without browser → shows "Launch browser first" message
- [x] Launch browser → REPL commands work
- [x] Pick Locator → shows in Locators View with aria

Phase 3 continued, ref #403

🤖 Generated with [Claude Code](https://claude.com/claude-code)