### PR TITLE
fix: make @playwright/test a peer dep and clear storage between tests

### DIFF
--- a/packages/runner/package.json
+++ b/packages/runner/package.json
@@ -22,13 +22,16 @@
   "dependencies": {
     "@playwright-repl/core": "workspace:*",
     "@playwright-repl/extension": "workspace:*",
-    "@playwright/test": "1.59.0-alpha-2026-02-21",
     "acorn": "^8.16.0",
     "acorn-walk": "^8.3.5",
     "esbuild": "^0.25.0",
     "magic-string": "^0.30.21"
   },
+  "peerDependencies": {
+    "@playwright/test": ">=1.57.0"
+  },
   "devDependencies": {
+    "@playwright/test": "1.59.0-alpha-2026-02-21",
     "typescript": "^5.0.0"
   }
 }

--- a/packages/runner/src/pw-preload.cts
+++ b/packages/runner/src/pw-preload.cts
@@ -75,6 +75,10 @@ const origLoad = (Module as any)._load;
               await sharedContext.unrouteAll({ behavior: 'ignoreErrors' }).catch(() => {});
               await sharedPage.unrouteAll({ behavior: 'ignoreErrors' }).catch(() => {});
               if (defaultViewport) await sharedPage.setViewportSize(defaultViewport);
+              await sharedPage.evaluate(() => {
+                try { localStorage.clear(); } catch {}
+                try { sessionStorage.clear(); } catch {}
+              }).catch(() => {});
               await sharedPage.goto('about:blank', { waitUntil: 'commit' });
             } catch {}
           }
@@ -105,6 +109,10 @@ const origLoad = (Module as any)._load;
             await sharedContext.unrouteAll({ behavior: 'ignoreErrors' }).catch(() => {});
             await sharedPage.unrouteAll({ behavior: 'ignoreErrors' }).catch(() => {});
             if (defaultViewport) await sharedPage.setViewportSize(defaultViewport);
+            await sharedPage.evaluate(() => {
+              try { localStorage.clear(); } catch {}
+              try { sessionStorage.clear(); } catch {}
+            }).catch(() => {});
             await sharedPage.goto('about:blank', { waitUntil: 'commit' });
           } catch {}
         }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -206,9 +206,6 @@ importers:
       '@playwright-repl/extension':
         specifier: workspace:*
         version: link:../extension
-      '@playwright/test':
-        specifier: 1.59.0-alpha-2026-02-21
-        version: 1.59.0-alpha-2026-02-21
       acorn:
         specifier: ^8.16.0
         version: 8.16.0
@@ -222,6 +219,9 @@ importers:
         specifier: ^0.30.21
         version: 0.30.21
     devDependencies:
+      '@playwright/test':
+        specifier: 1.59.0-alpha-2026-02-21
+        version: 1.59.0-alpha-2026-02-21
       typescript:
         specifier: ^5.0.0
         version: 5.9.3


### PR DESCRIPTION
## Summary
- Move `@playwright/test` from `dependencies` to `peerDependencies` — pw-cli now uses the project's Playwright version
- Clear `localStorage` and `sessionStorage` between tests in context reuse mode

## Problem
When installing pw-cli via yalc/npm in an external project, two versions of `@playwright/test` coexist, causing `test.describe() not expected here` crashes.

Context reuse also leaked state (localStorage filters) between tests, causing URL assertion failures.

## Tested
- All 26 todomvc tests pass (pw-cli)
- Restaurant reviews project: 12/12 tests pass with pw-cli, coverage at 54%
- 15.5s with pw-cli vs 18.8s with standard Playwright (same tests)

Closes #457

🤖 Generated with [Claude Code](https://claude.com/claude-code)