### PR TITLE
feat: add Assert Builder panel for building and verifying assertions

### DIFF
--- a/packages/vscode/build.mjs
+++ b/packages/vscode/build.mjs
@@ -15,6 +15,7 @@ const options = {
     'src/settingsView.script.ts',
     'src/locatorsView.script.ts',
     'src/replView.script.ts',
+    'src/assertView.script.ts',
   ],
   bundle: true,
   outdir: 'dist',

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -115,6 +115,11 @@
         "category": "Playwright REPL",
         "command": "playwright-repl.pickLocator",
         "title": "Pick Locator"
+      },
+      {
+        "category": "Playwright REPL",
+        "command": "playwright-repl.assertBuilder",
+        "title": "Assert Builder"
       }
     ],
     "configuration": {
@@ -175,6 +180,11 @@
           "id": "locatorContainer",
           "title": "Locator",
           "icon": "images/playwright-logo.png"
+        },
+        {
+          "id": "assertContainer",
+          "title": "Assert",
+          "icon": "images/playwright-logo.png"
         }
       ]
     },
@@ -198,6 +208,13 @@
           "type": "webview",
           "id": "playwright-repl.locatorsView",
           "name": "%views.test.playwright-repl.locatorsView%"
+        }
+      ],
+      "assertContainer": [
+        {
+          "type": "webview",
+          "id": "playwright-repl.assertView",
+          "name": "Assert"
         }
       ]
     }

