### PR TITLE
fix: remove default google.com navigation from pw-launch

### DIFF
--- a/packages/runner/src/pw-launch.ts
+++ b/packages/runner/src/pw-launch.ts
@@ -81,10 +81,6 @@ export async function handleLaunch(argv: string[]): Promise<void> {
   }, bridgePort);
   console.log(`Bridge port ${bridgePort} set via service worker`);
 
-  // 3. Navigate initial page
-  const page = browserContext.pages()[0];
-  if (page) await page.goto('https://www.google.com');
-
   console.log(`Ready! CDP: ${port} | Bridge: ${bridgePort}`);
   console.log('Extension will connect when BridgeServer starts (pw repl-extension).');
 


### PR DESCRIPTION
## Summary
- Remove hardcoded `page.goto('https://www.google.com')` from runner's `pw-launch.ts`
- Browser starts at `about:blank` by default, no navigation needed

## Test plan
- [ ] Run `pw-launch` — browser should open at `about:blank` instead of google.com

🤖 Generated with [Claude Code](https://claude.com/claude-code)