### PR TITLE
fix: detect browser close, CDP browser reuse improvements

### DIFF
--- a/packages/runner/src/cdpPreload.cts
+++ b/packages/runner/src/cdpPreload.cts
@@ -8,39 +8,45 @@
  * Safe no-op when connect() is called with a normal Playwright wsEndpoint.
  */
 
-import path = require('path');
+import Module = require('module');
 
-// Patch after modules are loaded — no Module._load hooks needed.
-setImmediate(() => {
-  let pw: any;
-  try {
-    const { createRequire } = require('module');
-    const projectRequire = createRequire(path.join(process.cwd(), 'package.json'));
-    pw = projectRequire('@playwright/test');
-  } catch {
-    try {
-      pw = require('@playwright/test');
-    } catch {
-      return;
-    }
+const origLoad = (Module as any)._load;
+let patched = false;
+
+(Module as any)._load = function (request: string, parent: unknown) {
+  const mod = origLoad.apply(this, arguments);
+
+  // Intercept playwright-core or @playwright/test to patch chromium.connect
+  if (!patched && (request === 'playwright-core' || request === '@playwright/test') && mod?.chromium?.connect && !mod.chromium.__pwReplPatched) {
+    patched = true;
+    (Module as any)._load = origLoad; // remove hook immediately
+
+    const origConnect = mod.chromium.connect.bind(mod.chromium);
+
+    mod.chromium.connect = async function(optionsOrWsEndpoint: any) {
+      const wsEndpoint = typeof optionsOrWsEndpoint === 'string'
+        ? optionsOrWsEndpoint
+        : optionsOrWsEndpoint?.wsEndpoint;
+
+      // Only intercept CDP URLs (from --remote-debugging-port)
+      if (!wsEndpoint || !wsEndpoint.includes('/devtools/browser/'))
+        return origConnect(optionsOrWsEndpoint);
+
+      const browser = await mod.chromium.connectOverCDP(wsEndpoint);
+      // Don't let the test runner kill our shared browser.
+      // Override both public close() and internal _close() to prevent
+      // the browser from being killed when the worker process exits.
+      browser.close = async () => {};
+      if (browser._close) browser._close = async () => {};
+      if (browser.disconnect) browser.disconnect = async () => {};
+      // Prevent the browser process from being killed via the connection
+      const conn = browser._connection || browser._browserConnection;
+      if (conn?.close) conn.close = () => {};
+      return browser;
+    };
+
+    mod.chromium.__pwReplPatched = true;
   }
 
-  if (!pw?.chromium?.connect || pw.chromium.__pwReplPatched)
-    return;
-
-  const origConnect = pw.chromium.connect.bind(pw.chromium);
-
-  pw.chromium.connect = async function(optionsOrWsEndpoint: any) {
-    const wsEndpoint = typeof optionsOrWsEndpoint === 'string'
-      ? optionsOrWsEndpoint
-      : optionsOrWsEndpoint?.wsEndpoint;
-
-    // Only intercept CDP URLs (from --remote-debugging-port)
-    if (!wsEndpoint || !wsEndpoint.includes('/devtools/browser/'))
-      return origConnect(optionsOrWsEndpoint);
-
-    return pw.chromium.connectOverCDP(wsEndpoint);
-  };
-
-  pw.chromium.__pwReplPatched = true;
-});
+  return mod;
+};

--- a/packages/vscode/src/browser.ts
+++ b/packages/vscode/src/browser.ts
@@ -24,6 +24,8 @@ export class BrowserManager {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   private _browserServer: any = undefined;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private _browser: any = undefined;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   private _browserContext: any = undefined;
   private _running = false;
   private _log: vscode.OutputChannel;
@@ -101,15 +103,19 @@ export class BrowserManager {
     this._log.appendLine(`Chromium launched. wsEndpoint: ${this._browserServer.wsEndpoint()}`);
 
     this._browserServer.on('close', () => {
-      this._log.appendLine('Browser server closed.');
+      this._log.appendLine('Browser closed by user.');
       this._running = false;
       this._browserServer = undefined;
       this._browserContext = undefined;
+      // Clean up bridge and HTTP proxy in background
+      this.stop().catch(() => {});
     });
 
     // 4. Connect to get browser context for REPL
-    const browser = await pw.chromium.connect(this._browserServer.wsEndpoint());
-    this._browserContext = browser.contexts()[0];
+    // Store browser ref to prevent GC from dropping the connection
+    // (launchServer kills Chrome when no clients are connected)
+    this._browser = await pw.chromium.connect(this._browserServer.wsEndpoint());
+    this._browserContext = this._browser.contexts()[0];
 
     // 5. Set bridge port via CDP on the extension's service worker
     await new Promise<void>(resolve => setTimeout(resolve, 2000));
@@ -215,6 +221,9 @@ export class BrowserManager {
     if (this._bridge) {
       await this._bridge.close().catch(() => {});
       this._bridge = undefined;
+    }
+    if (this._browser) {
+      this._browser = undefined;
     }
     if (this._browserContext) {
       this._browserContext = undefined;


### PR DESCRIPTION
## Summary
- Detect browser close (X button) and clean up immediately so relaunch works
- Store `_browser` ref to prevent GC dropping the Playwright connection
- cdpPreload: suppress `browser.close()`/`disconnect()` to prevent test runner from killing the shared browser
- Use `_extRequire` for `ws` module (not in user's project)
- Resolve workspace folder fallback in `_ensureBrowserManager`

## Known issue
Browser still closes after node-mode tests despite `browser.close()` suppression. Likely caused by CDP transport teardown when the worker process exits. Tracked separately.

## Test plan
- [x] Browser close detected when user clicks X
- [x] Bridge mode works (85ms single test)
- [x] CDP reuse works for node tests
- [x] `download.path()` works (CDP, not remote connect)
- [ ] Browser stays alive after tests (known issue)

Closes #494

🤖 Generated with [Claude Code](https://claude.com/claude-code)