--- a/packages/vscode/src/assertView.script.ts
+++ b/packages/vscode/src/assertView.script.ts
@@ -1,0 +1,129 @@
+/**
+ * Assert Builder webview script.
+ */
+
+import { vscode } from './common';
+
+const pickBtn = document.getElementById('pickBtn') as HTMLButtonElement;
+const locatorInput = document.getElementById('locator') as HTMLInputElement;
+const assertType = document.getElementById('assertType') as HTMLSelectElement;
+const negateCheckbox = document.getElementById('negateCheckbox') as HTMLInputElement;
+const argInput = document.getElementById('argInput') as HTMLInputElement;
+const assertionInput = document.getElementById('assertion') as HTMLInputElement;
+const verifyBtn = document.getElementById('verifyBtn') as HTMLButtonElement;
+const verifyResult = document.getElementById('verifyResult')!;
+
+let types: { value: string; label: string; needsArg: boolean; argType?: string }[] = [];
+let currentLocator = '';
+
+// ─── Event handlers ───────────────────────────────────────────────────────
+
+pickBtn.addEventListener('click', () => {
+  vscode.postMessage({ method: 'pick' });
+});
+
+function rebuild() {
+  const typeDef = types.find(t => t.value === assertType.value);
+  argInput.style.display = typeDef?.needsArg ? 'block' : 'none';
+  argInput.placeholder = typeDef?.argType === 'pair' ? 'attribute, value' :
+    typeDef?.argType === 'number' ? 'Count' : 'Expected value';
+  vscode.postMessage({ method: 'rebuild', params: { type: assertType.value, arg: argInput.value, negate: negateCheckbox.checked } });
+}
+
+assertType.addEventListener('change', rebuild);
+argInput.addEventListener('input', rebuild);
+negateCheckbox.addEventListener('change', rebuild);
+
+locatorInput.addEventListener('input', () => {
+  currentLocator = locatorInput.value;
+  vscode.postMessage({ method: 'locatorChanged', params: { locator: locatorInput.value } });
+  rebuild();
+});
+
+verifyBtn.addEventListener('click', () => {
+  vscode.postMessage({ method: 'verify', params: { assertion: assertionInput.value } });
+});
+
+// ─── Messages from extension ──────────────────────────────────────────────
+
+window.addEventListener('message', event => {
+  const { method, params } = event.data;
+
+  if (method === 'init') {
+    populateTypes(params.types);
+  } else if (method === 'update') {
+    currentLocator = params.locator;
+    locatorInput.value = params.locator;
+    assertionInput.value = params.assertion;
+    if (params.types) populateTypes(params.types);
+    // Detect current type from assertion
+    detectType(params.assertion);
+    verifyResult.style.display = 'none';
+  } else if (method === 'assertionUpdated') {
+    assertionInput.value = params.assertion;
+    verifyResult.style.display = 'none';
+  } else if (method === 'verifyProcessing') {
+    verifyBtn.disabled = params.processing;
+    verifyBtn.textContent = params.processing ? 'Verifying...' : 'Verify';
+    if (params.processing) {
+      verifyResult.style.display = 'inline';
+      verifyResult.textContent = '...';
+      verifyResult.style.color = 'var(--vscode-descriptionForeground)';
+    }
+  } else if (method === 'verifyResult') {
+    verifyResult.style.display = 'inline';
+    if (params.passed) {
+      verifyResult.textContent = '✓ Passed';
+      verifyResult.style.color = 'var(--vscode-terminal-ansiGreen)';
+      verifyResult.title = '';
+    } else {
+      const full = (params.error || 'Assertion failed').replace(/^### \w[\w ]*\n/gm, '').trim();
+      const expectedMatch = full.match(/Expected\s*(?:string)?:\s*(.+)/);
+      const receivedMatch = full.match(/Received\s*(?:string)?:\s*(.+)/);
+      const timeoutMatch = full.match(/Timed out (\d+)ms/);
+      let short: string;
+      if (expectedMatch && receivedMatch) {
+        short = `expected: ${expectedMatch[1].trim()}, received: ${receivedMatch[1].trim()}`;
+      } else if (timeoutMatch) {
+        short = `Timed out (${timeoutMatch[1]}ms)`;
+      } else {
+        const msgMatch = full.match(/Error:\s*(.+?)(?:\n|$)/);
+        short = msgMatch ? msgMatch[1].trim() : (full.split('\n')[0] || 'Assertion failed');
+      }
+      if (short.length > 80) short = short.slice(0, 80) + '...';
+      verifyResult.textContent = '✗ ' + short;
+      verifyResult.style.color = 'var(--vscode-terminal-ansiRed)';
+      verifyResult.title = full;
+    }
+  }
+});
+
+// ─── Helpers ──────────────────────────────────────────────────────────────
+
+function populateTypes(t: typeof types) {
+  types = t;
+  assertType.innerHTML = '';
+  for (const type of types) {
+    const opt = document.createElement('option');
+    opt.value = type.value;
+    opt.textContent = type.label;
+    assertType.appendChild(opt);
+  }
+}
+
+function detectType(assertion: string) {
+  for (const type of types) {
+    if (assertion.includes(`.${type.value}(`)) {
+      assertType.value = type.value;
+      const typeDef = types.find(t => t.value === type.value);
+      argInput.style.display = typeDef?.needsArg ? 'block' : 'none';
+      // Extract arg from assertion
+      const argMatch = assertion.match(new RegExp(`\\.${type.value}\\((.*)\\)`));
+      if (argMatch && argMatch[1]) {
+        const cleaned = argMatch[1].replace(/^['"]|['"]$/g, '');
+        argInput.value = cleaned;
+      }
+      return;
+    }
+  }
+}

--- a/packages/vscode/src/assertView.ts
+++ b/packages/vscode/src/assertView.ts
@@ -1,0 +1,306 @@
+/**
+ * Assert Builder — dedicated panel for building and testing Playwright assertions.
+ */
+
+import { DisposableBase } from './disposableBase';
+import { getNonce, html } from './utils';
+import type { BrowserManager } from './browser';
+import type { Picker } from './picker';
+import * as vscodeTypes from './vscodeTypes';
+
+interface AssertionType {
+  value: string;
+  label: string;
+  needsArg: boolean;
+  argType?: string;
+  tags?: string[];  // element tags this applies to, empty = all
+}
+
+const ALL_ASSERTION_TYPES: AssertionType[] = [
+  // Text
+  { value: 'toContainText', label: 'toContainText', needsArg: true, argType: 'string' },
+  { value: 'toHaveText', label: 'toHaveText', needsArg: true, argType: 'string' },
+  // Visibility & state
+  { value: 'toBeVisible', label: 'toBeVisible', needsArg: false },
+  { value: 'toBeHidden', label: 'toBeHidden', needsArg: false },
+  { value: 'toBeAttached', label: 'toBeAttached', needsArg: false },
+  { value: 'toBeEnabled', label: 'toBeEnabled', needsArg: false },
+  { value: 'toBeDisabled', label: 'toBeDisabled', needsArg: false },
+  // Form elements
+  { value: 'toBeChecked', label: 'toBeChecked', needsArg: false, tags: ['input'] },
+  { value: 'toHaveValue', label: 'toHaveValue', needsArg: true, argType: 'string', tags: ['input', 'textarea', 'select'] },
+  // Attributes & count
+  { value: 'toHaveAttribute', label: 'toHaveAttribute', needsArg: true, argType: 'pair' },
+  { value: 'toHaveCount', label: 'toHaveCount', needsArg: true, argType: 'number' },
+  // Page-level (uses expect(page) not expect(locator))
+  { value: 'toHaveURL', label: 'toHaveURL (page)', needsArg: true, argType: 'string' },
+  { value: 'toHaveTitle', label: 'toHaveTitle (page)', needsArg: true, argType: 'string' },
+];
+
+function filterTypes(tag?: string, inputType?: string): AssertionType[] {
+  const t = tag?.toLowerCase();
+  const filtered = ALL_ASSERTION_TYPES.filter(a => {
+    if (!a.tags) return true;
+    if (!t) return true;
+    return a.tags.includes(t);
+  });
+  // For checkbox/radio, prioritize toBeChecked
+  if (t === 'input' && (inputType === 'checkbox' || inputType === 'radio'))
+    return filtered.filter(a => a.value !== 'toHaveValue');
+  return filtered;
+}
+
+export class AssertView extends DisposableBase implements vscodeTypes.WebviewViewProvider {
+  private _vscode: vscodeTypes.VSCode;
+  private _view: vscodeTypes.WebviewView | undefined;
+  private _extensionUri: vscodeTypes.Uri;
+  private _browserManager: BrowserManager | undefined;
+  private _picker: Picker | undefined;
+  private _locator = '';
+  private _assertion = '';
+
+  constructor(vscode: vscodeTypes.VSCode, extensionUri: vscodeTypes.Uri) {
+    super();
+    this._vscode = vscode;
+    this._extensionUri = extensionUri;
+    this._disposables = [
+      vscode.window.registerWebviewViewProvider('playwright-repl.assertView', this, {
+        webviewOptions: { retainContextWhenHidden: true },
+      }),
+    ];
+  }
+
+  setBrowserManager(browserManager: BrowserManager) {
+    this._browserManager = browserManager;
+  }
+
+  setPicker(picker: Picker) {
+    this._picker = picker;
+  }
+
+  /** Called from pick event — fills locator and default assertion */
+  public async showAssertion(locator: string, assertion: string, elementInfo?: { tag?: string; attributes?: Record<string, string> }) {
+    this._locator = locator;
+    this._assertion = assertion;
+    const types = filterTypes(elementInfo?.tag, elementInfo?.attributes?.type);
+    await this._vscode.commands.executeCommand('playwright-repl.assertView.focus');
+    if (!this._view)
+      await new Promise(r => setTimeout(r, 200));
+    void this._view?.webview.postMessage({
+      method: 'update',
+      params: { locator, assertion, types },
+    });
+  }
+
+  resolveWebviewView(webviewView: vscodeTypes.WebviewView) {
+    this._view = webviewView;
+
+    webviewView.webview.options = {
+      enableScripts: true,
+      localResourceRoots: [this._extensionUri],
+    };
+
+    webviewView.webview.html = htmlForWebview(this._vscode, this._extensionUri, webviewView.webview);
+
+    this._disposables.push(webviewView.webview.onDidReceiveMessage(async data => {
+      if (data.method === 'pick') {
+        await this._vscode.commands.executeCommand('playwright-repl.assertBuilder');
+      } else if (data.method === 'verify') {
+        await this._verify(data.params.assertion);
+      } else if (data.method === 'rebuild') {
+        this._rebuildAssertion(data.params.type, data.params.arg, data.params.negate);
+      } else if (data.method === 'locatorChanged') {
+        this._locator = data.params.locator;
+      }
+    }));
+
+    // Send types on init
+    void webviewView.webview.postMessage({
+      method: 'init',
+      params: { types: ALL_ASSERTION_TYPES },
+    });
+  }
+
+  private _rebuildAssertion(type: string, arg?: string, negate?: boolean) {
+    if (!this._locator && !type.startsWith('toHave')) return;
+    const typeDef = ALL_ASSERTION_TYPES.find(t => t.value === type);
+    if (!typeDef) return;
+
+    const not = negate ? 'not.' : '';
+    const isPageLevel = type === 'toHaveURL' || type === 'toHaveTitle';
+    const target = isPageLevel ? 'page' : this._locator;
+    let assertion: string;
+    if (typeDef.argType === 'pair' && arg) {
+      const parts = arg.split(',').map(s => s.trim());
+      assertion = `await expect(${target}).${not}${type}('${parts[0] || ''}', '${parts[1] || ''}');`;
+    } else if (typeDef.needsArg && arg) {
+      const argStr = typeDef.argType === 'number' ? arg : `'${arg.replace(/'/g, "\\'")}'`;
+      assertion = `await expect(${target}).${not}${type}(${argStr});`;
+    } else {
+      assertion = `await expect(${target}).${not}${type}();`;
+    }
+
+    this._assertion = assertion;
+    void this._view?.webview.postMessage({
+      method: 'assertionUpdated',
+      params: { assertion },
+    });
+  }
+
+  private async _verify(assertion: string) {
+    if (!this._browserManager?.isRunning() || !assertion) return;
+    this._assertion = assertion;
+    void this._view?.webview.postMessage({ method: 'verifyProcessing', params: { processing: true } });
+    try {
+      const result = await this._browserManager.runCommand(assertion);
+      const passed = !result.isError;
+      void this._view?.webview.postMessage({
+        method: 'verifyResult',
+        params: { passed, error: passed ? null : result.text },
+      });
+    } catch (e: unknown) {
+      void this._view?.webview.postMessage({
+        method: 'verifyResult',
+        params: { passed: false, error: (e as Error).message },
+      });
+    }
+    void this._view?.webview.postMessage({ method: 'verifyProcessing', params: { processing: false } });
+  }
+}
+
+function htmlForWebview(vscode: vscodeTypes.VSCode, extensionUri: vscodeTypes.Uri, webview: vscodeTypes.Webview) {
+  const style = webview.asWebviewUri(vscode.Uri.joinPath(extensionUri, 'media', 'common.css'));
+  const script = webview.asWebviewUri(vscode.Uri.joinPath(extensionUri, 'dist', 'assertView.script.js'));
+  const nonce = getNonce();
+
+  return html`
+    <!DOCTYPE html>
+    <html lang="en">
+    <head>
+      <meta charset="UTF-8">
+      <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src ${webview.cspSource} 'unsafe-inline'; script-src 'nonce-${nonce}';">
+      <meta name="viewport" content="width=device-width, initial-scale=1.0">
+      <link href="${style}" rel="stylesheet">
+      <title>Assert</title>
+      <style>
+        body.assert-view {
+          user-select: text;
+          padding: 0;
+        }
+        .section {
+          margin: 0 10px 10px;
+          display: flex;
+          flex-direction: column;
+        }
+        .section label {
+          flex: none;
+          margin-bottom: 2px;
+        }
+        .hbox {
+          display: flex;
+          align-items: center;
+        }
+        .icon-btn {
+          cursor: pointer;
+          background: none;
+          border: none;
+          padding: 2px;
+          display: flex;
+          align-items: center;
+          border-radius: 3px;
+        }
+        .icon-btn:hover {
+          background: var(--vscode-toolbar-hoverBackground);
+        }
+        .icon-btn svg {
+          width: 16px;
+          height: 16px;
+          fill: var(--vscode-editor-foreground);
+        }
+        .inline-btn {
+          cursor: pointer;
+          background: var(--vscode-button-secondaryBackground);
+          color: var(--vscode-button-secondaryForeground);
+          border: none;
+          padding: 2px 10px;
+          border-radius: 2px;
+          font-size: 13px;
+        }
+        .inline-btn:hover {
+          background: var(--vscode-button-secondaryHoverBackground);
+        }
+        .inline-btn:disabled {
+          opacity: 0.5;
+          cursor: default;
+        }
+        select {
+          background: var(--vscode-dropdown-background, var(--vscode-input-background));
+          color: var(--vscode-dropdown-foreground, var(--vscode-input-foreground));
+          border: 1px solid var(--vscode-dropdown-border, var(--vscode-focusBorder, #007acc)) !important;
+          border-radius: 3px;
+          padding: 4px 24px 4px 8px;
+          font-size: 13px;
+          font-weight: 600;
+          cursor: pointer;
+          appearance: auto;
+          flex: none;
+          height: auto !important;
+        }
+        #argInput {
+          margin-top: 4px;
+        }
+        .step-num {
+          display: inline-flex;
+          align-items: center;
+          justify-content: center;
+          width: 18px;
+          height: 18px;
+          border-radius: 50%;
+          background: var(--vscode-badge-background);
+          color: var(--vscode-badge-foreground);
+          font-size: 11px;
+          font-weight: bold;
+          flex: none;
+          margin-right: 6px;
+        }
+      </style>
+    </head>
+    <body class="assert-view">
+      <div class="section">
+        <div class="hbox">
+          <span class="step-num">1</span>
+          <button id="pickBtn" title="Pick element" class="icon-btn"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48"><path d="M18 42h-7.5c-3 0-4.5-1.5-4.5-4.5v-27C6 7.5 7.5 6 10.5 6h27C42 6 42 10.404 42 10.5V18h-3V9H9v30h9v3Zm27-15-9 6 9 9-3 3-9-9-6 9-6-24 24 6Z"/></svg></button>
+          <label>Pick Locator</label>
+        </div>
+        <input id="locator" placeholder="Pick an element or type a locator" aria-label="Locator">
+      </div>
+      <div class="section">
+        <div class="hbox">
+          <span class="step-num">2</span>
+          <label>Select Matcher</label>
+        </div>
+        <div class="hbox" style="gap:6px;margin-top:2px;">
+          <select id="assertType" style="min-width:200px;"></select>
+          <label style="flex:none;font-size:12px;cursor:pointer;display:flex;align-items:center;gap:3px;margin-left:8px;">
+            not
+            <input id="negateCheckbox" type="checkbox">
+          </label>
+        </div>
+        <input id="argInput" placeholder="Expected value" aria-label="Expected value" style="display:none;">
+      </div>
+      <div class="section">
+        <div class="hbox">
+          <span class="step-num">3</span>
+          <label>Verify</label>
+        </div>
+        <input id="assertion" placeholder="Assertion will appear here" aria-label="Assertion">
+        <div class="hbox" style="margin-top:4px;align-items:center;">
+          <button id="verifyBtn" class="inline-btn">Verify</button>
+          <span id="verifyResult" style="font-size:13px;margin-left:6px;display:none;"></span>
+        </div>
+      </div>
+    </body>
+    <script nonce="${nonce}" src="${script}"></script>
+    </html>
+  `;
+}

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -40,6 +40,7 @@ import { Picker } from './picker';
 import { createRequire } from 'node:module';
 import { PlaywrightRepl } from './repl';
 import { ReplView } from './replView';
+import { AssertView } from './assertView';
 
 const stackUtils = new StackUtils({
   cwd: '/ensure_absolute_paths'
@@ -97,6 +98,7 @@ export class Extension implements RunHooks {
   // Playwright REPL: bridge-based features
   private _browserManager?: BrowserManager;
   private _replView!: ReplView;
+  private _assertView!: AssertView;
   private _recorder?: Recorder;
   private _picker?: Picker;
   private _repl?: PlaywrightRepl;
@@ -223,6 +225,16 @@ export class Extension implements RunHooks {
       this._replView.setBrowserManager(this._browserManager);
     if (this._locatorsView)
       this._locatorsView.setBrowserManager(this._browserManager);
+    if (this._assertView)
+      this._assertView.setBrowserManager(this._browserManager);
+  }
+
+  private _ensurePicker() {
+    if (this._picker || !this._browserManager) return;
+    this._picker = new Picker(this._browserManager, this._logger);
+    this._picker.setLocatorsView(this._locatorsView);
+    this._picker.setAssertView(this._assertView);
+    this._assertView.setPicker(this._picker);
   }
 
   reusedBrowserForTest(): ReusedBrowser {
@@ -239,6 +251,7 @@ export class Extension implements RunHooks {
     this._settingsView = new SettingsView(vscode, this._settingsModel, this._models, this._reusedBrowser, this._context.extensionUri);
     this._locatorsView = new LocatorsView(vscode, this._settingsModel, this._reusedBrowser, this._context.extensionUri);
     this._replView = new ReplView(vscode, this._context.extensionUri);
+    this._assertView = new AssertView(vscode, this._context.extensionUri);
     this._repl = new PlaywrightRepl();
     this._repl.show();
     const messageNoPlaywrightTestsFound = this._vscode.l10n.t('No Playwright tests found.');
@@ -344,6 +357,7 @@ export class Extension implements RunHooks {
       this._settingsView,
       this._locatorsView,
       this._replView,
+      this._assertView,
       this._testController,
       this._runProfile,
       this._debugProfile,
@@ -392,17 +406,31 @@ export class Extension implements RunHooks {
             vscode.window.showWarningMessage('Launch browser first.');
             return;
           }
-          if (!this._picker) {
-            this._picker = new Picker(this._browserManager, this._logger);
-            this._picker.setLocatorsView(this._locatorsView);
-          }
-          if (this._picker.isPicking)
-            await this._picker.stop();
+          this._ensurePicker();
+          if (this._picker!.isPicking)
+            await this._picker!.stop();
           else
-            await this._picker.start();
+            await this._picker!.start();
         } catch (e: unknown) {
           this._logger.error('Pick locator error:', (e as Error).message);
           vscode.window.showErrorMessage(`Pick locator failed: ${(e as Error).message}`);
+        }
+      }),
+
+      vscode.commands.registerCommand('playwright-repl.assertBuilder', async () => {
+        try {
+          await this._ensureBrowserManager();
+          if (!this._browserManager?.isRunning()) {
+            vscode.window.showWarningMessage('Could not launch browser.');
+            return;
+          }
+          this._ensurePicker();
+          // Focus Assert panel and start pick (sends result to Assert view)
+          await this._vscode.commands.executeCommand('playwright-repl.assertView.focus');
+          if (!this._picker!.isPicking)
+            await this._picker!.startForAssert();
+        } catch (e: unknown) {
+          this._logger.error('Assert builder error:', (e as Error).message);
         }
       }),
     ];

--- a/packages/vscode/src/locatorsView.script.ts
+++ b/packages/vscode/src/locatorsView.script.ts
@@ -19,9 +19,7 @@ import { createAction, vscode } from './common';
 // @ts-check
 const pickBtn = document.getElementById('pickBtn') as HTMLButtonElement;
 const locatorInput = document.getElementById('locator') as HTMLInputElement;
-const assertionInput = document.getElementById('assertion') as HTMLInputElement;
 const highlightSwitch = document.getElementById('highlightSwitch') as HTMLInputElement;
-const verifyBtn = document.getElementById('verifyBtn') as HTMLButtonElement;
 const ariaTextArea = document.getElementById('ariaSnapshot') as HTMLTextAreaElement;
 
 locatorInput.addEventListener('input', () => {
@@ -32,20 +30,12 @@ ariaTextArea.addEventListener('input', () => {
   vscode.postMessage({ method: 'ariaSnapshotChanged', params: { ariaSnapshot: ariaTextArea.value } });
 });
 
-assertionInput.addEventListener('input', () => {
-  vscode.postMessage({ method: 'assertionChanged', params: { assertion: assertionInput.value } });
-});
-
 pickBtn.addEventListener('click', () => {
   vscode.postMessage({ method: 'execute', params: { command: 'playwright-repl.pickLocator' } });
 });
 
 highlightSwitch.addEventListener('change', () => {
   vscode.postMessage({ method: 'highlight' });
-});
-
-verifyBtn.addEventListener('click', () => {
-  vscode.postMessage({ method: 'verify' });
 });
 
 window.addEventListener('message', event => {
@@ -60,11 +50,6 @@ window.addEventListener('message', event => {
     locatorInput.value = params.locator.locator;
     locatorError.textContent = params.locator.error || '';
     locatorError.style.display = params.locator.error ? 'inherit' : 'none';
-    assertionInput.value = params.assertion || '';
-    const assertionSection = document.getElementById('assertionSection')!;
-    assertionSection.style.display = params.assertion ? 'flex' : 'none';
-    const verifyResult = document.getElementById('verifyResult')!;
-    verifyResult.style.display = 'none';
     ariaTextArea.value = params.ariaSnapshot.yaml;
     ariaSnapshotError.textContent = params.ariaSnapshot.error || '';
     ariaSnapshotError.style.display = params.ariaSnapshot.error ? 'inherit' : 'none';
@@ -79,44 +64,5 @@ window.addEventListener('message', event => {
     }
   } else if (method === 'highlightState') {
     highlightSwitch.checked = params.active;
-  } else if (method === 'verifyProcessing') {
-    verifyBtn.disabled = params.processing;
-    verifyBtn.textContent = params.processing ? 'Verifying...' : 'Verify';
-    const verifyResult = document.getElementById('verifyResult')!;
-    if (params.processing) {
-      verifyResult.style.display = 'inline';
-      verifyResult.textContent = '...';
-      verifyResult.style.color = 'var(--vscode-descriptionForeground)';
-    }
-  } else if (method === 'verifyResult') {
-    const verifyResult = document.getElementById('verifyResult')!;
-    verifyResult.style.display = 'inline';
-    verifyResult.style.userSelect = 'text';
-    if (params.passed) {
-      verifyResult.textContent = '✓ Passed';
-      verifyResult.style.color = 'var(--vscode-terminal-ansiGreen)';
-      verifyResult.title = '';
-    } else {
-      const full = (params.error || 'Assertion failed').replace(/^### \w[\w ]*\n/gm, '').trim();
-      // Extract Expected/Received — handles both "Expected: x" and "Expected string: x"
-      const expectedMatch = full.match(/Expected\s*(?:string)?:\s*(.+)/);
-      const receivedMatch = full.match(/Received\s*(?:string)?:\s*(.+)/);
-      const timeoutMatch = full.match(/Timed out (\d+)ms/);
-      let short: string;
-      if (expectedMatch && receivedMatch) {
-        short = `expected: ${expectedMatch[1].trim()}, received: ${receivedMatch[1].trim()}`;
-      } else if (timeoutMatch && expectedMatch) {
-        short = `Timed out (${timeoutMatch[1]}ms), expected: ${expectedMatch[1].trim()}`;
-      } else if (timeoutMatch) {
-        short = `Timed out (${timeoutMatch[1]}ms)`;
-      } else {
-        const msgMatch = full.match(/Error:\s*(.+?)(?:\n|$)/);
-        short = msgMatch ? msgMatch[1].trim() : (full.split('\n')[0] || 'Assertion failed');
-      }
-      if (short.length > 80) short = short.slice(0, 80) + '...';
-      verifyResult.textContent = '✗ ' + short;
-      verifyResult.style.color = 'var(--vscode-terminal-ansiRed)';
-      verifyResult.title = full;
-    }
   }
 });

--- a/packages/vscode/src/locatorsView.ts
+++ b/packages/vscode/src/locatorsView.ts
@@ -26,7 +26,6 @@ export class LocatorsView extends DisposableBase implements vscodeTypes.WebviewV
   private _view: vscodeTypes.WebviewView | undefined;
   private _extensionUri: vscodeTypes.Uri;
   private _locator: { locator: string, error?: string } = { locator: '' };
-  private _assertion: string = '';
   private _ariaSnapshot: { yaml: string, error?: string } = { yaml: '' };
   private _settingsModel: SettingsModel;
   private _reusedBrowser: ReusedBrowser;
@@ -59,9 +58,8 @@ export class LocatorsView extends DisposableBase implements vscodeTypes.WebviewV
   }
 
   /** Allow external callers (e.g. our bridge picker) to show a locator. */
-  public async showLocator(locator: string, ariaSnapshot?: string, assertion?: string) {
+  public async showLocator(locator: string, ariaSnapshot?: string) {
     this._locator = { locator };
-    this._assertion = assertion || '';
     this._ariaSnapshot = { yaml: ariaSnapshot || '' };
     this._highlighted = false;
     // Focus first so the webview is resolved before we send the update
@@ -102,14 +100,10 @@ export class LocatorsView extends DisposableBase implements vscodeTypes.WebviewV
           this._ariaSnapshot.error = e.message;
           this._updateValues();
         });
-      } else if (data.method === 'assertionChanged') {
-        this._assertion = data.params.assertion;
       } else if (data.method === 'toggle') {
         void this._vscode.commands.executeCommand(`playwright-repl.toggle.${data.params.setting}`);
       } else if (data.method === 'highlight') {
         this._highlight();
-      } else if (data.method === 'verify') {
-        this._verify();
       }
     }));
 
@@ -141,25 +135,6 @@ export class LocatorsView extends DisposableBase implements vscodeTypes.WebviewV
     } catch {}
   }
 
-  private async _verify() {
-    if (!this._browserManager?.isRunning() || !this._assertion) return;
-    void this._view?.webview.postMessage({ method: 'verifyProcessing', params: { processing: true } });
-    try {
-      const result = await this._browserManager.runCommand(this._assertion);
-      const passed = !result.isError;
-      void this._view?.webview.postMessage({
-        method: 'verifyResult',
-        params: { passed, error: passed ? null : result.text }
-      });
-    } catch (e: unknown) {
-      void this._view?.webview.postMessage({
-        method: 'verifyResult',
-        params: { passed: false, error: (e as Error).message }
-      });
-    }
-    void this._view?.webview.postMessage({ method: 'verifyProcessing', params: { processing: false } });
-  }
-
   private _updateActions() {
     const actions = [
       pickElementAction(this._vscode),
@@ -173,7 +148,6 @@ export class LocatorsView extends DisposableBase implements vscodeTypes.WebviewV
       method: 'update',
       params: {
         locator: this._locator,
-        assertion: this._assertion,
         ariaSnapshot: this._ariaSnapshot,
         hideAria: this._backendVersion && this._backendVersion < 1.50
       }
@@ -264,16 +238,6 @@ function htmlForWebview(vscode: vscodeTypes.VSCode, extensionUri: vscodeTypes.Ur
         </div>
         <input id="locator" placeholder="${vscode.l10n.t('Locator')}" aria-labelledby="locatorLabel">
         <p id="locatorError" class="error"></p>
-      </div>
-      <div id="assertionSection" class="section">
-        <div class="hbox">
-          <label>Assert</label>
-        </div>
-        <input id="assertion" placeholder="Pick an element to see assertion" aria-label="Assertion">
-        <div class="hbox" style="margin-top:4px;align-items:center;">
-          <button id="verifyBtn" title="Run assertion" class="inline-btn" style="margin-left:0;">Verify</button>
-          <span id="verifyResult" style="font-size:13px;margin-left:6px;display:none;"></span>
-        </div>
       </div>
       <div id="ariaSection" class="section">
         <div class="hbox">

--- a/packages/vscode/src/picker.ts
+++ b/packages/vscode/src/picker.ts
@@ -11,12 +11,15 @@
 import * as vscode from 'vscode';
 import type { BrowserManager } from './browser.js';
 import type { LocatorsView } from './locatorsView';
+import type { AssertView } from './assertView';
 
 export class Picker {
   private _browserManager: BrowserManager;
   private _outputChannel: vscode.OutputChannel;
   private _locatorsView: LocatorsView | undefined;
+  private _assertView: AssertView | undefined;
   private _picking = false;
+  private _sendToAssert = false;
 
   constructor(browserManager: BrowserManager, outputChannel: vscode.OutputChannel) {
     this._browserManager = browserManager;
@@ -27,6 +30,16 @@ export class Picker {
 
   setLocatorsView(view: LocatorsView) {
     this._locatorsView = view;
+  }
+
+  setAssertView(view: AssertView) {
+    this._assertView = view;
+  }
+
+  /** Start pick and send result to Assert Builder */
+  async startForAssert() {
+    this._sendToAssert = true;
+    await this.start();
   }
 
   dispose() {
@@ -84,7 +97,10 @@ export class Picker {
             await vscode.env.clipboard.writeText(fullLocator);
 
           if (this._locatorsView)
-            this._locatorsView.showLocator(fullLocator, ariaSnapshot, assertion);
+            this._locatorsView.showLocator(fullLocator, ariaSnapshot);
+          if (this._assertView && this._sendToAssert)
+            this._assertView.showAssertion(fullLocator, assertion, info);
+          this._sendToAssert = false;
         }
         this._stop();
       }

--- a/packages/vscode/src/settingsView.ts
+++ b/packages/vscode/src/settingsView.ts
@@ -125,6 +125,7 @@ export class SettingsView extends DisposableBase implements vscodeTypes.WebviewV
     const actions = [
       pickElementAction(this._vscode),
       this._isRecording ? stopRecordingAction(this._vscode) : recordNewAction(this._vscode, this._reusedBrowser),
+      assertBuilderAction(this._vscode),
       revealTestOutputAction(this._vscode),
       closeBrowsersAction(this._vscode, this._reusedBrowser),
       {
@@ -306,6 +307,14 @@ export const pickElementAction = (vscode: vscodeTypes.VSCode) => {
     command: 'playwright-repl.pickLocator',
     svg: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48"><path d="M18 42h-7.5c-3 0-4.5-1.5-4.5-4.5v-27C6 7.5 7.5 6 10.5 6h27C42 6 42 10.404 42 10.5V18h-3V9H9v30h9v3Zm27-15-9 6 9 9-3 3-9-9-6 9-6-24 24 6Z"/></svg>`,
     text: vscode.l10n.t('Pick locator'),
+  };
+};
+
+export const assertBuilderAction = (vscode: vscodeTypes.VSCode) => {
+  return {
+    command: 'playwright-repl.assertBuilder',
+    svg: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48"><path d="M21.05 33.1 35.2 18.95l-2.3-2.25-11.85 11.85-6-6-2.25 2.25ZM24 44q-4.1 0-7.75-1.575-3.65-1.575-6.375-4.3-2.725-2.725-4.3-6.375Q4 28.1 4 24q0-4.15 1.575-7.8 1.575-3.65 4.3-6.35 2.725-2.7 6.375-4.275Q19.9 4 24 4q4.15 0 7.8 1.575 3.65 1.575 6.35 4.275 2.7 2.7 4.275 6.35Q44 19.85 44 24q0 4.1-1.575 7.75-1.575 3.65-4.275 6.375t-6.35 4.3Q28.15 44 24 44Z"/></svg>`,
+    text: vscode.l10n.t('Assert'),
   };
 };
 


### PR DESCRIPTION
## Summary
Dedicated Assert panel for interactively building and verifying Playwright assertions.

### Three-step workflow
```
① Pick Locator  [↗]
[page.getByRole('button', { name: 'Submit' })     ]

② Select Matcher
[toContainText          ▼]              not ☐
[Submit                                            ]

③ Verify
[await expect(page.getByRole('button')).toContainText('Submit')]
[Verify] ✓ Passed
```

### Features
- **13 matchers**: toContainText, toHaveText, toBeVisible, toBeHidden, toBeAttached, toBeEnabled, toBeDisabled, toBeChecked, toHaveValue, toHaveAttribute, toHaveCount, toHaveURL (page), toHaveTitle (page)
- **Smart filtering**: dropdown filtered by picked element type (checkbox → toBeChecked, input → toHaveValue)
- **"not" toggle**: negation checkbox for `.not.toBeVisible()` etc.
- **Assert button** in Testing sidebar (after Record)
- **Pick arrow** in Assert tab triggers assert-aware pick
- **Separation of concerns**: Locator tab for inspection, Assert tab for testing

### Also
- Remove assertion section from Locator View (moved to Assert)
- Clean up locatorsView.script.ts

Closes #433

🤖 Generated with [Claude Code](https://claude.com/claude-code)