### PR TITLE
fix: folder click in Test Explorer skipped tests

### DIFF
--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -895,10 +895,19 @@ export class Extension implements RunHooks {
       parseAllResults: (text: string) => { status: string; duration: number; errors: { message: string }[] }[];
     };
 
-    // Collect test items — only use direct bridge for leaf test items (not folders/files)
+    // Collect test items — only use direct bridge for leaf test items (not folders)
     const items = request.include || [];
     if (!items.length)
       return false;
+
+    // If any top-level item is not a test file, fall back to test runner.
+    // Folders and non-test items are best handled by the standard multi-worker path.
+    for (const item of items) {
+      if (!item.uri)
+        return false;
+      if (!/\.(spec|test)\.[tj]sx?$/.test(item.uri.fsPath))
+        return false;
+    }
 
     // Collect leaf test items from request — expand files/describes into their children
     const fileToItems = new Map<string, vscodeTypes.TestItem[]>();


### PR DESCRIPTION
## Summary
- `_tryDirectBridge` treated folders as leaf test items when children hadn't loaded yet (lazy loading)
- It tried to compile the directory path as a test file, failed, but returned `true` — preventing `model.runTests` from running
- Fix: check URI path pattern (`.spec.ts`/`.test.ts`) instead of `children.size` to detect non-test items
- Folders now always fall back to the standard Playwright test runner

## Test plan
- [x] Click folder → tests run via Playwright runner (first click works)
- [x] Click file → bridge mode (if eligible)
- [x] Click individual test → bridge mode (if eligible)
- [x] Show Browser OFF + click folder → standard headless run

Closes #478

🤖 Generated with [Claude Code](https://claude.com/claude-code)