### PR TITLE
docs: rewrite all READMEs, remove speed claims, focus on DX

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,44 +2,55 @@
 
 ![playwright-repl](cover-image.png)
 
-Interactive browser automation powered by Playwright — use it from **VS Code**, your **terminal**, as a **Chrome extension**, or let an **AI agent** drive it via MCP.
+Keyword-driven browser automation powered by Playwright. Use it from **VS Code**, your **terminal**, as a **Chrome extension**, or let an **AI agent** drive it via MCP.
+
+```
+pw> goto https://demo.playwright.dev/todomvc/
+pw> fill "What needs to be done?" Buy groceries
+pw> press Enter
+pw> snapshot
+pw> click e5
+pw> verify text 1 item left
+```
+
+Instead of writing `page.locator('[placeholder="What needs to be done?"]').fill('Buy groceries')`, you type `fill "What needs to be done?" Buy groceries`. Same Playwright engine, simpler syntax.
+
+---
+
+## Packages
 
 | Package | Description |
 |---------|-------------|
-| [Playwright REPL](https://github.com/stevez/playwright-repl/blob/main/packages/vscode/README.md) | VS Code extension — faster bridge tests (~66ms/test), REPL panel, assert builder, element picker |
-| [`playwright-repl`](https://github.com/stevez/playwright-repl/blob/main/packages/cli/README.md) | CLI — terminal REPL with keyword commands, recording, replay, and piping |
-| [Dramaturg](https://github.com/stevez/playwright-repl/blob/main/packages/extension/README.md) | Chrome extension — console, script editor, recorder, CDP object tree |
-| [`@playwright-repl/runner`](https://github.com/stevez/playwright-repl/blob/main/packages/runner/README.md) | Test runner — 1.5-2x faster bridge execution with context reuse |
-| [`@playwright-repl/mcp`](https://github.com/stevez/playwright-repl/blob/main/packages/mcp/README.md) | MCP server — AI agents control your real Chrome browser |
-| [`@playwright-repl/core`](https://github.com/stevez/playwright-repl/blob/main/packages/core/README.md) | Shared engine, parser, and utilities |
+| [Playwright REPL](packages/vscode/README.md) | VS Code extension — Test Explorer, REPL panel, assert builder, element picker |
+| [`playwright-repl`](packages/cli/README.md) | CLI — terminal REPL with keyword commands, recording, replay, and piping |
+| [Dramaturg](packages/extension/README.md) | Chrome extension — console, script editor, recorder, JS debugger |
+| [`@playwright-repl/runner`](packages/runner/README.md) | Test runner — drop-in replacement for `npx playwright test` with context reuse |
+| [`@playwright-repl/mcp`](packages/mcp/README.md) | MCP server — AI agents control your real Chrome browser |
+| [`@playwright-repl/core`](packages/core/README.md) | Shared parser, servers, and utilities |
 
 ---
 
-## VS Code Extension — Playwright REPL
+## VS Code Extension
 
-Faster Playwright test execution with interactive REPL, assertion builder, and element picker — all inside VS Code.
+Test Explorer, interactive REPL, assert builder, and element picker — all inside VS Code.
 
 | Feature | Description |
 |---------|-------------|
-| **Test Explorer** | Bridge execution — ~66ms per test instead of ~3s through standard runner |
-| **REPL Panel** | Interactive commands, inline screenshots, PDF save, execution timing |
-| **Locator Panel** | Pick elements, highlight toggle, ARIA snapshot |
+| **Test Explorer** | Run Playwright tests with persistent browser and context reuse |
+| **REPL Panel** | Interactive commands, inline screenshots, execution timing |
+| **Locator Panel** | Pick elements visually, highlight toggle, ARIA snapshot |
 | **Assert Builder** | 13 matchers, smart filtering by element type, verify against live page |
-| **Browser Reuse** | REPL, tests, recorder, picker share one headed browser |
+| **Recorder** | Capture interactions as `.pw` keyword commands or Playwright JavaScript |
 
-Three panels in the bottom bar:
+**Workflow:** Record → Pick Locator → Assert → Run Test
 
-```
-REPL | LOCATOR | ASSERT
-```
-
-> **[Full VS Code extension docs](https://github.com/stevez/playwright-repl/blob/main/packages/vscode/README.md)**
+> **[Full VS Code extension docs](packages/vscode/README.md)**
 
 ---
 
-## CLI — playwright-repl
+## CLI
 
-Terminal REPL for Playwright automation. Type a command, see the result instantly.
+Terminal REPL for Playwright. Type a command, see the result.
 
 ```bash
 npm install -g playwright-repl
@@ -48,116 +59,78 @@ playwright-repl --headed
 
 ```
 pw> goto https://demo.playwright.dev/todomvc/
-pw> fill "What needs to be done?" "Buy groceries"
+pw> fill "What needs to be done?" Buy groceries
 pw> press Enter
-pw> verify-text "1 item left"
+pw> verify text 1 item left
 pw> screenshot
 ```
 
-Two modes:
+**Two modes:**
 
-| Mode | Flag | Browser |
-|------|------|---------|
-| **Standalone** | *(default)* | Launches new Chromium via Playwright |
-| **Bridge** | `--bridge` | Your real Chrome via Dramaturg extension |
+| Mode | Flag | How it works |
+|------|------|--------------|
+| **Standalone** | *(default)* | Launches Chromium via Playwright |
+| **Bridge** | `--bridge` | Connects to your real Chrome via Dramaturg extension |
 
-→ **[Full CLI docs](https://github.com/stevez/playwright-repl/blob/main/packages/cli/README.md)**
+> **[Full CLI docs](packages/cli/README.md)**
 
-### Performance
+---
 
-Response time per command on [TodoMVC](https://demo.playwright.dev/todomvc), measured in milliseconds:
+## pw Commands
 
-| Command | `playwright-cli` | Standalone | Bridge |
-|---------|------------------:|-----------:|-------:|
-| `snapshot` | 211 | 4 | 14 |
-| `click` | 1538 | 1046 | 30 |
-| `hover` | 1240 | 1050 | 28 |
-| `fill` | 1236 | 1036 | 7 |
-| `press` | 1216 | 1033 | 11 |
-| `eval` | 1220 | 1010 | 3 |
-| `screenshot` | 274 | 107 | 129 |
-| `tab-list` | 217 | 4 | 4 |
-| `cookie-list` | 201 | 3 | 2 |
+The `@playwright-repl/runner` package provides the `pw` CLI:
 
-- **`playwright-cli`** — Playwright's official CLI. Each command spawns a new process (~200ms overhead).
-- **Standalone** — `playwright-repl` (default). REPL stays open — no per-command startup cost.
-- **Bridge** — `playwright-repl --bridge`. Playwright runs inside Chrome via `playwright-crx` — no external CDP round-trips.
+```bash
+npm install -D @playwright-repl/runner
+```
+
+```bash
+pw test                              # run Playwright tests with context reuse
+pw launch --port 9222                # launch Chrome with extension + CDP port
+pw repl --port 9222                  # Node REPL with Playwright globals (page, context, browser, expect)
+pw repl-extension --bridge-port 9877 # REPL via extension bridge
+pw close --port 9222                 # close browser
+```
+
+> **[Full runner docs](packages/runner/README.md)**
 
 ---
 
 ## Dramaturg — Chrome Extension
 
-Chrome side panel extension that runs the full Playwright API directly inside your browser — no Node.js backend required.
+Chrome side panel extension that runs Playwright directly inside your browser.
 
-Install from the [Chrome Web Store](https://chromewebstore.google.com/detail/dramaturg/ppbkmncnmjkfppilnmplpokdfagobipa), or build from source:
-
-```bash
-cd packages/extension && npm run build
-# Load in Chrome: chrome://extensions → Developer mode → Load unpacked → dist/
-```
+Install from the [Chrome Web Store](https://chromewebstore.google.com/detail/dramaturg/ppbkmncnmjkfppilnmplpokdfagobipa), or build from source.
 
 | Feature | |
 |---------|---|
-| Console with 2 input modes | `.pw` keywords, Playwright API / JavaScript — auto-detected |
+| Console | `.pw` keywords and Playwright JavaScript — auto-detected |
 | Script editor | Syntax highlighting, pass/fail gutter, autocompletion |
-| JS debugger | Breakpoints, Step Over/Into/Out, Variables tab with scope inspection |
-| Recorder | Captures clicks/fills/navigations as `.pw` commands and JS Playwright code |
-| Object tree | Expandable CDP object tree, just like Chrome DevTools |
-| Side panel & popup | Opens as side panel by default; switch to popup in Options |
+| JS debugger | Breakpoints, step over/into/out, variables with scope inspection |
+| Recorder | Captures interactions as `.pw` commands and Playwright code |
+| Object tree | Expandable CDP object tree |
 
-→ **[Full extension docs](https://github.com/stevez/playwright-repl/blob/main/packages/extension/README.md)**
+> **[Full extension docs](packages/extension/README.md)**
 
 ---
 
 ## MCP Server — AI Browser Agent
 
-Most browser MCP servers launch a separate, isolated browser — no history, no cookies, no auth.
-
-**`@playwright-repl/mcp` is different.**
-
-The MCP server pairs with the Dramaturg extension to give AI agents access to your **real** Chrome session — already logged in, cookies intact.
+AI agents control your **real** Chrome session — already logged in, cookies intact.
 
 ```bash
 npm install -g @playwright-repl/mcp
-playwright-repl-mcp   # extension connects automatically — no side panel needed
+playwright-repl-mcp
 ```
 
 | | `@playwright-repl/mcp` | Playwright MCP | Playwriter |
 |---|:---:|:---:|:---:|
-| MCP tools exposed | **2** `run_command`, `run_script` | ~70 tools | **1** `execute` |
-| Uses your real session | ✅ | ❌ | ✅ |
-| Playwright runs inside browser | ✅ | ❌ | ❌ |
-| `expect()` assertions | ✅ | ❌ | ❌ |
-| Full Playwright API | ✅ | ✅ | ✅ |
-| JS eval (`page.evaluate`) | ✅ | ❌ | ✅ |
+| Uses your real session | Yes | No | Yes |
+| `expect()` assertions | Yes | No | No |
+| Full Playwright API | Yes | Yes | Yes |
+| JS eval (`page.evaluate`) | Yes | No | Yes |
 
-> Playwright MCP and Playwriter control Chrome from outside via CDP relay. `@playwright-repl/mcp` runs Playwright natively inside Chrome via `playwright-crx` — enabling `expect()`, recording, and a full DevTools panel alongside AI.
-
-→ **[Full MCP docs](https://github.com/stevez/playwright-repl/blob/main/packages/mcp/README.md)**
-
----
-
-## Runner — @playwright-repl/runner
-
-Drop-in test runner that sits on top of Playwright Test. Bridge-compatible tests execute directly in the browser — **1.5-2x faster** than the standard test-server path.
-
-| Feature | Description |
-|---------|-------------|
-| **Bridge mode** | Compile test with esbuild, send to Chrome extension, execute in-browser (~50ms/test) |
-| **Node mode** | Falls back to standard Playwright runner for tests using Node APIs |
-| **Context reuse** | Shared browser context across tests — no teardown/recreate per test |
-| **pw-preload** | Injected via `NODE_OPTIONS`, patches `chromium.launch` for browser reuse |
-| **needsNode detection** | Static analysis of test files to route bridge vs node automatically |
-
-```bash
-# Run tests via pw CLI (bridge + node routing)
-pw test
-
-# Standard Playwright (for comparison)
-npx playwright test
-```
-
-→ **[Full runner docs](https://github.com/stevez/playwright-repl/blob/main/packages/runner/README.md)**
+> **[Full MCP docs](packages/mcp/README.md)**
 
 ---
 
@@ -165,29 +138,18 @@ npx playwright test
 
 ```
 packages/
-├── vscode/         # Playwright REPL — VS Code extension (Test Explorer, REPL, Assert Builder)
-├── core/           # @playwright-repl/core — shared Engine, BridgeServer, parser
+├── vscode/         # Playwright REPL — VS Code extension
 ├── cli/            # playwright-repl — terminal REPL
-├── runner/         # @playwright-repl/runner — test runner with bridge execution
-├── mcp/            # @playwright-repl/mcp — MCP server (run_command, run_script)
-└── extension/      # Dramaturg — Chrome side panel extension (React, Vite)
-```
-
-```bash
-# Build all packages
-npm run build
-
-# Build and watch (CLI + core)
-npm run dev
-
-# Run extension
-cd packages/extension && npm run build
+├── runner/         # @playwright-repl/runner — test runner (pw CLI)
+├── extension/      # Dramaturg — Chrome side panel extension
+├── mcp/            # @playwright-repl/mcp — MCP server for AI agents
+└── core/           # @playwright-repl/core — shared parser, servers, utilities
 ```
 
 ## Requirements
 
 - **Node.js** >= 20
-- **playwright** >= 1.59.0-alpha
+- **Playwright** >= 1.59
 
 ## License
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,6 +1,6 @@
-# playwright-repl (CLI)
+# playwright-repl
 
-Interactive terminal REPL for browser automation powered by Playwright. Type a command, see the result instantly — no code, no boilerplate.
+Interactive terminal REPL for browser automation powered by Playwright. Type a command, see the result — no code, no boilerplate.
 
 ```bash
 npm install -g playwright-repl
@@ -9,9 +9,9 @@ playwright-repl --headed
 
 ```
 pw> goto https://demo.playwright.dev/todomvc/
-pw> fill "What needs to be done?" "Buy groceries"
+pw> fill "What needs to be done?" Buy groceries
 pw> press Enter
-pw> verify-text "1 item left"
+pw> verify text 1 item left
 pw> screenshot
 ```
 
@@ -26,10 +26,10 @@ npx playwright install
 
 ## Connection Modes
 
-| Mode | Flag | Browser Source | Use Case |
-|------|------|---------------|----------|
-| **Standalone** | *(default)* | Launches new Chromium via Playwright | General automation, CI |
-| **Bridge** | `--bridge` | Your real Chrome (via extension) | Drive your existing session — cookies and logins intact |
+| Mode | Flag | How it works |
+|------|------|--------------|
+| **Standalone** | *(default)* | Launches Chromium via Playwright |
+| **Bridge** | `--bridge` | Connects to your real Chrome via Dramaturg extension — cookies and logins intact |
 
 ### Standalone
 
@@ -44,18 +44,18 @@ playwright-repl --persistent   # keeps profile between sessions
 
 ### Bridge
 
-The bridge mode starts an interactive REPL that acts as a **remote console for the Chrome extension** — your terminal becomes the command input for the extension's browser session. Commands run inside your real Chrome with your existing cookies and logins.
+The bridge mode turns your terminal into a remote console for the Chrome extension. Commands run inside your real Chrome with your existing cookies and logins.
 
 ```bash
-playwright-repl --bridge                      # start bridge server, wait for extension to connect
+playwright-repl --bridge                      # start bridge server, wait for extension
 playwright-repl --bridge --replay script.pw   # replay a script via bridge
 playwright-repl --bridge --replay examples/   # replay all .pw files
 playwright-repl --bridge --bridge-port 9877   # custom port (default 9876)
 ```
 
-The extension connects automatically — no need to open the side panel. Once connected, all commands run against the active tab in your real browser.
+The extension connects automatically — no need to open the side panel.
 
-> Requires the playwright-repl Chrome extension — see [packages/extension/README.md](../extension/README.md) for setup.
+> Requires the [Dramaturg Chrome extension](../extension/README.md).
 
 ## Usage
 
@@ -86,10 +86,10 @@ echo -e "goto https://example.com\nsnapshot" | playwright-repl
 
 | Mode | Standalone | Bridge |
 |------|:---:|:---:|
-| **Keyword** — `click "Sign in"`, `goto https://...` | ✅ | ✅ |
-| **Playwright API / JS** — `await page.title()`, `1 + 1` | ❌ | ✅ auto-detected |
+| **Keyword** — `click "Sign in"`, `goto https://...` | Yes | Yes |
+| **Playwright API / JS** — `await page.title()`, `1 + 1` | No | Yes (auto-detected) |
 
-Bridge mode auto-detects Playwright API and JavaScript expressions — just type them directly. For DOM access use `await page.evaluate(() => document.title)`. For the full keyword command list, see [Command Reference](#command-reference).
+Bridge mode auto-detects Playwright API and JavaScript expressions. For DOM access use `await page.evaluate(() => document.title)`. For keyword commands, see [Command Reference](#command-reference).
 
 ## CLI Options
 
@@ -127,7 +127,7 @@ Bridge mode auto-detects Playwright API and JavaScript expressions — just type
 
 ## Recording & Replay
 
-Record your browser interactions and replay them later — great for regression tests, onboarding demos, or CI smoke tests.
+Record browser interactions and replay them later — great for regression tests, onboarding demos, or CI smoke tests.
 
 ### Record
 
@@ -139,9 +139,9 @@ playwright-repl --record my-test.pw --headed
 pw> .record my-test
 ⏺ Recording to my-test.pw
 pw> goto https://demo.playwright.dev/todomvc/
-pw> fill "What needs to be done?" "Buy groceries"
+pw> fill "What needs to be done?" Buy groceries
 pw> press Enter
-pw> verify-text "1 item left"
+pw> verify text 1 item left
 pw> .save
 ✓ Saved 4 commands to my-test.pw
 ```
@@ -162,7 +162,7 @@ playwright-repl --replay examples/ --silent
 pw> .replay my-test.pw
 ```
 
-Multi-file replay runs all files sequentially, writes a `replay-<timestamp>.log` with per-command results, and prints a pass/fail summary. Exit code 0 if all pass, 1 if any fail.
+Multi-file replay runs all files sequentially, writes a `replay-<timestamp>.log`, and prints a pass/fail summary. Exit code 0 if all pass, 1 if any fail.
 
 ### .pw File Format
 
@@ -173,10 +173,10 @@ Plain text — human-readable, diffable, version-controllable:
 # App: https://demo.playwright.dev/todomvc/
 
 goto https://demo.playwright.dev/todomvc/
-fill "What needs to be done?" "Buy groceries"
+fill "What needs to be done?" Buy groceries
 press Enter
-verify-text "Buy groceries"
-verify-text "1 item left"
+verify text Buy groceries
+verify text 1 item left
 ```
 
 ## Examples
@@ -200,7 +200,7 @@ playwright-repl --replay examples/ --silent
 ## Requirements
 
 - Node.js >= 20
-- `playwright` >= 1.59.0-alpha (browser binaries only needed for standalone mode)
+- `playwright` >= 1.59
 
 ---
 
@@ -273,11 +273,11 @@ pw> highlight --clear                # dismiss the highlight overlay
 
 | Command | Alias | Description |
 |---------|-------|-------------|
-| `verify-text <text>` | `vt` | Verify text is visible on page |
-| `verify-no-text <text>` | `vnt` | Verify text is not visible |
-| `verify-element <role> <name>` | `ve` | Verify element exists by role and name |
-| `verify-value <ref> <value>` | `vv` | Verify input/select/checkbox value |
-| `verify-list <ref> <items>` | `vl` | Verify list contains expected items |
+| `verify text <text>` | `vt` | Verify text is visible on page |
+| `verify no-text <text>` | `vnt` | Verify text is not visible |
+| `verify element <role> <name>` | `ve` | Verify element exists by role and name |
+| `verify value <ref> <value>` | `vv` | Verify input/select/checkbox value |
+| `verify list <ref> <items>` | `vl` | Verify list contains expected items |
 
 ### Tabs
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "playwright-repl",
   "version": "0.20.0",
-  "description": "Interactive REPL for Playwright browser automation — keyword-driven testing from your terminal",
+  "description": "Interactive REPL for Playwright — keyword commands, recording, and replay",
   "type": "module",
   "bin": {
     "playwright-repl": "./dist/playwright-repl.js"

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,62 +1,20 @@
 # @playwright-repl/core
 
-Shared engine, parser, and utilities for the playwright-repl monorepo.
+Shared parser, servers, and utilities for the playwright-repl ecosystem.
 
-Used by [`playwright-repl`](../cli/README.md) (CLI) and [`@playwright-repl/mcp`](../mcp/README.md) (MCP server).
+Used by [`playwright-repl`](../cli/README.md) (CLI), [`@playwright-repl/runner`](../runner/README.md) (runner), and [`@playwright-repl/mcp`](../mcp/README.md) (MCP server).
 
 ## Install
 
 ```bash
-npm install @playwright-repl/core playwright
+npm install @playwright-repl/core
 ```
-
-> Requires `playwright >= 1.59.0-alpha` (includes `lib/mcp/browser/` engine internals).
 
 ## Key Exports
 
-### `Engine`
-
-Runs Playwright's browser backend in-process. No daemon, no socket — commands execute directly.
-
-```typescript
-import { Engine } from '@playwright-repl/core';
-
-const engine = new Engine();
-await engine.start({ headed: true });
-
-const result = await engine.run({ _: ['goto', 'https://example.com'] });
-console.log(result.text);
-
-const snap = await engine.run({ _: ['snapshot'] });
-console.log(snap.text);
-
-await engine.close();
-```
-
-**`EngineOpts`** (passed to `start()`):
-
-| Option | Type | Description |
-|--------|------|-------------|
-| `headed` | `boolean` | Visible browser window |
-| `browser` | `string` | `chrome`, `firefox`, `webkit`, `msedge` |
-| `persistent` | `boolean` | Persistent browser profile |
-| `profile` | `string` | Profile directory path |
-
-**`EngineResult`**:
-
-```typescript
-interface EngineResult {
-  text?: string;   // Text output (accessibility tree, command result, error message)
-  image?: string;  // Base64 data URL for screenshot commands
-  isError?: boolean;
-}
-```
-
----
-
 ### `BridgeServer`
 
-WebSocket server that the Dramaturg Chrome extension connects to. Used by the CLI (`--bridge`) and MCP server.
+WebSocket server that the Dramaturg Chrome extension connects to. Used by the CLI (`--bridge`), MCP server, and `pw repl-extension`.
 
 ```typescript
 import { BridgeServer } from '@playwright-repl/core';
@@ -80,12 +38,27 @@ await bridge.close();
 | Method | Description |
 |--------|-------------|
 | `start(port?)` | Start WebSocket server (default port `9876`) |
-| `run(command)` | Send a command string to the extension, returns `EngineResult` |
+| `run(command)` | Send a command to the extension, returns `EngineResult` |
+| `runScript(script, language)` | Send a multi-line script (`'pw'` or `'javascript'`) |
 | `waitForConnection(timeoutMs?)` | Wait until extension connects (default 30s) |
 | `onConnect(fn)` | Callback when extension connects |
 | `onDisconnect(fn)` | Callback when extension disconnects |
-| `connected` | `boolean` — whether extension is currently connected |
+| `connected` | `boolean` — whether extension is connected |
 | `close()` | Shut down the server |
+
+---
+
+### `CommandServer`
+
+HTTP server for external command execution. Used by `--server` mode (AI agents) and extension mode.
+
+**Endpoints:**
+
+| Endpoint | Description |
+|----------|-------------|
+| `POST /run` | Execute a command via `engine.run()` |
+| `POST /select-tab` | Switch active page by URL |
+| `GET /health` | Server status check |
 
 ---
 
@@ -123,17 +96,33 @@ const items = buildCompletionItems();
 
 ---
 
+## Types
+
+```typescript
+interface EngineResult {
+  text?: string;     // Text output (accessibility tree, command result, error)
+  image?: string;    // Base64 data URL (screenshot commands)
+  isError?: boolean;
+}
+
+interface ParsedArgs {
+  _: string[];       // Positional arguments
+  [key: string]: unknown;  // Named flags
+}
+```
+
 ## File Structure
 
 ```
 src/
-├── engine.ts           # In-process Playwright backend (Engine class)
-├── bridge-server.ts    # WebSocket bridge server (BridgeServer class)
-├── extension-server.ts # HTTP command server (CommandServer class — internal)
+├── bridge-server.ts    # WebSocket bridge server (BridgeServer)
+├── extension-server.ts # HTTP command server (CommandServer)
 ├── parser.ts           # Command parsing + alias resolution
-├── page-scripts.ts     # Text locators + assertion helpers (serializable fns)
+├── page-scripts.ts     # Text locators + assertion helpers
 ├── completion-data.ts  # Autocomplete items for all commands
+├── filter.ts           # Response filtering
 ├── resolve.ts          # COMMANDS map, minimist re-export, version
 ├── colors.ts           # ANSI color helpers
+├── types.ts            # Shared type definitions
 └── index.ts            # Public exports
 ```

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@playwright-repl/core",
+  "description": "Shared parser, servers, and utilities for playwright-repl",
   "version": "0.20.0",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/extension/README.md
+++ b/packages/extension/README.md
@@ -1,26 +1,18 @@
-# <img src="public/icons/dramaturg_icon_128.png" width="48" height="48" align="center"> Dramaturg (@playwright-repl/extension)
+# <img src="public/icons/dramaturg_icon_128.png" width="48" height="48" align="center"> Dramaturg
 
-Chrome side panel extension that runs the full Playwright API directly inside your browser — no Node.js backend, no external server required. Use it as a standalone automation console, or connect it to the CLI for terminal-driven control.
+Chrome side panel extension that runs the full Playwright API directly inside your browser — no Node.js backend required. Use it as a standalone console, or connect it to the CLI / MCP server.
 
 | Feature | Description |
 |---------|-------------|
-| 🧠 **Mode Detection** | Console auto-detects input type — `.pw` keyword or Playwright API / JavaScript (`await page.*`, `1 + 1`) — no prefix needed |
-| 🎬 **Record** | Capture clicks, fills, and navigations — generates `.pw` commands and JS Playwright code, inserted into the editor live |
-| ▶ **Run** | Run scripts line-by-line with pass/fail gutter indicators |
-| 🐛 **Debug** | Step Over / Step Into / Step Out / Continue with breakpoints, inline variable values, and a Variables tab showing scope variables |
-| 📂 **Load / Save** | Open `.pw` or `.js` files from disk; save editor content with one click |
-| 🔗 **Auto-attach** | Automatically attaches to the active tab when the panel opens |
-| 🗂 **Tab Switcher** | Switch the active browser target to any open tab from the toolbar dropdown |
-| 🌳 **Object Tree** | Console results render as an expandable object tree with lazy property loading |
-| 🖼 **Screenshot Preview** | Screenshot commands display the image inline; click to expand full-size |
-| 🌳 **Snapshot Tree** | `snapshot` renders as an expandable accessibility tree — click nodes to expand/collapse |
-| ✨ **Autocomplete** | `.pw` keyword and Playwright API (`page.*`, `expect()`) ghost-text suggestions in both console and editor |
-| 📖 **Help** | `help` shows categorized commands; `help click` for per-command help; `help js` for Playwright API reference |
-| ⚙️ **Preferences** | Default language mode (`.pw` or JS), bridge port, and open mode — configurable in Options |
-| 🌗 **Light / Dark Mode** | Toggle between light and dark themes from the toolbar, persisted across sessions |
-| 🪟 **Side Panel & Popup** | Opens as a Chrome side panel by default; switch to a standalone popup window in Options |
-| 🔧 **DevTools REPL** | Console-only REPL tab in Chrome DevTools — always available alongside Elements/Network for quick debugging |
-| ⚡ **Fast** | Commands execute directly via CDP in the service worker — no Node.js roundtrip, near-instant response |
+| **Console** | Auto-detects input type — `.pw` keywords or Playwright API / JavaScript |
+| **Script Editor** | Syntax highlighting, pass/fail gutter, autocomplete, run/step/stop |
+| **JS Debugger** | Breakpoints, step over/into/out, variables with scope inspection |
+| **Recorder** | Captures clicks, fills, navigations as `.pw` commands and Playwright code |
+| **Object Tree** | Expandable CDP object tree, like Chrome DevTools |
+| **Tab Switcher** | Switch active target to any open tab from the toolbar |
+| **Preferences** | Language mode, bridge port, open mode — configurable in Options |
+| **Light / Dark** | Toggle themes from toolbar, persisted across sessions |
+| **DevTools REPL** | Console-only tab in Chrome DevTools for quick debugging |
 
 ## Setup
 
@@ -29,13 +21,11 @@ Chrome side panel extension that runs the full Playwright API directly inside yo
    npm run build   # from packages/extension/
    ```
    Then open `chrome://extensions` → enable **Developer mode** → **Load unpacked** → select `packages/extension/dist/`
-3. Click the **Dramaturg** icon to open the side panel (or popup — configure in Options)
+2. Click the **Dramaturg** icon to open the side panel
 
-## Features
+## Console
 
-### Console — two input modes, one input
-
-The Console tab auto-detects what you type and routes it to the right executor:
+Auto-detects what you type and routes it to the right executor:
 
 | What you type | Mode | Runs in |
 |---|---|---|
@@ -53,143 +43,86 @@ The Console tab auto-detects what you type and routes it to the right executor:
 → "Playwright"
 ```
 
-JS mode runs in an async context, so top-level `await` works naturally — along with promises, template literals, variables, and more:
+JS mode runs in an async context — top-level `await`, promises, template literals, variables, and IIFEs all work naturally.
 
-```
-> const title = await page.title()               ← top-level await + const
-→ "Playwright"
+Results render as an **expandable object tree** — click any object to lazily fetch its properties.
 
-> `The title is: ${title}`                        ← template literals
-→ "The title is: Playwright"
-
-> await fetch('https://api.example.com').then(r => r.json())   ← promises
-→ { status: "ok" }
-
-> let items = await page.locator('li').all()      ← let (scoped per input)
-> items.length
-→ 5
-
-> (() => { let sum = 0; for (let i = 0; i < 10; i++) sum += i; return sum })()   ← IIFE
-→ 45
-
-> (async () => {                                  ← async IIFE (multi-line)
-    const el = await page.locator('h1');
-    return (await el.textContent()).toUpperCase();
-  })()
-→ "PLAYWRIGHT"
-```
-
-Results are rendered as an **expandable object tree** — click any object to lazily fetch its properties, just like Chrome DevTools.
-
-- **Command history** — Up/Down arrows cycle through previous commands
-- **Autocomplete** — `.pw` keyword and Playwright API (`page.*`, `expect()`) ghost-text suggestions
+- **Command history** — Up/Down arrows
+- **Autocomplete** — `.pw` keyword and Playwright API ghost-text suggestions
 - **Screenshot preview** — inline image with click-to-expand lightbox
 - **Ctrl+L / `.clear`** — clear console output
 
-### Script Editor
+## Script Editor
 
-Write and run multi-line `.pw` scripts or JavaScript (Playwright API, DOM) directly in the panel:
+Write and run multi-line `.pw` scripts or JavaScript directly in the panel:
 
 - **Syntax highlighting** — `.pw` keywords, strings, comments; full JS highlighting in JS mode
-- **Autocomplete** — Playwright API ghost-text suggestions in JS mode; `.pw` keyword suggestions in keyword mode
-- **Auto-closing brackets** — parentheses, brackets, and quotes close automatically
-- **Pass/fail gutter** — ✓/✗ markers per line after execution
+- **Autocomplete** — Playwright API and keyword ghost-text suggestions
+- **Pass/fail gutter** — check/cross markers per line after execution
 - **Run / Step / Stop** — run all lines, step through one at a time, or abort
-- **JS step debugger** — pauses at each line with inline variable values, resumes on Step
+- **JS debugger** — pauses at each line with inline variable values
 - **Open / Save** — load `.pw` or `.js` files from disk; save with timestamp filename
 - **Ctrl+Enter** — run the script from keyboard
 
-### Recording
+## Recording
 
-Click **Record**, interact with the page — clicks, hovers, fills, and navigations are captured automatically and inserted into the editor at the cursor in two formats:
+Click **Record**, interact with the page — clicks, hovers, fills, and navigations are captured and inserted into the editor at the cursor:
 
-- **`.pw` commands** — `goto`, `click`, `fill`, `press` — ready to replay with the CLI or extension
-- **JS Playwright code** — `await page.click(...)` — ready to paste into a Playwright test
+- **`.pw` commands** — `goto`, `click`, `fill`, `press` — ready to replay
+- **JS Playwright code** — `await page.click(...)` — ready to paste into a test
 
-Ambiguous elements are automatically disambiguated with ancestor context (e.g. `click "Save" --in "Settings"`).
+Ambiguous elements are disambiguated with ancestor context (e.g. `click "Save" --in "Settings"`).
 
-> Recording captures only human interactions — not AI-driven or programmatic commands.
-
-### Tab Management
+## Tab Management
 
 - **Tab switcher dropdown** — lists all open tabs; switch active target without leaving the panel
 - **Auto-attach** — attaches to the active tab automatically when the panel opens
-- **Connection status** — color-coded indicator (green / yellow / red) with tooltip
-- **Attach button** — manually re-attach after tab navigation or detach
-
-### Preferences
-
-- **Bridge port** — configure the WebSocket port for CLI / MCP server connection (default `9876`)
-- **Open mode** — side panel (default) or popup window
-- **Dark mode toggle** — sun/moon button in toolbar, persisted across sessions
+- **Connection status** — color-coded indicator (green / yellow / red)
+- **Attach button** — manually re-attach after tab navigation
 
 ## Connect to CLI (Bridge Mode)
 
-The extension can act as the browser end of a CLI terminal session:
+The extension connects to the CLI bridge server automatically:
 
 ```bash
 playwright-repl --bridge   # start the CLI bridge server
 ```
 
-The extension connects automatically — no need to open the side panel. Your terminal becomes a remote console for the browser — type commands in the CLI, they execute in your real Chrome session.
+Your terminal becomes a remote console for the browser — commands execute in your real Chrome session.
 
 See [packages/cli/README.md](../cli/README.md) for CLI setup.
 
 ## Connect to MCP Server (AI Browser Agent)
 
-The extension also connects to the `@playwright-repl/mcp` server, letting AI agents like Claude control your real browser:
+The extension connects to the `@playwright-repl/mcp` server for AI-driven automation:
 
 ```bash
 npm install -g @playwright-repl/mcp
 playwright-repl-mcp   # starts the MCP bridge server
 ```
 
-The extension connects automatically — no side panel needed. The AI agent can then call `run_command` to execute single commands, or `run_script` to run multi-line scripts in your real Chrome session.
-
-See [packages/mcp/README.md](../mcp/README.md) for full MCP setup and Claude Desktop / Claude Code configuration.
+See [packages/mcp/README.md](../mcp/README.md) for MCP setup.
 
 ## What Makes This Unique
 
-Most browser automation tools require a Node.js backend. This extension runs the full Playwright API — `page`, `context`, `expect`, locators, assertions — entirely inside Chrome, with zero backend.
+Most browser automation tools require a Node.js backend. This extension runs Playwright — `page`, `context`, `expect`, locators, assertions — entirely inside Chrome.
 
 | | Node + Playwright | Chrome DevTools | **Dramaturg** |
 |---|---|---|---|
-| Runs Playwright | ✅ Node process | ❌ | ✅ Service worker |
-| Full `page.*` API | ✅ | ❌ | ✅ |
-| `expect()` in console | ✅ (test runner only) | ❌ | ✅ interactively |
-| JS in page context | via `page.evaluate` | ✅ | ✅ |
-| CDP object tree | ❌ | ✅ | ✅ |
-| Real attached tab | ❌ (separate launch) | ✅ | ✅ |
-
-### Performance
-
-Commands execute directly via CDP in the service worker — no Node.js roundtrip. Enable `log time on` in the console to see execution times.
-
-| Command | Time |
-|---------|------|
-| `goto https://demo.playwright.dev/todomvc` | 305ms |
-| `snapshot` | 6ms |
-| `fill "What needs to be done?" "Buy milk"` | 14ms |
-| `press Enter` | 12ms |
-| `screenshot` | 87ms |
-| `hover "What needs to be done?"` | 38ms |
-| `click "Walk dog"` | 33ms |
-| `console` | 4ms |
-| `network` | 4ms |
-| `tab-list` | 4ms |
-| `go-back` | 196ms |
-
----
+| Runs Playwright | Node process | No | Service worker |
+| Full `page.*` API | Yes | No | Yes |
+| `expect()` in console | Test runner only | No | Yes, interactively |
+| JS in page context | via `page.evaluate` | Yes | Yes |
+| CDP object tree | No | Yes | Yes |
+| Real attached tab | No (separate launch) | Yes | Yes |
 
 ## Architecture
 
-### How it works
-
 Two technologies make Playwright run inside the browser:
 
-**1. playwright-crx** — replaces Playwright's CDP WebSocket with `chrome.debugger`, allowing the full Playwright API to run inside a Chrome extension's service worker. When you open the panel, `crxApp.attach(tabId)` connects to the active tab and sets `page`, `context`, and `expect` as live globals in the service worker.
+**1. playwright-crx** — replaces Playwright's CDP WebSocket with `chrome.debugger`, enabling the full Playwright API inside a Chrome extension's service worker.
 
-**2. swDebugEval** — the panel and service worker are separate JS contexts. To call Playwright objects, the panel uses `chrome.debugger` a second time — attaching to the service worker itself and evaluating expressions in its runtime, where the live Playwright globals exist.
+**2. swDebugEval** — the panel evaluates expressions in the service worker's runtime via `chrome.debugger`, where live Playwright globals (`page`, `context`, `expect`) exist.
 
 ### Command Execution Pipeline
 
@@ -200,7 +133,6 @@ Side Panel (React)
         ▼
   commands.ts — parseReplCommand()
   Compiles keyword → jsExpr string
-  "click Submit" → "return await refAction(page, 'Submit', 'click')"
         │
         ▼
   bridge.ts — executeCommand()
@@ -214,55 +146,29 @@ Side Panel (React)
   Chrome tab
 ```
 
-### background.ts — Lifecycle + Bridge
+### background.ts — Message Types
 
 | Message type | Action |
 |---|---|
-| `bridge-command` | Parses and executes CLI/MCP commands via self-debug eval |
-| `attach` | `crxApp.attach(tabId)` — connects playwright-crx to the tab |
-| `record-start` | Injects recorder into the active tab |
-| `record-stop` | Disconnects recorder port |
+| `bridge-command` | Parses and executes CLI/MCP commands |
+| `attach` | `crxApp.attach(tabId)` — connects to tab |
+| `record-start` | Injects recorder into active tab |
+| `record-stop` | Disconnects recorder |
 | `health` | Returns `{ ok: !!crxApp }` |
-| `get-bridge-port` | Returns bridge port from `chrome.storage` (for offscreen doc) |
-
-### File Structure
-
-```
-src/
-├── background.ts           # Service worker — lifecycle (attach, record, health, CDP)
-├── commands.ts             # Keyword → jsExpr compiler
-├── page-scripts.ts         # Serializable helper functions (locators, assertions, tabs)
-└── panel/
-    ├── panel.html
-    ├── panel.tsx           # React root
-    ├── App.tsx             # Root component — auto-attach, tab listener
-    ├── reducer.ts          # useReducer — console lines, loading state
-    ├── components/
-    │   ├── Toolbar.tsx     # Record button, attach status, tab switcher
-    │   ├── CommandInput.tsx # CodeMirror 6 REPL input with autocomplete + history
-    │   ├── ConsolePane.tsx  # Output lines
-    │   ├── EditorPane.tsx   # Multi-line script editor
-    │   └── Console/        # Object tree renderer
-    └── lib/
-        ├── bridge.ts       # executeCommand — parses + calls swDebugEval
-        ├── run.ts          # runAndDispatch — local commands + bridge + dispatch
-        ├── sw-debugger.ts  # swDebugEval — chrome.debugger evaluation in SW context
-        ├── cm-input-setup.ts # CodeMirror 6 extensions (autocomplete, keymaps, history)
-        ├── command-history.ts # Persistent localStorage command history
-        └── filter.ts       # Response filtering
-```
+| `get-bridge-port` | Returns bridge port from `chrome.storage` |
 
 ## Build & Test
 
 ```bash
-# Build
 cd packages/extension
+
+# Build
 npm run build
 
 # Unit tests (Vitest browser mode)
 npm run test
 
-# E2E tests (Playwright — loads real extension in Chromium)
+# E2E tests (Playwright)
 npm run test:e2e
 npx playwright test e2e/panel
 npx playwright test e2e/commands

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -2,7 +2,7 @@
   "name": "@playwright-repl/extension",
   "version": "0.20.0",
   "private": true,
-  "description": "Chrome DevTools panel extension for Playwright REPL",
+  "description": "Dramaturg — Chrome extension with console, recorder, and element picker",
   "type": "module",
   "scripts": {
     "build": "vite build",

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -140,7 +140,7 @@ Dramaturg is the other half of the system — it's what gives the MCP server acc
 
 ### What the extension does
 
-- **Runs Playwright inside Chrome** — uses `playwright-crx` and `chrome.debugger` to execute commands directly in your existing session, no separate browser needed. Because Playwright runs inside the browser rather than relaying through an external process, the entire AI → command → result loop is faster.
+- **Runs Playwright inside Chrome** — uses `playwright-crx` and `chrome.debugger` to execute commands directly in your existing session, no separate browser needed.
 - **Connects automatically** — a persistent offscreen document maintains the WebSocket connection to the MCP server; reconnects if the connection drops. No side panel needed.
 - **Auto-attaches** — on the first command, automatically attaches to the active Chrome tab
 - **Executes commands** — receives `run_command` calls from the AI and runs them against the active tab

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,5 +1,6 @@
 {
     "name": "@playwright-repl/mcp",
+    "description": "MCP server — AI agents control your real Chrome browser",
     "version": "0.20.0",
     "type": "module",
     "bin": {

--- a/packages/runner/README.md
+++ b/packages/runner/README.md
@@ -1,140 +1,110 @@
 # @playwright-repl/runner
 
-Playwright test runner with faster execution via context reuse and bridge mode.
+Drop-in replacement for `npx playwright test` with context reuse. Keeps the browser open between tests — no teardown/recreate per test.
 
 ## Quick Start
 
 ```bash
-cd your-playwright-project
-pw test
+npm install -D @playwright-repl/runner
 ```
 
-## Benchmark
-
-CI results (todomvc, 26 tests, 1 worker):
-
-| Runner | Ubuntu | macOS | Windows |
-|--------|--------|-------|---------|
-| Playwright | 10.6s | 8.1s | 31.3s |
-| pw-cli | 5.8s | 6.9s | 6.0s |
-| Bridge direct | 4.8s | 4.3s | 3.6s |
-
-The speedup comes from **skipping per-test context creation**. Playwright creates a new browser context + page for each test (for isolation). `pw` reuses the same page across tests, making per-test overhead consistent regardless of OS.
-
-```
-Standard Playwright:
-  Test runner → new context → new page → CDP commands → close page
-  (per-test overhead: 150-525ms depending on OS)
-
-pw:
-  Test runner → bridge → reuse page → CDP commands
-  (per-test overhead: ~100ms, consistent across OS)
-```
-
-## Benefits
-
-- **1.5-2x faster** on all platforms, consistent ~100ms per test (Playwright varies: 150ms Linux → 525ms Windows)
-- **No context creation overhead** — reuses the same page, no `newPage()` per test
-- **Same test syntax** — standard `import { test, expect } from '@playwright/test'`, no code changes
-- **Automatic fallback** — tests using Node APIs (fs, route, etc.) fall back to Playwright's standard runner
-
-### Trade-offs
-
-- **No test isolation** — tests share state (localStorage, cookies). Tests must clean up after themselves
-- **Bridge mode limitations** — no `page.route()`, `page.waitForEvent()`, `page.$eval()`
-
-## CLI Usage
+Replace `npx playwright test` with `pw test`:
 
 ```bash
-pw test [options] [test-filter...]
+pw test                         # run all tests
+pw test todomvc/                # run tests in a folder
+pw test --workers 1             # single worker
+pw test --reporter list         # custom reporter
 ```
 
-### Options
+All Playwright CLI flags work — `pw` passes them through.
 
-| Option | Description | Default |
-|--------|-------------|---------|
-| `-c, --config <file>` | Playwright config file | `playwright.config.ts` |
-| `-g, --grep <pattern>` | Filter tests by name | |
-| `--headed` | Run with visible browser | headless |
-| `--workers <n>` | Number of workers | 1 |
-| `--timeout <ms>` | Per-test timeout | 30000 |
-| `--retries <n>` | Retry failed tests | 0 |
+## How It Works
 
-### Examples
+Standard Playwright creates a new browser context for every test. `pw test` reuses the same persistent browser context across tests in the same worker.
+
+- **Bridge mode** — compiles the test with esbuild, sends it to the Chrome extension for in-browser execution
+- **Node mode** — falls back to standard Playwright for tests that use Node-only APIs (fs, net, etc.)
+- **Automatic routing** — static analysis detects which mode each test needs
+
+## pw Commands
 
 ```bash
-# Run all tests
-pw test
+pw test [files...]                       # run Playwright tests with context reuse
+pw launch --port 9222                    # launch Chrome with extension + CDP port
+pw launch --port 9222 --bridge-port 9877 # custom bridge port
+pw launch --port 9222 --headless         # headless mode
+pw repl --port 9222                      # Node REPL with Playwright globals
+pw repl --port 9222 script.js            # run script, exit (browser stays alive)
+pw repl-extension --bridge-port 9877     # REPL via extension bridge
+pw close --port 9222                     # close browser
+```
 
-# Run specific file
-pw test tests/login.spec.ts
+### pw repl
 
-# Filter by name
-pw test --grep "login"
+Lightweight Node REPL with `page`, `context`, `browser`, and `expect` as globals. Powered by `node:repl` — full JavaScript with tab completion and history.
 
-# Headed mode (see the browser)
-pw test --headed
+```bash
+pw launch --port 9222
+pw repl --port 9222
+```
 
-# With config
-pw test --config playwright.config.ts
+```
+pw> await page.goto('https://example.com')
+pw> await page.title()
+Example Domain
+(3.2ms)
+pw> await page.locator('a').count()
+1
+(12.4ms)
+pw> 1 + 1
+2
+```
+
+### pw repl-extension
+
+REPL that routes commands through the Chrome extension bridge. Useful for testing the extension path.
+
+```bash
+pw launch --port 9222 --bridge-port 9877
+pw repl-extension --bridge-port 9877
+```
+
+## Options
+
+| Option | Description |
+|--------|-------------|
+| `--port <n>` | Chrome CDP port (default: 9222) |
+| `--bridge-port <n>` | BridgeServer WebSocket port (default: 9877) |
+| `--headless` | Launch browser in headless mode |
+
+All `pw test` options are passed through to Playwright.
+
+## CI Setup
+
+```yaml
+- name: Install
+  run: npm ci
+
+- name: Install browsers
+  run: npx playwright install --with-deps chromium
+
+- name: Run tests
+  run: npx pw test
 ```
 
 ## Compatibility
 
-Tests are standard Playwright — same `import { test, expect } from '@playwright/test'`, same API, same config. No code changes needed.
+Works with standard `@playwright/test` tests. No changes needed to your test files.
 
-### Supported
+**Supported:** All Playwright test features — fixtures, assertions, test.describe, test.beforeEach, etc.
 
-- `test`, `test.describe`, `test.only`, `test.skip`
-- `test.beforeEach`, `test.afterEach`, `test.beforeAll`, `test.afterAll`
-- `test.extend()` — custom fixtures
-- `page.*` — all Playwright page methods
-- `expect()` — all async matchers
-- `playwright.config.ts` — testDir, timeout, retries
-- TypeScript
-
-### Node Mode (full Playwright compatibility)
-
-Tests that use Node APIs (fs, process.env, .route(), etc.) automatically fall back to Playwright's standard runner with full support for:
-
-- Parallel workers (`--workers > 1`)
-- `test.use()` — per-test config
-- Projects
-- Custom reporters (HTML, JSON)
-- Global setup/teardown
-- Trace recording
-
-### Bridge Mode Limitations
-
-Bridge-mode tests (simple, no Node APIs) run faster but don't support:
-
-- `page.route()` / `page.waitForEvent()` / `page.waitForResponse()` — non-serializable callbacks
-- `page.$eval()` / `page.$$eval()` — callback-based APIs
-
-## CI Setup
-
-The runner needs both **Chromium** and **Chrome** browsers installed:
-
-```bash
-# Install browsers (CI)
-npx playwright install chromium chrome
-
-# Linux (with system deps)
-npx playwright install --with-deps chromium chrome
-```
-
-Both are required because `pw-cli` uses playwright-crx which runs inside Chrome with the extension loaded, while standard Playwright tests use Chromium.
+**Bridge mode limitations:** Tests that use Node-only APIs (`fs`, `net`, `child_process`) automatically fall back to Node mode.
 
 ## Development
 
 ```bash
-# Build
-pnpm --filter @playwright-repl/runner run build
-
-# Run examples
-cd examples
-node ../dist/cli.js test
-
-# Run single test
-node ../dist/cli.js test todomvc/adding-todos/should-add-single-todo.spec.ts
+cd packages/runner
+pnpm run build
+pnpm run test
 ```

--- a/packages/runner/package.json
+++ b/packages/runner/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@playwright-repl/runner",
   "version": "0.20.0",
-  "description": "Playwright test runner with faster bridge execution",
+  "description": "Drop-in Playwright test runner with context reuse",
   "type": "module",
   "bin": {
     "pw": "./dist/pw-cli.js"

--- a/packages/vscode/README.md
+++ b/packages/vscode/README.md
@@ -1,18 +1,20 @@
 # Playwright REPL for VS Code
 
-Interactive browser automation with **faster test execution**, a live REPL, and an assertion builder — all inside VS Code.
+Interactive browser automation inside VS Code — Test Explorer, live REPL, assertion builder, and element picker.
 
 ![Playwright REPL](images/hero.png)
 
 ## Features
 
-### Test Explorer with Bridge Execution
-Run Playwright tests directly through the bridge — **66ms per test** instead of 3+ seconds through the standard test runner. Works with individual tests and files. Folders fall back to the standard multi-worker path.
+### Test Explorer
+
+Run Playwright tests with a persistent browser and context reuse. Works with individual tests and files. Folders fall back to the standard multi-worker path.
 
 ![Test Explorer](images/test-explorer.png)
 
 ### REPL Panel
-Interactive command panel in the bottom bar. Type Playwright keyword commands (`snapshot`, `click`, `fill`, `goto`) or JavaScript (`await page.title()`, `page.locator('h1').click()`).
+
+Interactive command panel in the bottom bar. Type keyword commands (`snapshot`, `click`, `fill`, `goto`) or JavaScript (`await page.title()`, `page.locator('h1').click()`).
 
 - Command history (up/down arrows)
 - Inline screenshot display
@@ -23,41 +25,54 @@ Interactive command panel in the bottom bar. Type Playwright keyword commands (`
 ![REPL](images/repl.png)
 
 ### Locator Panel
+
 Pick elements from the browser and inspect their locator and ARIA snapshot.
 
 - **Pick arrow** — click to enter pick mode, click an element in the browser
-- **Highlight toggle** — highlight the picked element in the browser
+- **Highlight toggle** — highlight the picked element
 - **Editable locator** — modify and experiment
 - **ARIA snapshot** — accessibility tree for the picked element
 
 ![Locator](images/locator.png)
 
 ### Assert Builder
-Build and verify Playwright assertions interactively. Three-step workflow:
+
+Build and verify Playwright assertions interactively:
 
 1. **Pick Locator** — pick an element or type a locator manually
-2. **Select Matcher** — dropdown with 13 matchers, smart-filtered by element type
+2. **Select Matcher** — 13 matchers, smart-filtered by element type
 3. **Verify** — run the assertion against the live page, see pass/fail instantly
 
 Matchers: `toContainText`, `toHaveText`, `toBeVisible`, `toBeHidden`, `toBeAttached`, `toBeEnabled`, `toBeDisabled`, `toBeChecked`, `toHaveValue`, `toHaveAttribute`, `toHaveCount`, `toHaveURL`, `toHaveTitle`
 
-Supports negation (`not` checkbox) and editable assertions for tweaking.
+Supports negation (`not` checkbox) and editable assertions.
 
 ![Assert Builder](images/assert-builder.png)
 
 ### Recorder
-Record browser interactions as Playwright commands. Click elements, fill forms, navigate — the recorder captures each action.
+
+Record browser interactions as Playwright commands. Click elements, fill forms, navigate — the recorder captures each action as `.pw` keyword commands or Playwright JavaScript.
 
 ### Browser Reuse
-REPL, Test Explorer, Recorder, and Picker all share the same headed browser. No extra browser windows. The browser stays open between test runs.
+
+REPL, Test Explorer, Recorder, and Picker all share the same headed browser. No extra browser windows. The browser stays open between test runs — no context setup overhead per test.
+
+## Workflow
+
+**Record → Pick Locator → Assert → Run Test**
+
+1. **Record** interactions to generate test steps
+2. **Pick** elements to get locators
+3. **Assert** expected values against the live page
+4. **Run** tests through the Test Explorer
 
 ## Commands
 
 | Command | Description |
 |---------|-------------|
-| `Playwright REPL: Launch Browser` | Launch Chromium with bridge |
-| `Playwright REPL: Stop Browser` | Close browser and bridge |
-| `Playwright REPL: Open REPL` | Open the REPL terminal |
+| `Playwright REPL: Launch Browser` | Launch Chromium with extension |
+| `Playwright REPL: Stop Browser` | Close browser |
+| `Playwright REPL: Open REPL` | Open the REPL panel |
 | `Playwright REPL: Pick Locator` | Enter pick mode |
 | `Playwright REPL: Start Recording` | Start recording actions |
 | `Playwright REPL: Stop Recording` | Stop recording |
@@ -83,24 +98,12 @@ The extension adds three panels to the bottom bar:
 | Panel | Purpose |
 |-------|---------|
 | **REPL** | Interactive command execution |
-| **Locator** | Element inspection + highlight |
-| **Assert** | Assertion building + verification |
-
-## Performance
-
-Bridge execution skips the test-server subprocess entirely — compiles the test with esbuild and sends it directly to the browser. No `newPage()` overhead per test.
-
-| Scenario | Standard Playwright | Bridge (direct) |
-|----------|----------|-------------|
-| Single test | ~300ms (Linux), ~800ms (Windows) | **~100ms** |
-| todomvc (26 tests) | 8-10s (Linux), 31s (Windows) | **4-5s** |
-
-The speedup varies by platform because Playwright creates a new browser context per test. On Windows, `newPage()` takes ~525ms (OS process creation overhead); on Linux ~150ms. Bridge mode reuses the same page, so performance is consistent across platforms.
+| **Locator** | Element inspection and highlight |
+| **Assert** | Assertion building and verification |
 
 ## Development
 
 ```bash
-# Build
 cd packages/vscode
 pnpm run build
 

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@playwright-repl/vscode",
   "displayName": "Playwright REPL",
-  "description": "Faster Playwright test execution with interactive REPL, assertion builder, and element picker",
+  "description": "Playwright REPL for VS Code — Test Explorer, REPL, assert builder, and element picker",
   "icon": "images/playwright-logo.png",
   "version": "0.20.0",
   "private": true,


### PR DESCRIPTION
## Summary

- Full rewrite of all 7 READMEs (root, vscode, cli, runner, extension, mcp, core)
- Removed all speed/performance claims — benchmark (#464) proved bridge and CDP are same speed per-command
- Updated all package.json descriptions
- Focused messaging on three value props:
  - **DX workflow** — Record → Pick → Assert → Test
  - **Keyword simplicity** — `click e5` instead of `page.locator(...).click()`
  - **Multi-surface** — VS Code, terminal, Chrome extension, AI agents (MCP)
- Added `pw launch`/`pw repl`/`pw close` documentation to runner README
- Removed Engine docs from core README (Engine moved to CLI package)
- Net reduction: -168 lines

## Test plan

- [ ] All READMEs read cleanly with consistent structure
- [ ] No speed claims remain (grep for "faster", "ms", "performance", "benchmark")
- [ ] Build passes
- [ ] Package descriptions match README content

🤖 Generated with [Claude Code](https://claude.com/claude-code)