### PR TITLE
feat: support options object and conditional skip/fixme in shim

### DIFF
--- a/packages/extension/src/test-framework.ts
+++ b/packages/extension/src/test-framework.ts
@@ -47,18 +47,21 @@ function resetState() {
 
 // ─── Registration API ──────────────────────────────────────────────────────
 
-function test(name: string, fn: TestFn) {
+function test(name: string, fnOrOpts: TestFn | Record<string, unknown>, maybeFn?: TestFn) {
+  const fn = typeof fnOrOpts === 'function' ? fnOrOpts : maybeFn!;
   currentSuite.tests.push({ name, fn, only: false, skip: false });
 }
 
-test.only = (name: string, fn: TestFn) => {
+test.only = (name: string, fnOrOpts: TestFn | Record<string, unknown>, maybeFn?: TestFn) => {
+  const fn = typeof fnOrOpts === 'function' ? fnOrOpts : maybeFn!;
   hasOnly = true;
   currentSuite.tests.push({ name, fn, only: true, skip: false });
 };
 
 class SkipError extends Error { constructor() { super('SKIP'); this.name = 'SkipError'; } }
-test.skip = (nameOrCond: any, fn?: any) => {
+test.skip = (nameOrCond: any, fnOrOpts?: any, maybeFn?: any) => {
   if (typeof nameOrCond === 'string') {
+    const fn = typeof fnOrOpts === 'function' ? fnOrOpts : maybeFn;
     currentSuite.tests.push({ name: nameOrCond, fn, only: false, skip: true });
   } else if (nameOrCond) {
     throw new SkipError();
@@ -90,7 +93,8 @@ test.beforeEach = (fn: HookFn) => { currentSuite.beforeEach.push(fn); };
 test.afterEach = (fn: HookFn) => { currentSuite.afterEach.push(fn); };
 
 test.extend = (fixtures: Record<string, any>) => {
-  const extendedTest = (name: string, fn: TestFn) => {
+  const extendedTest = (name: string, fnOrOpts: TestFn | Record<string, unknown>, maybeFn?: TestFn) => {
+    const fn = typeof fnOrOpts === 'function' ? fnOrOpts : maybeFn!;
     currentSuite.tests.push({
       name, only: false, skip: false,
       fn: async (baseFixtures: any) => {

--- a/packages/runner/examples/todomvc/shim-features/shim-features.spec.ts
+++ b/packages/runner/examples/todomvc/shim-features/shim-features.spec.ts
@@ -1,0 +1,41 @@
+/**
+ * Tests for shim features: conditional skip/fixme, options object form.
+ * These run in bridge mode to verify the shim handles these patterns.
+ */
+
+import { test, expect } from '../fixtures';
+
+test.describe('Shim Features', () => {
+
+  // Options object as second argument
+  test('options object form', {
+    annotation: { type: 'feature', description: 'Test options object support' },
+  }, async ({ page }) => {
+    await expect(page.getByRole('textbox', { name: 'What needs to be done?' })).toBeVisible();
+  });
+
+  // Conditional skip — false condition, test should RUN
+  test('conditional skip (false — should run)', async ({ page }) => {
+    test.skip(false);
+    await expect(page.getByRole('textbox', { name: 'What needs to be done?' })).toBeVisible();
+  });
+
+  // Conditional skip — true condition, test should be SKIPPED
+  test('conditional skip (true — should skip)', async ({ page }) => {
+    test.skip(true, 'Skipping for test');
+    await expect(page.getByText('This should not run')).toBeVisible();
+  });
+
+  // Conditional fixme — false condition, test should RUN
+  test('conditional fixme (false — should run)', async ({ page }) => {
+    test.fixme(false);
+    await expect(page.getByRole('textbox', { name: 'What needs to be done?' })).toBeVisible();
+  });
+
+  // Conditional fixme — true condition, test should be SKIPPED
+  test('conditional fixme (true — should skip)', async ({ page }) => {
+    test.fixme(true, 'Known issue');
+    await expect(page.getByText('This should not run')).toBeVisible();
+  });
+
+});

--- a/packages/runner/src/shim/framework.ts
+++ b/packages/runner/src/shim/framework.ts
@@ -58,17 +58,20 @@ function resetState() {
 
 // ─── Registration API ──────────────────────────────────────────────────────
 
-function test(name: string, fn: TestFn) {
+function test(name: string, fnOrOpts: TestFn | Record<string, unknown>, maybeFn?: TestFn) {
+  const fn = typeof fnOrOpts === 'function' ? fnOrOpts : maybeFn!;
   currentSuite.tests.push({ name, fn, only: false, skip: false });
 }
 
-test.only = (name: string, fn: TestFn) => {
+test.only = (name: string, fnOrOpts: TestFn | Record<string, unknown>, maybeFn?: TestFn) => {
+  const fn = typeof fnOrOpts === 'function' ? fnOrOpts : maybeFn!;
   hasOnly = true;
   currentSuite.tests.push({ name, fn, only: true, skip: false });
 };
 
-test.skip = (nameOrCond: any, fn?: any) => {
+test.skip = (nameOrCond: any, fnOrOpts?: any, maybeFn?: any) => {
   if (typeof nameOrCond === 'string') {
+    const fn = typeof fnOrOpts === 'function' ? fnOrOpts : maybeFn;
     currentSuite.tests.push({ name: nameOrCond, fn, only: false, skip: true });
   } else if (nameOrCond) {
     throw new SkipError(); // conditional form inside test body
@@ -103,7 +106,8 @@ test.beforeEach = (fn: HookFn) => { currentSuite.beforeEach.push(fn); };
 test.afterEach = (fn: HookFn) => { currentSuite.afterEach.push(fn); };
 
 test.extend = (fixtures: Record<string, any>) => {
-  const extendedTest = (name: string, fn: TestFn) => {
+  const extendedTest = (name: string, fnOrOpts: TestFn | Record<string, unknown>, maybeFn?: TestFn) => {
+    const fn = typeof fnOrOpts === 'function' ? fnOrOpts : maybeFn!;
     currentSuite.tests.push({
       name, only: false, skip: false,
       fn: async (baseFixtures: any) => {
@@ -240,6 +244,7 @@ export function installFramework() {
   _g.__runTests = __runTests;
   _g.__resetTestState = resetState;
   _g.__setGrep = (pattern: string | null) => { grepPattern = pattern ? new RegExp(pattern, 'i') : null; };
+  _g.__setGrepExact = (pattern: string | null) => { grepPattern = pattern ? new RegExp(pattern) : null; };
   _g.__setTimeout = (ms: number) => { testTimeout = ms; };
   resetState();
 }


### PR DESCRIPTION
## Summary
Support two Playwright test patterns in the bridge-mode shim:

### 1. Options object as second argument
```ts
test('name', { annotation: { type: 'issue' } }, async ({ page }) => { ... });
```

### 2. Conditional skip/fixme (already worked, confirmed with tests)
```ts
test('name', async ({ page }) => {
  test.skip(true, 'reason');   // skips
  test.fixme(true, 'reason');  // skips
});
```

### Changes
- `extension/src/test-framework.ts` — bridge mode (Chrome extension)
- `runner/src/shim/framework.ts` — standalone mode
- Both `test()`, `test.only()`, `test.skip()`, and `test.extend()` accept `(name, opts, fn)`
- Added `__setGrepExact` to runner's framework
- Test: `shim-features.spec.ts` — 3 passed, 2 skipped

Closes #355

🤖 Generated with [Claude Code](https://claude.com/claude-code)