### PR TITLE
fix: detect browser close and clean up immediately

### DIFF
--- a/packages/vscode/src/browser.ts
+++ b/packages/vscode/src/browser.ts
@@ -101,10 +101,12 @@ export class BrowserManager {
     this._log.appendLine(`Chromium launched. wsEndpoint: ${this._browserServer.wsEndpoint()}`);
 
     this._browserServer.on('close', () => {
-      this._log.appendLine('Browser server closed.');
+      this._log.appendLine('Browser closed by user.');
       this._running = false;
       this._browserServer = undefined;
       this._browserContext = undefined;
+      // Clean up bridge and HTTP proxy in background
+      this.stop().catch(() => {});
     });
 
     // 4. Connect to get browser context for REPL


### PR DESCRIPTION
## Summary
When the user closes Chrome via the X button, immediately set `_running=false` and clear refs so the extension can relaunch without needing the manual "Stop Browser" command.

Closes #494

🤖 Generated with [Claude Code](https://claude.com/claude-code)