### PR TITLE
refactor: extract shared sw-debugger-core for background.ts and panel

### DIFF
--- a/packages/extension/src/background.ts
+++ b/packages/extension/src/background.ts
@@ -207,36 +207,7 @@ async function stopPicking(): Promise<{ ok: boolean }> {
 
 // ─── Bridge Command Execution ────────────────────────────────────────────────
 
-// ─── Self-debug eval (chrome.debugger → own SW target, bypasses MV3 CSP) ────
-
-let selfTargetId: string | null = null;
-
-async function ensureSelfAttached(): Promise<string> {
-  const swUrl = `chrome-extension://${chrome.runtime.id}/background.js`;
-  const targets = await new Promise<chrome.debugger.TargetInfo[]>(resolve =>
-    chrome.debugger.getTargets(resolve)
-  );
-  const sw = targets.find(t => t.type === 'worker' && t.url === swUrl);
-  if (!sw) throw new Error('Background worker target not found.');
-  if (selfTargetId === sw.id) return sw.id;
-  await new Promise<void>((resolve, reject) => {
-    chrome.debugger.attach({ targetId: sw.id }, '1.3', () => {
-      if (chrome.runtime.lastError) {
-        if (/already attached/i.test(chrome.runtime.lastError.message ?? '')) {
-          selfTargetId = sw.id; resolve();
-        } else reject(new Error(chrome.runtime.lastError.message));
-      } else {
-        chrome.debugger.sendCommand({ targetId: sw.id }, 'Runtime.enable', {}, () => {});
-        selfTargetId = sw.id; resolve();
-      }
-    });
-  });
-  return sw.id;
-}
-
-chrome.debugger.onDetach.addListener((source) => {
-  if (source.targetId === selfTargetId) selfTargetId = null;
-});
+import { cdpEval, cdpCallFunctionOn } from './lib/sw-debugger-core';
 
 /** Format a CDP ObjectPreview into a readable string (similar to Node.js REPL output). */
 function formatCdpPreview(preview: any, depth = 0): string {
@@ -292,45 +263,9 @@ function formatCdpPreview(preview: any, depth = 0): string {
   return `{${inner}}`;
 }
 
-/** Call a function on a remote object and return the string result. */
-function callFunctionOn(targetId: string, objectId: string, fn: string): Promise<string | null> {
-  return new Promise(resolve => {
-    chrome.debugger.sendCommand(
-      { targetId },
-      'Runtime.callFunctionOn',
-      { objectId, functionDeclaration: fn, returnByValue: true },
-      (res: any) => resolve(res?.result?.value ?? null)
-    );
-  });
-}
-
 async function executeBridgeExpr(jsExpr: string): Promise<{ text: string; isError: boolean; image?: string }> {
   try {
-    const targetId = await ensureSelfAttached();
-    // Wrap {…} in parens so V8 parses it as an object literal, not a block statement.
-    const expr = jsExpr.trimStart().startsWith('{') ? `(${jsExpr})` : jsExpr;
-
-    const rawResult = await new Promise<any>((resolve, reject) => {
-      chrome.debugger.sendCommand(
-        { targetId },
-        'Runtime.evaluate',
-        { expression: expr, awaitPromise: true, returnByValue: false, generatePreview: true, objectGroup: 'bridge', replMode: true },
-        (res: any) => {
-          if (chrome.runtime.lastError) {
-            selfTargetId = null;
-            reject(new Error(chrome.runtime.lastError.message));
-          } else if (res?.exceptionDetails) {
-            const msg = res.exceptionDetails.exception?.description
-              ?? res.exceptionDetails.text ?? 'Unknown error';
-            reject(new Error(msg));
-          } else {
-            resolve(res?.result);
-          }
-        }
-      );
-    });
-
-    const r = rawResult;
+    const r = await cdpEval(jsExpr, 'bridge');
     if (!r || r.type === 'undefined') return formatBridgeResult(undefined);
     if (r.type === 'string' || r.type === 'number' || r.type === 'boolean') return formatBridgeResult(r.value);
 
@@ -340,14 +275,16 @@ async function executeBridgeExpr(jsExpr: string): Promise<{ text: string; isErro
       const fn = isMap
         ? 'function(){return [...this].map(([k,v])=>JSON.stringify(k)+" => "+JSON.stringify(v)).join(", ")}'
         : 'function(){return [...this].map(v=>JSON.stringify(v)).join(", ")}';
-      const inner = await callFunctionOn(targetId, r.objectId, fn);
+      const res = await cdpCallFunctionOn(r.objectId, fn);
+      const inner = res?.result?.value ?? null;
       if (inner !== null) return formatBridgeResult(`${r.description} {${inner}}`);
     }
 
     // Plain objects/arrays: use JSON.stringify for full nested representation
     if (r.objectId && (r.description === 'Object' || /^Array\(\d+\)$/.test(r.description ?? ''))) {
-      const json = await callFunctionOn(targetId, r.objectId,
+      const res = await cdpCallFunctionOn(r.objectId,
         'function(){try{return JSON.stringify(this)}catch{return null}}');
+      const json = res?.result?.value ?? null;
       if (json) return formatBridgeResult(json);
     }
 

--- a/packages/extension/src/lib/sw-debugger-core.ts
+++ b/packages/extension/src/lib/sw-debugger-core.ts
@@ -1,0 +1,140 @@
+/**
+ * Shared CDP debugger core — attaches to the extension's service worker target
+ * and provides low-level helpers for Runtime.evaluate, callFunctionOn, and getProperties.
+ *
+ * Used by both background.ts (bridge eval) and panel/lib/sw-debugger.ts (panel eval).
+ * Vite bundles a copy into each entry point.
+ */
+
+let swTargetId: string | null = null;
+
+if (typeof chrome !== 'undefined' && chrome.debugger) {
+    chrome.debugger.onDetach.addListener((source) => {
+        if (source.targetId === swTargetId) swTargetId = null;
+    });
+}
+
+// ─── Target Discovery ────────────────────────────────────────────────────────
+
+function querySwTarget(): Promise<string | null> {
+    const swUrl = `chrome-extension://${chrome.runtime.id}/background.js`;
+    return new Promise(resolve => {
+        chrome.debugger.getTargets(targets => {
+            const sw = targets.find(t => t.type === 'worker' && t.url === swUrl);
+            resolve(sw?.id ?? null);
+        });
+    });
+}
+
+async function findSwTarget(): Promise<string | null> {
+    // Wake the SW and wait for it to confirm it's alive before polling
+    await chrome.runtime.sendMessage({ type: 'ping' }).catch(() => {});
+    // Poll until it appears as a debuggable target (up to ~1s)
+    for (let i = 0; i < 10; i++) {
+        const id = await querySwTarget();
+        if (id) return id;
+        await new Promise(r => setTimeout(r, 100));
+    }
+    return null;
+}
+
+// ─── Attach ──────────────────────────────────────────────────────────────────
+
+export async function ensureAttached(): Promise<string> {
+    // Fast path: already attached
+    if (swTargetId) return swTargetId;
+    const targetId = await findSwTarget();
+    if (!targetId) throw new Error('Background worker target not found. Try reloading the extension.');
+    if (swTargetId === targetId) return targetId;
+    await new Promise<void>((resolve, reject) => {
+        chrome.debugger.attach({ targetId }, '1.3', () => {
+            if (chrome.runtime.lastError) {
+                const msg = chrome.runtime.lastError.message ?? '';
+                if (/already attached/i.test(msg)) { swTargetId = targetId; resolve(); }
+                else reject(new Error(msg));
+            } else {
+                chrome.debugger.sendCommand({ targetId }, 'Runtime.enable', {}, () => {});
+                swTargetId = targetId; resolve();
+            }
+        });
+    });
+    return targetId;
+}
+
+export function resetTargetId() { swTargetId = null; }
+export function getTargetId() { return swTargetId; }
+
+// ─── Generic CDP Command ─────────────────────────────────────────────────────
+
+export async function cdpSendCommand(method: string, params: Record<string, unknown> = {}): Promise<any> {
+    const targetId = await ensureAttached();
+    return new Promise((resolve, reject) => {
+        chrome.debugger.sendCommand({ targetId }, method, params, (result: any) => {
+            if (chrome.runtime.lastError) {
+                reject(new Error(chrome.runtime.lastError.message));
+            } else {
+                resolve(result);
+            }
+        });
+    });
+}
+
+// ─── Runtime.evaluate ────────────────────────────────────────────────────────
+
+/**
+ * Evaluate a JS expression in the service worker's runtime.
+ * Wraps `{…}` in parens so V8 parses object literals correctly.
+ * Returns the raw CDP result object (not exceptionDetails — those throw).
+ */
+export async function cdpEval(expression: string, objectGroup = 'console'): Promise<any> {
+    const expr = expression.trimStart().startsWith('{') ? `(${expression})` : expression;
+    const targetId = await ensureAttached();
+    const result = await new Promise<any>((resolve, reject) => {
+        chrome.debugger.sendCommand(
+            { targetId },
+            'Runtime.evaluate',
+            { expression: expr, awaitPromise: true, returnByValue: false, generatePreview: true, objectGroup, replMode: true },
+            (res: any) => {
+                if (chrome.runtime.lastError) {
+                    swTargetId = null;
+                    reject(new Error(chrome.runtime.lastError.message));
+                } else {
+                    resolve(res);
+                }
+            }
+        );
+    });
+    if (result?.exceptionDetails) {
+        const msg = result.exceptionDetails.exception?.description
+            ?? result.exceptionDetails.text ?? 'Unknown error';
+        throw new Error(msg);
+    }
+    return result?.result;
+}
+
+// ─── Runtime.callFunctionOn ──────────────────────────────────────────────────
+
+export async function cdpCallFunctionOn(
+    objectId: string,
+    functionDeclaration: string,
+    returnByValue = true,
+): Promise<any> {
+    return cdpSendCommand('Runtime.callFunctionOn', {
+        objectId, functionDeclaration, returnByValue,
+    });
+}
+
+// ─── Runtime.getProperties ───────────────────────────────────────────────────
+
+export async function cdpGetProperties(objectId: string): Promise<any> {
+    return cdpSendCommand('Runtime.getProperties', {
+        objectId, ownProperties: true, generatePreview: true,
+    });
+}
+
+// ─── Debug helper ────────────────────────────────────────────────────────────
+
+/** Debug helper — call from console: (await import('...')).swDebugTargets() */
+export function swDebugTargets(): Promise<chrome.debugger.TargetInfo[]> {
+    return new Promise(resolve => chrome.debugger.getTargets(resolve));
+}

--- a/packages/extension/src/panel/lib/sw-debugger.ts
+++ b/packages/extension/src/panel/lib/sw-debugger.ts
@@ -3,6 +3,8 @@
 // The panel is a separate context so it CAN see the SW in getTargets().
 import { SerializedValue } from '@/components/Console/types';
 import { CdpRemoteObject, fromCdpRemoteObject, CdpPropertyDescriptor } from '@/components/Console/cdpToSerialized';
+import { cdpSendCommand, cdpGetProperties, cdpCallFunctionOn, cdpEval, getTargetId } from '../../lib/sw-debugger-core';
+export { swDebugTargets } from '../../lib/sw-debugger-core';
 
 export type ScopeInfo = {
     type: string;
@@ -10,139 +12,32 @@ export type ScopeInfo = {
     objectId: string
 }
 
-let swTargetId: string | null = null;
-
-if (typeof chrome !== 'undefined') {
-    chrome.debugger.onDetach.addListener((source) => {
-        if (source.targetId === swTargetId) swTargetId = null;
-    });
-}
-
-/** Debug helper — call from console: (await import('/panel/lib/sw-debugger.js')).swDebugTargets() */
-export function swDebugTargets(): Promise<chrome.debugger.TargetInfo[]> {
-    return new Promise(resolve => chrome.debugger.getTargets(resolve));
-}
-
-function querySwTarget(): Promise<string | null> {
-    const swUrl = `chrome-extension://${chrome.runtime.id}/background.js`;
-    return new Promise(resolve => {
-        chrome.debugger.getTargets(targets => {
-            const sw = targets.find(t => t.type === 'worker' && t.url === swUrl);
-            resolve(sw?.id ?? null);
-        });
-    });
-}
-
-async function findSwTarget(): Promise<string | null> {
-    // Wake the SW and wait for it to confirm it's alive before polling
-    await chrome.runtime.sendMessage({ type: 'ping' }).catch(() => {});
-    // Poll until it appears as a debuggable target (up to ~1s)
-    for (let i = 0; i < 10; i++) {
-        const id = await querySwTarget();
-        if (id) return id;
-        await new Promise(r => setTimeout(r, 100));
-    }
-    return null;
-}
-
-async function ensureAttached(): Promise<string> {
-    // Fast path: already attached — skip ping/poll (critical when SW is debugger-paused)
-    if (swTargetId) return swTargetId;
-    const targetId = await findSwTarget();
-    if (!targetId) throw new Error('Background worker target not found. Try reloading the extension.');
-    if (swTargetId === targetId) return targetId;
-    await new Promise<void>((resolve, reject) => {
-        chrome.debugger.attach({ targetId }, '1.3', () => {
-            if (chrome.runtime.lastError) {
-                const msg = chrome.runtime.lastError.message ?? '';
-                // Extension already attached (persists after panel page closes) — reuse it
-                if (/already attached/i.test(msg)) { swTargetId = targetId; resolve(); }
-                else reject(new Error(msg));
-            } else {
-                chrome.debugger.sendCommand({ targetId }, 'Runtime.enable', {}, () => {});
-                swTargetId = targetId; resolve();
-            }
-        });
-    });
-    return targetId;
-}
-
 export async function swGetProperties(objectId: string): Promise<unknown> {
-    const targetId = await ensureAttached();
-    return new Promise((resolve, reject) => {
-        chrome.debugger.sendCommand(
-            { targetId },
-            'Runtime.getProperties',
-            { objectId, ownProperties: true, generatePreview: true },
-            (result: any) => {
-                if (chrome.runtime.lastError) {
-                    swTargetId = null;
-                    reject(new Error(chrome.runtime.lastError.message));
-                    return;
-                }
-                resolve(result);
-            }
-        );
-    });
+    return cdpGetProperties(objectId);
 }
 
 export async function swCallFunctionOn(objectId: string, functionDeclaration: string): Promise<unknown> {
-    const targetId = await ensureAttached();
-    return new Promise((resolve, reject) => {
-        chrome.debugger.sendCommand(
-            { targetId },
-            'Runtime.callFunctionOn',
-            { objectId, functionDeclaration, returnByValue: true, awaitPromise: false },
-            (result: any) => {
-                if (chrome.runtime.lastError) {
-                    reject(new Error(chrome.runtime.lastError.message));
-                    return;
-                }
-                resolve(result);
-            }
-        );
-    });
+    return cdpCallFunctionOn(objectId, functionDeclaration);
 }
 
 export async function swDebugEval(expression: string): Promise<unknown> {
-    const targetId = await ensureAttached();
-    // Wrap {…} in parens so V8 parses it as an object literal, not a block statement.
-    // This is the same approach Chrome DevTools and Node REPL use.
-    const expr = expression.trimStart().startsWith('{') ? `(${expression})` : expression;
-
     // When paused at a breakpoint, evaluate in the call frame scope (access to local variables)
-    const method = pausedCallFrameId ? 'Debugger.evaluateOnCallFrame' : 'Runtime.evaluate';
-    const params: Record<string, unknown> = {
-        expression: expr, awaitPromise: true, returnByValue: false, generatePreview: true, objectGroup: 'console',
-    };
     if (pausedCallFrameId) {
-        params.callFrameId = pausedCallFrameId;
-    } else {
-        params.replMode = true;
+        const expr = expression.trimStart().startsWith('{') ? `(${expression})` : expression;
+        const result = await cdpSendCommand('Debugger.evaluateOnCallFrame', {
+            callFrameId: pausedCallFrameId,
+            expression: expr, awaitPromise: true, returnByValue: false, generatePreview: true, objectGroup: 'console',
+        });
+        if (result?.exceptionDetails) {
+            const msg = result.exceptionDetails.exception?.description
+                ?? result.exceptionDetails.text ?? 'Unknown error';
+            throw new Error(msg);
+        }
+        return result;
     }
-
-    return new Promise((resolve, reject) => {
-        chrome.debugger.sendCommand(
-            { targetId },
-            method,
-            params,
-            (result: any) => {
-                if (chrome.runtime.lastError) {
-                    swTargetId = null;
-                    reject(new Error(chrome.runtime.lastError.message));
-                    return;
-                }
-                if (result?.exceptionDetails) {
-                    const msg = result.exceptionDetails.exception?.description
-                        ?? result.exceptionDetails.text
-                        ?? 'Unknown error';
-                    reject(new Error(msg));
-                    return;
-                }
-                resolve(result);
-            }
-        );
-    });
+    // Normal eval — delegate to shared core (returns result.result, not the wrapper)
+    const raw = await cdpEval(expression);
+    return { result: raw };
 }
 
 type ConsoleCallback = (level: string, args: SerializedValue[]) => void;
@@ -164,54 +59,23 @@ export function onDebugPaused(callback: PauseCallback | null) {
 }
 
 export async function swDebuggerEnable(): Promise<void> {
-    const targetId = await ensureAttached();
-    return new Promise((resolve, reject) => {
-        chrome.debugger.sendCommand({ targetId }, 'Debugger.enable', {}, () => {
-            if (chrome.runtime.lastError) reject(new Error(chrome.runtime.lastError.message));
-            else resolve();
-        });
-    });
+    await cdpSendCommand('Debugger.enable');
 }
 
 export async function swDebuggerDisable(): Promise<void> {
     pausedCallFrameId = null;
-    const targetId = await ensureAttached();
-    return new Promise((resolve, reject) => {
-        chrome.debugger.sendCommand({ targetId }, 'Debugger.disable', {}, () => {
-            if (chrome.runtime.lastError) reject(new Error(chrome.runtime.lastError.message));
-            else resolve();
-        });
-    });
+    await cdpSendCommand('Debugger.disable');
 }
 
 export async function swSetBreakpointByUrl(url: string, lineNumber: number): Promise<string> {
-    const targetId = await ensureAttached();
-    return new Promise((resolve, reject) => {
-        chrome.debugger.sendCommand(
-            { targetId },
-            'Debugger.setBreakpointByUrl',
-            { url, lineNumber },
-            (result: any) => {
-                if (chrome.runtime.lastError) reject(new Error(chrome.runtime.lastError.message));
-                else resolve(result?.breakpointId ?? '');
-            }
-        );
-    });
+    const result = await cdpSendCommand('Debugger.setBreakpointByUrl', { url, lineNumber });
+    return result?.breakpointId ?? '';
 }
 
 /** Like swDebugEval but returns raw result (doesn't reject on exceptions). */
 export async function swDebugEvalRaw(expression: string): Promise<{ result?: any; exceptionDetails?: any }> {
-    const targetId = await ensureAttached();
-    return new Promise((resolve, reject) => {
-        chrome.debugger.sendCommand(
-            { targetId },
-            'Runtime.evaluate',
-            { expression, awaitPromise: true, returnByValue: false, generatePreview: true, replMode: true },
-            (result: any) => {
-                if (chrome.runtime.lastError) reject(new Error(chrome.runtime.lastError.message));
-                else resolve(result);
-            }
-        );
+    return cdpSendCommand('Runtime.evaluate', {
+        expression, awaitPromise: true, returnByValue: false, generatePreview: true, replMode: true,
     });
 }
 
@@ -227,78 +91,31 @@ export async function swRemoveAllBreakpoints(): Promise<void> {
 }
 
 export async function swRemoveBreakpoint(breakpointId: string): Promise<void> {
-    const targetId = await ensureAttached();
-    return new Promise((resolve, reject) => {
-        chrome.debugger.sendCommand(
-            { targetId },
-            'Debugger.removeBreakpoint',
-            { breakpointId },
-            () => {
-                if (chrome.runtime.lastError) reject(new Error(chrome.runtime.lastError.message));
-                else resolve();
-            }
-        );
-    });
+    await cdpSendCommand('Debugger.removeBreakpoint', { breakpointId });
 }
 
 export async function swDebugResume(): Promise<void> {
-    const targetId = await ensureAttached();
-    return new Promise((resolve, reject) => {
-        chrome.debugger.sendCommand({ targetId }, 'Debugger.resume', {}, () => {
-            if (chrome.runtime.lastError) reject(new Error(chrome.runtime.lastError.message));
-            else resolve();
-        });
-    });
+    await cdpSendCommand('Debugger.resume');
 }
 
 export async function swDebugPause(): Promise<void> {
-    const targetId = await ensureAttached();
-    return new Promise((resolve, reject) => {
-        chrome.debugger.sendCommand({ targetId }, 'Debugger.pause', {}, () => {
-            if (chrome.runtime.lastError) reject(new Error(chrome.runtime.lastError.message));
-            else resolve();
-        });
-    });
+    await cdpSendCommand('Debugger.pause');
 }
 
 export async function swDebugStepOver(): Promise<void> {
-    const targetId = await ensureAttached();
-    return new Promise((resolve, reject) => {
-        chrome.debugger.sendCommand({ targetId }, 'Debugger.stepOver', {}, () => {
-            if (chrome.runtime.lastError) reject(new Error(chrome.runtime.lastError.message));
-            else resolve();
-        });
-    });
+    await cdpSendCommand('Debugger.stepOver');
 }
 
 export async function swDebugStepInto(): Promise<void> {
-    const targetId = await ensureAttached();
-    return new Promise((resolve, reject) => {
-        chrome.debugger.sendCommand({ targetId }, 'Debugger.stepInto', {}, () => {
-            if (chrome.runtime.lastError) reject(new Error(chrome.runtime.lastError.message));
-            else resolve();
-        });
-    });
+    await cdpSendCommand('Debugger.stepInto');
 }
 
 export async function swDebugStepOut(): Promise<void> {
-    const targetId = await ensureAttached();
-    return new Promise((resolve, reject) => {
-        chrome.debugger.sendCommand({ targetId }, 'Debugger.stepOut', {}, () => {
-            if (chrome.runtime.lastError) reject(new Error(chrome.runtime.lastError.message));
-            else resolve();
-        });
-    });
+    await cdpSendCommand('Debugger.stepOut');
 }
 
 export async function swTerminateExecution(): Promise<void> {
-    const targetId = await ensureAttached();
-    return new Promise((resolve, reject) => {
-        chrome.debugger.sendCommand({ targetId }, 'Runtime.terminateExecution', {}, () => {
-            if (chrome.runtime.lastError) reject(new Error(chrome.runtime.lastError.message));
-            else resolve();
-        });
-    });
+    await cdpSendCommand('Runtime.terminateExecution');
 }
 
 async function eagerSerialize(obj: CdpRemoteObject, depth = 0, visited = new Set<string>()): Promise<SerializedValue> {
@@ -328,7 +145,7 @@ async function eagerSerialize(obj: CdpRemoteObject, depth = 0, visited = new Set
 }
 
 chrome.debugger.onEvent.addListener(async (source, method, params: any) => {
-    if (source.targetId !== swTargetId) return;
+    if (source.targetId !== getTargetId()) return;
 
     if (method === 'Debugger.paused') {
         if (params.callFrames?.length > 0) {


### PR DESCRIPTION
## Summary
- Extract shared CDP eval logic into `src/lib/sw-debugger-core.ts`
- `background.ts` removes ~75 lines: `ensureSelfAttached`, `callFunctionOn`, `onDetach`, duplicated `Runtime.evaluate`
- `sw-debugger.ts` removes ~247 lines: 12 boilerplate CDP functions collapsed to 1-liners via `cdpSendCommand`
- Net reduction: **106 lines**

## What's in the shared core
- `ensureAttached()` — find SW target with polling, attach debugger
- `cdpSendCommand(method, params)` — generic CDP command wrapper
- `cdpEval(expression, objectGroup)` — Runtime.evaluate with object-literal wrapping
- `cdpCallFunctionOn(objectId, fn)` — Runtime.callFunctionOn
- `cdpGetProperties(objectId)` — Runtime.getProperties

## What stays in each consumer
- **background.ts**: `formatCdpPreview`, `formatBridgeResult`, `executeBridgeExpr` (bridge-specific string formatting)
- **sw-debugger.ts**: breakpoints, pause/resume, step commands, `eagerSerialize`, console events, paused-frame eval

## Test plan
- [x] All 146 E2E tests pass
- [x] Build succeeds (Vite bundles core into both entry points)

Closes #263

🤖 Generated with [Claude Code](https://claude.com/claude-code)