### PR TITLE
chore: release v0.21.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## v0.21.2 — npm Publish & VS Code Marketplace
+
+**2026-04-01**
+
+### Features
+
+- **VS Code Marketplace**: Published to the [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=playwright-repl.playwright-repl-vscode). ([#510](https://github.com/stevez/playwright-repl/issues/510))
+- **npm publish**: Published `@playwright-repl/core` and `@playwright-repl/runner` to npm.
+
+### Docs
+
+- **GIF demos**: Added animated GIFs for REPL, Locator, Assert Builder, Recorder, and Browser REPL. ([#514](https://github.com/stevez/playwright-repl/pull/514))
+- **VS Code README**: Screenshots, GIFs, Browser REPL section with Dramaturg link. ([#511](https://github.com/stevez/playwright-repl/pull/511), [#513](https://github.com/stevez/playwright-repl/pull/513), [#516](https://github.com/stevez/playwright-repl/pull/516))
+- **VS Code CHANGELOG**: Created for marketplace Changelog tab.
+
+### Fixes
+
+- **Recorder empty line**: Fixed recorder leaving an empty line gap when cursor is on a blank line. ([#514](https://github.com/stevez/playwright-repl/pull/514))
+- **Marketplace images**: Use absolute GitHub URLs for marketplace rendering. ([#517](https://github.com/stevez/playwright-repl/pull/517))
+
 ## v0.21.0 — VS Code Extension, DevTools REPL & Runner
 
 **2026-03-31**

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "playwright-repl",
-  "version": "0.21.0",
+  "version": "0.21.2",
   "description": "Interactive REPL for Playwright — keyword commands, recording, and replay",
   "type": "module",
   "bin": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@playwright-repl/core",
   "description": "Shared parser, servers, and utilities for playwright-repl",
-  "version": "0.21.0",
+  "version": "0.21.2",
   "type": "module",
   "main": "./dist/index.js",
   "exports": {

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@playwright-repl/extension",
-  "version": "0.21.0",
+  "version": "0.21.2",
   "private": true,
   "description": "Dramaturg — Chrome extension with console, recorder, and element picker",
   "type": "module",

--- a/packages/extension/public/manifest.json
+++ b/packages/extension/public/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Dramaturg",
-  "version": "0.21.0",
+  "version": "0.21.2",
   "description": "Playwright engineer's companion — console, editor, runner, debugger, and recorder in a Chrome side panel.",
   "permissions": [
     "activeTab",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@playwright-repl/mcp",
     "description": "MCP server — AI agents control your real Chrome browser",
-    "version": "0.21.0",
+    "version": "0.21.2",
     "type": "module",
     "bin": {
         "playwright-repl-mcp": "./dist/index.js"

--- a/packages/runner/package.json
+++ b/packages/runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@playwright-repl/runner",
-  "version": "0.21.0",
+  "version": "0.21.2",
   "description": "Playwright test utilities — bridge-mode compilation, node detection, and CLI subcommands",
   "type": "module",
   "bin": {

--- a/packages/vscode/CHANGELOG.md
+++ b/packages/vscode/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## 0.21.2
+
+**2026-04-01**
+
+### Fixes
+
+- Bundle `@playwright-repl/core` and `@playwright-repl/runner` as npm dependencies
+- Use absolute GitHub URLs for marketplace images
+- Light gallery banner to match icon background
+
+### Docs
+
+- Added GIF demos for REPL, Locator, Assert Builder, Recorder, and Browser REPL
+- Added Browser REPL section with Dramaturg Chrome extension features
+- Documented `.clear` and `.history` commands
+
 ## 0.21.0
 
 **2026-03-31**

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -4,10 +4,10 @@
   "description": "Playwright REPL for VS Code — Test Explorer, REPL, assert builder, and element picker",
   "icon": "images/dramaturg-icon.png",
   "galleryBanner": {
-    "color": "#1e1e1e",
-    "theme": "dark"
+    "color": "#ffffff",
+    "theme": "light"
   },
-  "version": "0.21.0",
+  "version": "0.21.2",
   "private": true,
   "publisher": "playwright-repl",
   "repository": {


### PR DESCRIPTION
## Summary
- Bump all packages to 0.21.2
- Update root and VS Code CHANGELOGs
- Prepare for npm publish of core and runner (needed for VS Code marketplace VSIX)

## Test plan
- [ ] CI passes
- [ ] npm publish core and runner after merge
- [ ] Republish VS Code extension without `--no-dependencies`

🤖 Generated with [Claude Code](https://claude.com/claude-code)