### PR TITLE
feat: add assertion strings to Locator View on pick

### DIFF
--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -168,7 +168,7 @@
       "panel": [
         {
           "id": "playwrightReplContainer",
-          "title": "Locators",
+          "title": "Locator",
           "icon": "images/playwright-logo.png"
         }
       ]

--- a/packages/vscode/package.nls.json
+++ b/packages/vscode/package.nls.json
@@ -23,6 +23,6 @@
   "configuration.playwright-repl.pickLocatorCopyToClipboard": "Automatically copy picked locator to clipboard.",
   "configuration.playwright-repl.updateSnapshots": "Update snapshots",
   "configuration.playwright-repl.updateSourceMethod": "Update source method",
-  "views.test.playwright-repl.locatorsView": "Locators",
+  "views.test.playwright-repl.locatorsView": "Locator",
   "views.test.playwright-repl.settingsView": "Playwright REPL"
 }

--- a/packages/vscode/src/locatorsView.script.ts
+++ b/packages/vscode/src/locatorsView.script.ts
@@ -18,6 +18,7 @@ import { createAction, vscode } from './common';
 
 // @ts-check
 const locatorInput = document.getElementById('locator') as HTMLInputElement;
+const assertionInput = document.getElementById('assertion') as HTMLInputElement;
 const ariaTextArea = document.getElementById('ariaSnapshot') as HTMLTextAreaElement;
 const copyToClipboardCheckbox = document.getElementById('copyToClipboardCheckbox') as HTMLInputElement;
 
