### PR TITLE
fix: improve error handling, cleanup, and observability

### DIFF
--- a/packages/cli/src/repl.ts
+++ b/packages/cli/src/repl.ts
@@ -232,7 +232,7 @@ export async function processLine(ctx: ReplContext, line: string): Promise<void>
   }
 
   if (line === '.exit' || line === '.quit') {
-    ctx.conn.close();
+    await ctx.conn.close();
     process.exit(0);
   }
 
@@ -430,11 +430,11 @@ export async function runReplayMode(ctx: ReplContext, replayFile: string, step: 
     }
     ctx.session.endReplay();
     console.log(`\n${c.green}✓${c.reset} Replay complete`);
-    ctx.conn.close();
+    await ctx.conn.close();
     process.exit(0);
   } catch (err: unknown) {
     console.error(`${c.red}Error:${c.reset} ${(err as Error).message}`);
-    ctx.conn.close();
+    await ctx.conn.close();
     process.exit(1);
   }
 }
@@ -452,7 +452,7 @@ export async function runMultiReplayMode(ctx: ReplContext, targets: string[], st
   const files = resolveReplayFiles(targets);
   if (files.length === 0) {
     console.error(`${c.red}Error:${c.reset} No .pw files found`);
-    ctx.conn.close();
+    await ctx.conn.close();
     process.exit(1);
   }
 
@@ -542,7 +542,7 @@ export async function runMultiReplayMode(ctx: ReplContext, targets: string[], st
   fs.writeFileSync(logFile, logLines.join('\n') + '\n', 'utf-8');
   console.log(`${c.dim}Log: ${logFile}${c.reset}`);
 
-  ctx.conn.close();
+  await ctx.conn.close();
   process.exit(failCount > 0 ? 1 : 0);
 }
 
@@ -584,20 +584,20 @@ export function startCommandLoop(ctx: ReplContext): void {
       await new Promise(r => setTimeout(r, 50));
     }
     ctx.log(`\n${c.dim}Closing browser...${c.reset}`);
-    ctx.conn.close();
+    await ctx.conn.close();
     process.exit(0);
   });
 
   let lastSigint = 0;
   ctx.rl!.on('SIGINT', () => {
     if (ctx.opts?.extension) {
-      ctx.conn.close();
-      process.exit(0);
+      ctx.conn.close().finally(() => process.exit(0));
+      return;
     }
     const now = Date.now();
     if (now - lastSigint < 500) {
-      ctx.conn.close();
-      process.exit(0);
+      ctx.conn.close().finally(() => process.exit(0));
+      return;
     }
     lastSigint = now;
     ctx.log(`\n${c.dim}(Ctrl+C again to exit, or type .exit)${c.reset}`);

--- a/packages/cli/test/repl-integration.test.ts
+++ b/packages/cli/test/repl-integration.test.ts
@@ -25,7 +25,7 @@ function makeCtx(overrides = {}) {
   return {
     conn: {
       connected: true,
-      close: vi.fn(),
+      close: vi.fn().mockResolvedValue(undefined),
       start: vi.fn().mockResolvedValue(undefined),
       run: vi.fn().mockResolvedValue({ text: '### Result\nOK' }),
     },
@@ -247,9 +247,9 @@ describe('startCommandLoop', () => {
     expect(ctx.log).toHaveBeenCalled();
     expect(exitSpy).not.toHaveBeenCalled();
 
-    // Second SIGINT within 500ms
+    // Second SIGINT within 500ms — close().finally(() => exit(0)) is async
     rl.emit('SIGINT');
-    expect(exitSpy).toHaveBeenCalledWith(0);
+    await vi.waitFor(() => expect(exitSpy).toHaveBeenCalledWith(0));
 
     exitSpy.mockRestore();
   });

--- a/packages/core/src/engine.ts
+++ b/packages/core/src/engine.ts
@@ -163,10 +163,15 @@ export class Engine {
         console.log('Connecting to existing Chrome on port ' + cdpPort + ' (use --spawn to launch Chrome automatically)');
       }
 
-      // 3. Wait for Chrome CDP to be ready (no timeout — waits until available).
+      // 3. Wait for Chrome CDP to be ready (30s timeout).
       console.log('Waiting for Chrome CDP...');
       const cdpUrl = `http://localhost:${cdpPort}`;
+      const cdpTimeout = 30_000;
+      const cdpStart = Date.now();
       while (true) {
+        if (Date.now() - cdpStart > cdpTimeout) {
+          throw new Error(`Timeout: Chrome CDP not available at ${cdpUrl} after ${cdpTimeout / 1000}s`);
+        }
         try {
           const res = await fetch(`${cdpUrl}/json/version`);
           if (res.ok) break;
@@ -380,7 +385,9 @@ export class Engine {
   private _scheduleReconnect(): void {
     if (this._isReconnecting) return;
     this._isReconnecting = true;
-    this._doReconnect().catch(() => {});
+    this._doReconnect().catch((e) => {
+      console.warn('Reconnection failed:', e instanceof Error ? e.message : String(e));
+    });
   }
 
   private async _doReconnect(): Promise<void> {
@@ -392,13 +399,27 @@ export class Engine {
 
     console.log('Browser context closed. Waiting for Chrome to reconnect...');
 
+    let attempt = 0;
     while (!this._connected) {
+      attempt++;
       await new Promise(r => setTimeout(r, 1500));
+
+      // Check if engine was closed during reconnect
+      if (!this._reconnectInfo) {
+        console.log('Reconnection cancelled (engine closed).');
+        break;
+      }
 
       try {
         const res = await fetch(`${cdpUrl}/json/version`);
-        if (!res.ok) continue;
-      } catch { continue; }
+        if (!res.ok) {
+          console.warn(`Reconnect attempt ${attempt}: CDP responded with status ${res.status}`);
+          continue;
+        }
+      } catch (e) {
+        console.warn(`Reconnect attempt ${attempt}: CDP not available (${e instanceof Error ? e.message : String(e)})`);
+        continue;
+      }
 
       // CDP is responding — reconnect
       try {
@@ -411,8 +432,10 @@ export class Engine {
 
         (config as any).browser.cdpEndpoint = cdpUrl;
         await this._connectToCdp(deps, config, clientInfo);
-        console.log('Reconnected to Chrome CDP.');
-      } catch { /* retry next iteration */ }
+        console.log(`Reconnected to Chrome CDP after ${attempt} attempt(s).`);
+      } catch (e) {
+        console.warn(`Reconnect attempt ${attempt}: connection failed (${e instanceof Error ? e.message : String(e)})`);
+      }
     }
 
     this._isReconnecting = false;

--- a/packages/core/src/extension-server.ts
+++ b/packages/core/src/extension-server.ts
@@ -92,7 +92,9 @@ export class CommandServer {
         const { url } = JSON.parse(body);
         console.log(`[select-tab] ${url || 'no-url'}`);
         if (url && url !== this._lastActiveUrl) {
-          await withTimeout(this._engine.selectPageByUrl(url), 5000).catch(() => {});
+          await withTimeout(this._engine.selectPageByUrl(url), 5000).catch(e => {
+            console.warn(`[select-tab] failed to select page: ${e instanceof Error ? e.message : String(e)}`);
+          });
           this._lastActiveUrl = url;
         }
         res.writeHead(200, { 'Content-Type': 'application/json' });
@@ -113,7 +115,9 @@ export class CommandServer {
 
         // Auto-select the tab matching the panel's active tab (only when it changes).
         if (activeTabUrl && activeTabUrl !== this._lastActiveUrl) {
-          await withTimeout(this._engine.selectPageByUrl(activeTabUrl), 5000).catch(() => {});
+          await withTimeout(this._engine.selectPageByUrl(activeTabUrl), 5000).catch(e => {
+            console.warn(`[server] tab select failed: ${e instanceof Error ? e.message : String(e)}`);
+          });
           this._lastActiveUrl = activeTabUrl;
         }
 

--- a/packages/extension/src/background.ts
+++ b/packages/extension/src/background.ts
@@ -24,22 +24,22 @@ async function ensureOffscreen() {
     justification: 'Maintains WebSocket connection to CLI/MCP bridge server',
   });
 }
-ensureOffscreen().catch(() => {});
+ensureOffscreen().catch(e => console.warn('[pw-repl] offscreen document creation failed:', e));
 
 // ─── Settings + Action (sidepanel / popup) ───────────────────────────────────
 
 // Disable auto-open so action.onClicked fires (Chrome persists this across reloads)
-chrome.sidePanel.setPanelBehavior({ openPanelOnActionClick: false }).catch(() => {});
+chrome.sidePanel.setPanelBehavior({ openPanelOnActionClick: false }).catch(e => console.debug('[pw-repl] setPanelBehavior:', e));
 
 let cachedSettings: Partial<PwReplSettings> = { openAs: 'sidepanel' };
-loadSettings().then(s => cachedSettings = s).catch(() => {});
+loadSettings().then(s => cachedSettings = s).catch(e => console.warn('[pw-repl] settings load failed:', e));
 
 chrome.storage.onChanged.addListener((changes, area) => {
   if (area === 'local' && changes.openAs) {
     cachedSettings.openAs = changes.openAs.newValue;
   }
   if (area === 'local' && changes.bridgePort) {
-    chrome.runtime.sendMessage({ type: 'bridge-port-changed', port: changes.bridgePort.newValue }).catch(() => {});
+    chrome.runtime.sendMessage({ type: 'bridge-port-changed', port: changes.bridgePort.newValue }).catch(() => { /* panel may not be open */ });
   }
 });
 
@@ -108,7 +108,7 @@ async function attachToTab(tabId: number): Promise<{ ok: boolean; url?: string; 
     } catch {
       // Attach failed (stale frames, etc.) — detach all stale sessions and retry.
       // The _doDetach fix in playwright-crx handles broken pages gracefully.
-      await app.detachAll().catch(() => {});
+      await app.detachAll().catch(e => console.debug('[pw-repl] detachAll before retry:', e));
       currentPage = await app.attach(tabId);
     }
 
@@ -162,7 +162,7 @@ async function startRecording(): Promise<{ ok: boolean; url?: string; error?: st
 
 async function stopRecording(): Promise<{ ok: boolean }> {
   if (recordingTabId) {
-    await chrome.tabs.sendMessage(recordingTabId, { type: 'record-stop' }).catch(() => {});
+    await chrome.tabs.sendMessage(recordingTabId, { type: 'record-stop' }).catch(e => console.debug('[pw-repl] record-stop:', e));
     recordingTabId = null;
   }
   return { ok: true };
@@ -171,7 +171,7 @@ async function stopRecording(): Promise<{ ok: boolean }> {
 // Re-inject recorder after navigation (page reload / SPA navigation)
 chrome.tabs.onUpdated.addListener((tabId, changeInfo) => {
   if (tabId === recordingTabId && changeInfo.status === 'complete') {
-    chrome.scripting.executeScript({ target: { tabId }, files: ['content/recorder.js'] }).catch(() => {});
+    chrome.scripting.executeScript({ target: { tabId }, files: ['content/recorder.js'] }).catch(e => console.debug('[pw-repl] recorder re-inject:', e));
   }
 });
 
@@ -201,7 +201,7 @@ async function startPicking(): Promise<{ ok: boolean; error?: string }> {
 
 async function stopPicking(): Promise<{ ok: boolean }> {
   const tabId = await getActiveTabId();
-  if (tabId) await chrome.tabs.sendMessage(tabId, { type: 'pick-stop' }).catch(() => {});
+  if (tabId) await chrome.tabs.sendMessage(tabId, { type: 'pick-stop' }).catch(e => console.debug('[pw-repl] pick-stop:', e));
   return { ok: true };
 }
 
@@ -445,7 +445,7 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
   if (msg.type === 'attach')        { attachToTab(msg.tabId).then(sendResponse); return true; }
   if (msg.type === 'detach')        {
     if (activeTabId !== null && crxApp) {
-      crxApp.detach(activeTabId).catch(() => {});
+      crxApp.detach(activeTabId).catch(e => console.debug('[pw-repl] detach:', e));
       currentPage = null;
       activeTabId = null;
     }

--- a/packages/extension/src/devtools/console.tsx
+++ b/packages/extension/src/devtools/console.tsx
@@ -19,7 +19,7 @@ function DevToolsConsole() {
       attachToTab(tabId).then(res => {
         if (res.ok && res.url)
           dispatch({ type: 'ATTACH_SUCCESS', url: res.url, tabId });
-      }).catch(() => {});
+      }).catch(e => console.warn('[pw-repl] auto-attach failed:', e));
     }
   }, []);
 

--- a/packages/extension/src/lib/sw-debugger-core.ts
+++ b/packages/extension/src/lib/sw-debugger-core.ts
@@ -28,7 +28,7 @@ function querySwTarget(): Promise<string | null> {
 
 async function findSwTarget(): Promise<string | null> {
     // Wake the SW and wait for it to confirm it's alive before polling
-    await chrome.runtime.sendMessage({ type: 'ping' }).catch(() => {});
+    await chrome.runtime.sendMessage({ type: 'ping' }).catch(() => { /* SW may not be ready yet */ });
     // Poll until it appears as a debuggable target (up to ~1s)
     for (let i = 0; i < 10; i++) {
         const id = await querySwTarget();

--- a/packages/extension/src/panel/components/DebugBar.tsx
+++ b/packages/extension/src/panel/components/DebugBar.tsx
@@ -8,32 +8,32 @@ interface DebugBarProps {
 
 function DebugBar({ dispatch }: DebugBarProps) {
     function handleContinue() {
-        swDebugResume().catch(() => {});
+        swDebugResume().catch(e => console.warn('[debug] resume failed:', e));
     }
 
     function handleStepOver() {
-        swDebugStepOver().catch(() => {});
+        swDebugStepOver().catch(e => console.warn('[debug] step-over failed:', e));
     }
 
     function handleStepInto() {
-        swDebugStepInto().catch(() => {});
+        swDebugStepInto().catch(e => console.warn('[debug] step-into failed:', e));
     }
 
     function handleStepOut() {
-        swDebugStepOut().catch(() => {});
+        swDebugStepOut().catch(e => console.warn('[debug] step-out failed:', e));
     }
 
     function handleRestart() {
         // Stop current execution, then re-run in debug mode
-        swTerminateExecution().catch(() => {});
-        swDebugResume().catch(() => {});
+        swTerminateExecution().catch(e => console.warn('[debug] terminate failed:', e));
+        swDebugResume().catch(e => console.warn('[debug] resume failed:', e));
         dispatch({ type: 'RUN_STOP' });
         // Re-start is handled by the user clicking Debug again
     }
 
     function handleStop() {
-        swTerminateExecution().catch(() => {});
-        swDebugResume().catch(() => {});
+        swTerminateExecution().catch(e => console.warn('[debug] terminate failed:', e));
+        swDebugResume().catch(e => console.warn('[debug] resume failed:', e));
         dispatch({ type: 'RUN_STOP' });
     }
 

--- a/packages/extension/src/panel/components/Toolbar.tsx
+++ b/packages/extension/src/panel/components/Toolbar.tsx
@@ -85,7 +85,7 @@ function Toolbar({ editorContent, editorMode, stepLine, attachedUrl, attachedTab
     async function handleTabChange(tabId: number) {
         const tab = availableTabs.find(t => t.id === tabId);
         setSelectedTabId(tabId); // show in dropdown immediately
-        chrome.tabs.update(tabId, { active: true }).catch(() => {});
+        chrome.tabs.update(tabId, { active: true }).catch(e => console.debug('[pw-repl] tab activate:', e));
         if (tab && isInternalUrl(tab.url)) {
             dispatch({ type: 'DETACH' });
             return;
@@ -184,8 +184,8 @@ function Toolbar({ editorContent, editorMode, stepLine, attachedUrl, attachedTab
     function handleStop() {
         cancelRunRef.current = true;
         if (isStepDebugging) {
-            swTerminateExecution().catch(() => {});
-            swDebugResume().catch(() => {}); // unpause so termination takes effect
+            swTerminateExecution().catch(e => console.warn('[debug] terminate failed:', e));
+            swDebugResume().catch(e => console.warn('[debug] resume failed:', e)); // unpause so termination takes effect
         }
         dispatch({ type: 'RUN_STOP' });
     }
@@ -249,7 +249,7 @@ function Toolbar({ editorContent, editorMode, stepLine, attachedUrl, attachedTab
     useEffect(() => {
         if (isRunning && isRecording) {
             setIsRecording(false);
-            chrome.runtime.sendMessage({ type: 'record-stop' }).catch(() => {});
+            chrome.runtime.sendMessage({ type: 'record-stop' }).catch(e => console.debug('[pw-repl] record-stop:', e));
         }
     }, [isRunning]);
 
@@ -258,7 +258,7 @@ function Toolbar({ editorContent, editorMode, stepLine, attachedUrl, attachedTab
 
         if (isRecording) {
             setIsRecording(false);
-            chrome.runtime.sendMessage({ type: 'record-stop' }).catch(() => {});
+            chrome.runtime.sendMessage({ type: 'record-stop' }).catch(e => console.debug('[pw-repl] record-stop:', e));
             return;
         }
 
@@ -318,7 +318,7 @@ function Toolbar({ editorContent, editorMode, stepLine, attachedUrl, attachedTab
 
         if (isPicking) {
             setIsPicking(false);
-            await chrome.runtime.sendMessage({ type: 'pick-stop' }).catch(() => {});
+            await chrome.runtime.sendMessage({ type: 'pick-stop' }).catch(e => console.debug('[pw-repl] pick-stop:', e));
             return;
         }
 
@@ -339,7 +339,7 @@ function Toolbar({ editorContent, editorMode, stepLine, attachedUrl, attachedTab
     function handleDetach() {
         dispatch({ type: 'DETACH' });
         // Let background know we're detaching (for cleanup)
-        chrome.runtime.sendMessage({ type: 'detach' }).catch(() => { });
+        chrome.runtime.sendMessage({ type: 'detach' }).catch(e => console.debug('[pw-repl] detach:', e));
     }
 
     // ─── Theme toggle ───

--- a/packages/extension/src/panel/lib/run.ts
+++ b/packages/extension/src/panel/lib/run.ts
@@ -169,7 +169,7 @@ export async function runJsScriptStep(code: string, dispatch: React.Dispatch<Act
                 dispatch({ type: 'SET_SCOPE_DATA', scopes});
             } else {
                 // Already at last line, stepped past — finish
-                swDebugResume().catch(() => {});
+                swDebugResume().catch(e => console.debug('[debug] auto-resume:', e));
             }
         });
 
@@ -202,8 +202,8 @@ export async function runJsScriptStep(code: string, dispatch: React.Dispatch<Act
         dispatch({ type: 'COMMAND_ERROR', line: { text: trimStack(e?.message ?? String(e)), type: 'error' } });
     } finally {
         onDebugPaused(null);
-        await swDebuggerDisable().catch(() => {});
-        await swRemoveAllBreakpoints().catch(() => {})
+        await swDebuggerDisable().catch(e => console.debug('[debug] disable:', e));
+        await swRemoveAllBreakpoints().catch(e => console.debug('[debug] cleanup breakpoints:', e));
     }
 }
 

--- a/packages/extension/src/panel/lib/sw-debugger.ts
+++ b/packages/extension/src/panel/lib/sw-debugger.ts
@@ -87,7 +87,7 @@ export function swTrackBreakpoint(breakpointId: string) {
 
 export async function swRemoveAllBreakpoints(): Promise<void> {
     const ids = activeBreakpointIds.splice(0);
-    for (const id of ids) await swRemoveBreakpoint(id).catch(() => {});
+    for (const id of ids) await swRemoveBreakpoint(id).catch(e => console.debug('[debug] remove breakpoint:', e));
 }
 
 export async function swRemoveBreakpoint(breakpointId: string): Promise<void> {


### PR DESCRIPTION
## Summary

- **Await `conn.close()` in all CLI exit paths** to prevent zombie browser processes on exit (#448)
- **Add 30s timeout to CDP ready loop** in engine.ts extension mode — no longer hangs forever if Chrome fails to start (#449)
- **Log reconnection attempts with context** instead of silently swallowing errors in engine.ts and extension-server.ts (#450)
- **Replace 30+ silent `.catch(() => {})`** across the extension with `console.warn` (user-impacting) or `console.debug` (expected-failure paths) (#451)

## Test plan

- [x] All 995 tests pass (core: 144, cli: 176, extension: 675)
- [x] Build succeeds with no type errors
- [ ] Manual: verify CLI exits cleanly (no zombie Chrome) after `.exit` and Ctrl+C
- [ ] Manual: verify extension debug bar operations log warnings on failure in DevTools console

Closes #448, #449, #450, #451

🤖 Generated with [Claude Code](https://claude.com/claude-code)