### PR TITLE
feat: add page command to REPL

### DIFF
--- a/packages/vscode/src/repl.ts
+++ b/packages/vscode/src/repl.ts
@@ -270,6 +270,27 @@ export class PlaywrightRepl {
       return;
     }
 
+    // Intercept 'page' — show useful page info instead of raw object
+    if (command.trim() === 'page') {
+      try {
+        const result = await this._browserManager.runCommand('await JSON.stringify({ url: page.url(), title: await page.title(), viewport: await page.evaluate(() => ({ width: document.documentElement.clientWidth, height: document.documentElement.clientHeight, dpr: window.devicePixelRatio })) })');
+        if (result.text && !result.isError) {
+          const info = JSON.parse(result.text);
+          this._write(`URL:      ${info.url}`);
+          this._write(`Title:    ${info.title}`);
+          const vp = info.viewport ? `${info.viewport.width}x${info.viewport.height}` : 'auto';
+          const dpr = info.viewport?.dpr && info.viewport.dpr !== 1 ? ` @${info.viewport.dpr}x` : '';
+          this._write(`Viewport: ${vp}${dpr}`);
+        } else {
+          this._writeEmitter.fire(`${RED}${result.text || 'Could not get page info'}${RESET}\r\n`);
+        }
+      } catch (e: unknown) {
+        this._writeEmitter.fire(`${RED}Error: ${(e as Error).message}${RESET}\r\n`);
+      }
+      this._processing = false;
+      return;
+    }
+
     this._commandCount++;
     const start = Date.now();
     try {

--- a/packages/vscode/src/replView.ts
+++ b/packages/vscode/src/replView.ts
@@ -88,6 +88,31 @@ export class ReplView extends DisposableBase implements vscodeTypes.WebviewViewP
       return;
     }
 
+    // Intercept 'page' — show useful page info instead of raw object
+    if (command.trim() === 'page') {
+      this._setProcessing(true);
+      try {
+        const result = await this._browserManager.runCommand('await JSON.stringify({ url: page.url(), title: await page.title(), viewport: await page.evaluate(() => ({ width: document.documentElement.clientWidth, height: document.documentElement.clientHeight, dpr: window.devicePixelRatio })) })');
+        if (result.text && !result.isError) {
+          const info = JSON.parse(result.text);
+          const vp = info.viewport ? `${info.viewport.width}x${info.viewport.height}` : 'auto';
+          const dpr = info.viewport?.dpr && info.viewport.dpr !== 1 ? ` @${info.viewport.dpr}x` : '';
+          this._appendOutput(
+            `URL:      ${info.url}\n` +
+            `Title:    ${info.title}\n` +
+            `Viewport: ${vp}${dpr}`,
+            'output',
+          );
+        } else {
+          this._appendOutput(result.text || 'Could not get page info', 'error');
+        }
+      } catch (e: unknown) {
+        this._appendOutput(`Error: ${(e as Error).message}`, 'error');
+      }
+      this._setProcessing(false);
+      return;
+    }
+
     this._setProcessing(true);
     this._commandCount++;
     const start = Date.now();


### PR DESCRIPTION
## Summary
- Intercept `page` command in both REPL webview and terminal
- Shows URL, title, and viewport instead of raw Page object dump
- Uses `document.clientWidth/clientHeight` for actual viewport (works with DevTools device emulation)
- Shows DPR when not 1x (e.g., `375x812 @2x`)

## Example
```
> page
URL:      https://www.google.com
Title:    Google
Viewport: 1280x720
```

Closes #428

🤖 Generated with [Claude Code](https://claude.com/claude-code)