### PR TITLE
feat: add REPL console panel in Chrome DevTools

### DIFF
--- a/packages/extension/README.md
+++ b/packages/extension/README.md
@@ -19,6 +19,7 @@ Chrome side panel extension that runs the full Playwright API directly inside yo
 | ⚙️ **Preferences** | Default language mode (`.pw` or JS), bridge port, and open mode — configurable in Options |
 | 🌗 **Light / Dark Mode** | Toggle between light and dark themes from the toolbar, persisted across sessions |
 | 🪟 **Side Panel & Popup** | Opens as a Chrome side panel by default; switch to a standalone popup window in Options |
+| 🔧 **DevTools REPL** | Console-only REPL tab in Chrome DevTools — always available alongside Elements/Network for quick debugging |
 | ⚡ **Fast** | Commands execute directly via CDP in the service worker — no Node.js roundtrip, near-instant response |
 
 ## Setup

--- a/packages/extension/public/manifest.json
+++ b/packages/extension/public/manifest.json
@@ -29,6 +29,7 @@
       "128": "icons/dramaturg_icon_128.png"
     }
   },
+  "devtools_page": "devtools/devtools.html",
   "side_panel": {
     "default_path": "panel/panel.html"
   },

--- a/packages/extension/src/devtools/console.html
+++ b/packages/extension/src/devtools/console.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>REPL</title>
+</head>
+<body>
+  <div id="root"></div>
+  <script type="module" src="console.tsx"></script>
+</body>
+</html>

--- a/packages/extension/src/devtools/console.tsx
+++ b/packages/extension/src/devtools/console.tsx
@@ -1,0 +1,40 @@
+/**
+ * DevTools REPL Console — mounts the Console component in a DevTools panel.
+ */
+import '../panel/panel.css';
+import { createRoot } from 'react-dom/client';
+import { useReducer, useEffect } from 'react';
+import { panelReducer, initialState } from '../panel/reducer';
+import { attachToTab } from '../panel/lib/bridge';
+import { Console } from '../panel/components/Console';
+import { onConsoleEvent } from '../panel/lib/sw-debugger';
+
+function DevToolsConsole() {
+  const [state, dispatch] = useReducer(panelReducer, initialState);
+
+  // Auto-attach to the inspected tab
+  useEffect(() => {
+    if (chrome.devtools?.inspectedWindow) {
+      const tabId = chrome.devtools.inspectedWindow.tabId;
+      attachToTab(tabId).then(res => {
+        if (res.ok && res.url)
+          dispatch({ type: 'ATTACH_SUCCESS', url: res.url, tabId });
+      }).catch(() => {});
+    }
+  }, []);
+
+  // Forward console.log/error from the page
+  useEffect(() => {
+    onConsoleEvent((level, args) => {
+      for (const arg of args) {
+        const type = level === 'error' ? 'error' : level === 'warn' ? 'info' : 'success';
+        dispatch({ type: 'ADD_LINE', line: { text: '', type, value: arg } });
+      }
+    });
+    return () => onConsoleEvent(null);
+  }, [dispatch]);
+
+  return <Console outputLines={state.outputLines} dispatch={dispatch} />;
+}
+
+createRoot(document.getElementById('root')!).render(<DevToolsConsole />);

--- a/packages/extension/src/devtools/devtools.html
+++ b/packages/extension/src/devtools/devtools.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html>
+<head><meta charset="UTF-8"></head>
+<body>
+  <script src="devtools.ts" type="module"></script>
+</body>
+</html>

--- a/packages/extension/src/devtools/devtools.ts
+++ b/packages/extension/src/devtools/devtools.ts
@@ -1,0 +1,8 @@
+/**
+ * DevTools entry point — creates a "REPL" panel in Chrome DevTools.
+ */
+chrome.devtools.panels.create(
+  'REPL',
+  'icons/dramaturg_icon_16.png',
+  'devtools/console.html',
+);

--- a/packages/extension/vite.config.ts
+++ b/packages/extension/vite.config.ts
@@ -58,6 +58,8 @@ export default defineConfig({
         "panel/panel": resolve(__dirname, "src/panel/panel.html"),
         "preferences/preferences": resolve(__dirname, "src/preferences/preferences.html"),
         "offscreen/offscreen": resolve(__dirname, "src/offscreen/offscreen.html"),
+        "devtools/devtools": resolve(__dirname, "src/devtools/devtools.html"),
+        "devtools/console": resolve(__dirname, "src/devtools/console.html"),
       },
       output: {
         entryFileNames: "[name].js",

--- a/packages/vscode/src/browser.ts
+++ b/packages/vscode/src/browser.ts
@@ -67,7 +67,16 @@ export class BrowserManager {
       ),
     );
 
-    this._browserContext = await pw.chromium.launchPersistentContext('', {
+    // Create user data dir with DevTools prefs (dock to bottom)
+    const os = await import('node:os');
+    const userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pw-repl-'));
+    const defaultDir = path.join(userDataDir, 'Default');
+    fs.mkdirSync(defaultDir, { recursive: true });
+    fs.writeFileSync(path.join(defaultDir, 'Preferences'), JSON.stringify({
+      devtools: { preferences: { currentDockState: '"bottom"' } },
+    }));
+
+    this._browserContext = await pw.chromium.launchPersistentContext(userDataDir, {
       channel: 'chromium',
       headless,
       args: [
@@ -77,6 +86,7 @@ export class BrowserManager {
         '--no-default-browser-check',
         '--disable-background-timer-throttling',
         '--disable-infobars',
+        '--auto-open-devtools-for-tabs',
         '--remote-debugging-port=9222',
       ],
       env: cleanEnv,


### PR DESCRIPTION
## Summary
Add a "REPL" tab in Chrome DevTools for running Playwright commands while debugging.

- Opens automatically when DevTools opens (no setup needed)
- Same Console component as the side panel (CodeMirror input, object tree, snapshots)
- Auto-attaches to the inspected tab
- Auto-opens DevTools on VS Code browser launch

## Files
- `devtools/devtools.html` + `devtools.ts` — bootstrap, creates the panel
- `devtools/console.html` + `console.tsx` — React app mounting Console component
- `manifest.json` — added `devtools_page`
- `vite.config.ts` — added devtools entry points
- `browser.ts` — added `--auto-open-devtools-for-tabs` launch flag

Closes #414

🤖 Generated with [Claude Code](https://claude.com/claude-code)