@@ -45,6 +46,9 @@ window.addEventListener('message', event => {
     locatorInput.value = params.locator.locator;
     locatorError.textContent = params.locator.error || '';
     locatorError.style.display = params.locator.error ? 'inherit' : 'none';
+    assertionInput.value = params.assertion || '';
+    const assertionSection = document.getElementById('assertionSection')!;
+    assertionSection.style.display = params.assertion ? 'flex' : 'none';
     ariaTextArea.value = params.ariaSnapshot.yaml;
     ariaSnapshotError.textContent = params.ariaSnapshot.error || '';
     ariaSnapshotError.style.display = params.ariaSnapshot.error ? 'inherit' : 'none';

--- a/packages/vscode/src/locatorsView.ts
+++ b/packages/vscode/src/locatorsView.ts
@@ -26,6 +26,7 @@ export class LocatorsView extends DisposableBase implements vscodeTypes.WebviewV
   private _view: vscodeTypes.WebviewView | undefined;
   private _extensionUri: vscodeTypes.Uri;
   private _locator: { locator: string, error?: string } = { locator: '' };
+  private _assertion: string = '';
   private _ariaSnapshot: { yaml: string, error?: string } = { yaml: '' };
   private _settingsModel: SettingsModel;
   private _reusedBrowser: ReusedBrowser;
@@ -53,8 +54,9 @@ export class LocatorsView extends DisposableBase implements vscodeTypes.WebviewV
   }
 
   /** Allow external callers (e.g. our bridge picker) to show a locator. */
-  public showLocator(locator: string, ariaSnapshot?: string) {
+  public showLocator(locator: string, ariaSnapshot?: string, assertion?: string) {
     this._locator = { locator };
+    this._assertion = assertion || '';
     this._ariaSnapshot = { yaml: ariaSnapshot || '' };
     this._updateValues();
     void this._vscode.commands.executeCommand('playwright-repl.locatorsView.focus');
@@ -124,6 +126,7 @@ export class LocatorsView extends DisposableBase implements vscodeTypes.WebviewV
       method: 'update',
       params: {
         locator: this._locator,
+        assertion: this._assertion,
         ariaSnapshot: this._ariaSnapshot,
         hideAria: this._backendVersion && this._backendVersion < 1.50
       }
@@ -164,6 +167,12 @@ function htmlForWebview(vscode: vscodeTypes.VSCode, extensionUri: vscodeTypes.Ur
         </div>
         <input id="locator" placeholder="${vscode.l10n.t('Locator')}" aria-labelledby="locatorLabel">
         <p id="locatorError" class="error"></p>
+      </div>
+      <div id="assertionSection" class="section">
+        <div class="hbox">
+          <label>Assert</label>
+        </div>
+        <input id="assertion" placeholder="Pick an element to see assertion" readonly aria-label="Assertion">
       </div>
       <div id="ariaSection" class="section">
         <div class="hbox">

--- a/packages/vscode/src/picker.ts
+++ b/packages/vscode/src/picker.ts
@@ -54,7 +54,14 @@ export class Picker {
       if (!this._picking) return;
 
       if (event.type === 'element-picked-raw') {
-        const info = event.info as { locator?: string };
+        const info = event.info as {
+          locator?: string;
+          tag?: string;
+          text?: string;
+          value?: string;
+          checked?: boolean;
+          attributes?: Record<string, string>;
+        };
         const locator = info?.locator;
         if (locator) {
           const fullLocator = `page.${locator}`;
@@ -68,13 +75,16 @@ export class Picker {
               ariaSnapshot = ariaResult.text;
           } catch {}
 
+          // Derive assertion from element info
+          const assertion = deriveAssertion(info, fullLocator);
+
           // Copy to clipboard if setting is enabled
           const copyOnPick = vscode.workspace.getConfiguration('playwright-repl').get('pickLocatorCopyToClipboard', false);
           if (copyOnPick)
             await vscode.env.clipboard.writeText(fullLocator);
 
           if (this._locatorsView)
-            this._locatorsView.showLocator(fullLocator, ariaSnapshot);
+            this._locatorsView.showLocator(fullLocator, ariaSnapshot, assertion);
         }
         this._stop();
       }
@@ -97,4 +107,35 @@ export class Picker {
     this._outputChannel.appendLine('Pick mode ended.');
   }
 
+}
+
+// ─── Assertion derivation ─────────────────────────────────────────────────
+
+function deriveAssertion(
+  info: { tag?: string; text?: string; value?: string; checked?: boolean; attributes?: Record<string, string> },
+  locator: string,
+): string {
+  const tag = info.tag?.toLowerCase() ?? '';
+  const inputType = (info.attributes?.type || '').toLowerCase();
+
+  // Checkbox/radio → checked assertion
+  if (tag === 'input' && (inputType === 'checkbox' || inputType === 'radio') && info.checked !== undefined) {
+    return info.checked
+      ? `await expect(${locator}).toBeChecked();`
+      : `await expect(${locator}).not.toBeChecked();`;
+  }
+
+  // Input/textarea/select → value assertion
+  if ((tag === 'input' || tag === 'textarea' || tag === 'select') && info.value !== undefined) {
+    return `await expect(${locator}).toHaveValue('${info.value.replace(/'/g, "\\'")}');`;
+  }
+
+  // Has text content → text assertion (skip if locator is getByText — redundant)
+  const text = info.text?.trim();
+  if (text && !/\.getByText\(/.test(locator)) {
+    return `await expect(${locator}).toContainText('${text.slice(0, 80).replace(/'/g, "\\'")}');`;
+  }
+
+  // Fallback → visible assertion
+  return `await expect(${locator}).toBeVisible();`;
 }


### PR DESCRIPTION
## Summary
- Derive assertion from picked element info and display in Locator View
- Assertion shown between locator and aria sections
- No extra bridge calls — assertion derived locally from event data
- Rename panel tab from "Locators" to "Locator"

## Assertion priority
1. Checkbox/radio → `toBeChecked()`
2. Input/textarea/select → `toHaveValue()`
3. Has text → `toContainText()`
4. Fallback → `toBeVisible()`

## Files changed
- `picker.ts` — derive assertion from event info, pass to Locators View
- `locatorsView.ts` — accept assertion param, add HTML section, send to webview
- `locatorsView.script.ts` — display assertion in readonly input
- `package.json` — rename container title to "Locator"
- `package.nls.json` — rename view name to "Locator"

Closes #410

🤖 Generated with [Claude Code](https://claude.com/claude-code)