### PR TITLE
chore: release v0.21.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,38 @@
 # Changelog
 
+## v0.21.0 — VS Code Extension, DevTools REPL & Runner
+
+**2026-03-31**
+
+### Features
+
+- **VS Code extension**: Full-featured Test Explorer integration with REPL, recorder, locator picker, and assert builder panels. ([#404](https://github.com/stevez/playwright-repl/pull/404)–[#439](https://github.com/stevez/playwright-repl/pull/439))
+- **pw CLI**: Drop-in `pw` command replaces `npx playwright test` with bridge-based execution — up to 35% faster on Linux/Windows. ([#361](https://github.com/stevez/playwright-repl/pull/361)–[#368](https://github.com/stevez/playwright-repl/pull/368))
+- **DevTools REPL panel**: Chrome DevTools now has a "Playwright" tab with re-attach on tab switch and attached URL indicator. ([#439](https://github.com/stevez/playwright-repl/pull/439), [#505](https://github.com/stevez/playwright-repl/pull/505), [#506](https://github.com/stevez/playwright-repl/pull/506))
+- **about:blank support**: Side panel and tab dropdown now support `about:blank` pages; `tab-new` opens `about:blank` by default. ([#507](https://github.com/stevez/playwright-repl/pull/507))
+- **CI benchmarks**: Automated Playwright vs pw-cli benchmark comparison in CI. ([#445](https://github.com/stevez/playwright-repl/pull/445))
+
+### Fixes
+
+- **Browser close detection**: Detect browser close and clean up immediately, handle CDP context reuse. ([#495](https://github.com/stevez/playwright-repl/pull/495), [#496](https://github.com/stevez/playwright-repl/pull/496), [#499](https://github.com/stevez/playwright-repl/pull/499))
+- **pw-cli outside monorepo**: Fix `pw` CLI to work outside the monorepo without Module._load hooks. ([#490](https://github.com/stevez/playwright-repl/pull/490))
+- **Playwright resolution**: Resolve playwright-core from user's project, not bundled copy. ([#487](https://github.com/stevez/playwright-repl/pull/487))
+- **VS Code headless hang**: Remove pw-preload from VS Code extension to fix headless hang. ([#483](https://github.com/stevez/playwright-repl/pull/483))
+- **Test Explorer folder click**: Fix folder click skipping tests via bridge. ([#482](https://github.com/stevez/playwright-repl/pull/482))
+- **Node tests browser reuse**: Node tests reuse browser via CDP, fix crash when browser not running. ([#480](https://github.com/stevez/playwright-repl/pull/480))
+- **Remove google.com default**: Remove hardcoded google.com navigation from pw-launch. ([#508](https://github.com/stevez/playwright-repl/pull/508))
+
+### Refactoring
+
+- **Simplify runner**: Remove pw-preload and pw-worker from runner package. ([#492](https://github.com/stevez/playwright-repl/pull/492))
+- **Engine to CLI**: Move Engine from core to cli, make core Playwright-free. ([#463](https://github.com/stevez/playwright-repl/pull/463))
+- **CDP_PORT constant**: Replace hardcoded port 9222 with CDP_PORT constant. ([#500](https://github.com/stevez/playwright-repl/pull/500))
+- **Shared sw-debugger-core**: Extract shared service worker debugger core for background.ts and panel. ([#442](https://github.com/stevez/playwright-repl/pull/442))
+
+### Docs
+
+- **README rewrite**: Rewrite all READMEs, remove speed claims, focus on DX. ([#471](https://github.com/stevez/playwright-repl/pull/471))
+
 ## v0.20.0 — MCP & Standalone Mode
 
 **2026-03-22**

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "playwright-repl",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "description": "Interactive REPL for Playwright — keyword commands, recording, and replay",
   "type": "module",
   "bin": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@playwright-repl/core",
   "description": "Shared parser, servers, and utilities for playwright-repl",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "type": "module",
   "main": "./dist/index.js",
   "exports": {

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@playwright-repl/extension",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "private": true,
   "description": "Dramaturg — Chrome extension with console, recorder, and element picker",
   "type": "module",

--- a/packages/extension/public/manifest.json
+++ b/packages/extension/public/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Dramaturg",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "description": "Playwright engineer's companion — console, editor, runner, debugger, and recorder in a Chrome side panel.",
   "permissions": [
     "activeTab",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@playwright-repl/mcp",
     "description": "MCP server — AI agents control your real Chrome browser",
-    "version": "0.20.0",
+    "version": "0.21.0",
     "type": "module",
     "bin": {
         "playwright-repl-mcp": "./dist/index.js"

--- a/packages/runner/package.json
+++ b/packages/runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@playwright-repl/runner",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "description": "Playwright test utilities — bridge-mode compilation, node detection, and CLI subcommands",
   "type": "module",
   "bin": {

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -3,7 +3,7 @@
   "displayName": "Playwright REPL",
   "description": "Playwright REPL for VS Code — Test Explorer, REPL, assert builder, and element picker",
   "icon": "images/playwright-logo.png",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "private": true,
   "publisher": "playwright-repl",
   "repository": {


### PR DESCRIPTION
## Summary
- Bump all packages from 0.20.0 to 0.21.0 (core, cli, extension, mcp, runner, vscode, manifest.json)
- Update CHANGELOG.md with v0.21.0 release notes

## Test plan
- [ ] CI passes
- [ ] Review CHANGELOG for accuracy

🤖 Generated with [Claude Code](https://claude.com/claude-code)