### PR TITLE
chore: release v0.21.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## v0.21.4 — VS Code Extension Fix
+
+**2026-04-01**
+
+### Fixes
+
+- **VS Code extension**: Bundle runtime dependencies (`@playwright-repl/core`, `@playwright-repl/runner`, `esbuild`) into VSIX so bridge-mode tests work for marketplace users. ([#524](https://github.com/stevez/playwright-repl/issues/524))
+- **Publish script**: Added `packages/vscode/publish.mjs` to automate VSIX packaging via temp directory (avoids pnpm/vsce symlink conflict). ([#524](https://github.com/stevez/playwright-repl/issues/524))
+- **Dependencies**: Moved `@babel/*`, `stack-utils`, `which` to devDependencies — already bundled by esbuild at build time.
+
 ## v0.21.2 — npm Publish & VS Code Marketplace
 
 **2026-04-01**

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "playwright-repl",
-  "version": "0.21.3",
+  "version": "0.21.4",
   "description": "Interactive REPL for Playwright — keyword commands, recording, and replay",
   "type": "module",
   "bin": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@playwright-repl/core",
   "description": "Shared parser, servers, and utilities for playwright-repl",
-  "version": "0.21.3",
+  "version": "0.21.4",
   "type": "module",
   "main": "./dist/index.js",
   "exports": {

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@playwright-repl/extension",
-  "version": "0.21.3",
+  "version": "0.21.4",
   "private": true,
   "description": "Dramaturg — Chrome extension with console, recorder, and element picker",
   "type": "module",

--- a/packages/extension/public/manifest.json
+++ b/packages/extension/public/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Dramaturg",
-  "version": "0.21.3",
+  "version": "0.21.4",
   "description": "Playwright engineer's companion — console, editor, runner, debugger, and recorder in a Chrome side panel.",
   "permissions": [
     "activeTab",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@playwright-repl/mcp",
     "description": "MCP server — AI agents control your real Chrome browser",
-    "version": "0.21.3",
+    "version": "0.21.4",
     "type": "module",
     "bin": {
         "playwright-repl-mcp": "./dist/index.js"

--- a/packages/runner/package.json
+++ b/packages/runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@playwright-repl/runner",
-  "version": "0.21.3",
+  "version": "0.21.4",
   "description": "Playwright test utilities — bridge-mode compilation, node detection, and CLI subcommands",
   "type": "module",
   "bin": {

--- a/packages/vscode/.vscodeignore
+++ b/packages/vscode/.vscodeignore
@@ -1,6 +1,6 @@
 src/**
-node_modules/**
 build.mjs
+publish.mjs
 tsconfig.json
 *.map
 test/**

--- a/packages/vscode/CHANGELOG.md
+++ b/packages/vscode/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.21.4
+
+**2026-04-01**
+
+### Fixes
+
+- Bundle runtime dependencies (`esbuild`, `@playwright-repl/core`, `@playwright-repl/runner`) into VSIX — bridge-mode tests now work for marketplace users
+- Move `@babel/*`, `stack-utils`, `which` to devDependencies (already bundled by esbuild)
+- Add `publish.mjs` script for automated VSIX packaging
+
 ## 0.21.2
 
 **2026-04-01**

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -7,7 +7,7 @@
     "color": "#ffffff",
     "theme": "light"
   },
-  "version": "0.21.3",
+  "version": "0.21.4",
   "private": true,
   "publisher": "playwright-repl",
   "repository": {
@@ -245,21 +245,20 @@
   },
   "scripts": {
     "build": "node build.mjs",
-    "watch": "node build.mjs --watch"
+    "watch": "node build.mjs --watch",
+    "package": "node publish.mjs",
+    "publish:vsce": "node publish.mjs publish"
   },
   "dependencies": {
+    "@playwright-repl/core": "workspace:*",
+    "@playwright-repl/runner": "workspace:*"
+  },
+  "devDependencies": {
     "@babel/core": "^7.23.2",
     "@babel/helper-plugin-utils": "^7.22.5",
     "@babel/plugin-proposal-decorators": "^7.24.7",
     "@babel/preset-typescript": "^7.23.2",
     "@babel/traverse": "^7.23.2",
-    "@playwright-repl/core": "^0.21.3",
-    "@playwright-repl/runner": "^0.21.3",
-    "stack-utils": "^2.0.6",
-    "which": "^4.0.0",
-    "ws": "^8.17.1"
-  },
-  "devDependencies": {
     "@types/babel__core": "^7.20.3",
     "@types/babel__helper-plugin-utils": "^7.10.2",
     "@types/babel__traverse": "^7.20.3",
@@ -269,6 +268,9 @@
     "@types/which": "^3.0.3",
     "@types/ws": "^8.5.3",
     "@vscode/vsce": "^3.7.1",
-    "esbuild": "^0.25.0"
+    "esbuild": "^0.25.0",
+    "stack-utils": "^2.0.6",
+    "which": "^4.0.0",
+    "ws": "^8.17.1"
   }
 }

--- a/packages/vscode/publish.mjs
+++ b/packages/vscode/publish.mjs
@@ -1,0 +1,84 @@
+#!/usr/bin/env node
+/**
+ * Publish VS Code extension to marketplace.
+ *
+ * Why a temp directory?  vsce uses npm internally and follows workspace
+ * symlinks, pulling the entire monorepo into the VSIX.  Copying to a
+ * standalone directory gives npm a clean install with no symlinks.
+ *
+ * Usage:
+ *   node scripts/publish-vscode.mjs          # package only (creates .vsix)
+ *   node scripts/publish-vscode.mjs publish  # package + publish to marketplace
+ */
+
+import { execSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+
+const VSCODE_PKG = import.meta.dirname;
+const ROOT = path.resolve(VSCODE_PKG, '..', '..');
+const publish = process.argv.includes('publish');
+
+function run(cmd, opts = {}) {
+  console.log(`\n> ${cmd}`);
+  execSync(cmd, { stdio: 'inherit', ...opts });
+}
+
+// ─── 1. Build monorepo ────────────────────────────────────────────────────
+console.log('=== Building monorepo ===');
+run('pnpm run build', { cwd: ROOT });
+run('node build.mjs', { cwd: VSCODE_PKG });
+
+// ─── 2. Copy to temp directory ────────────────────────────────────────────
+const tmpDir = path.join(os.tmpdir(), 'vscode-publish');
+if (fs.existsSync(tmpDir)) fs.rmSync(tmpDir, { recursive: true });
+fs.mkdirSync(tmpDir, { recursive: true });
+
+const items = [
+  'dist', 'chrome-extension', 'images', 'media', 'l10n',
+  'package.json', 'README.md', 'CHANGELOG.md', 'LICENSE', 'NOTICE',
+  '.vscodeignore',
+  // localization files
+  ...fs.readdirSync(VSCODE_PKG).filter(f => f.startsWith('package.nls')),
+];
+
+for (const item of items) {
+  const src = path.join(VSCODE_PKG, item);
+  if (!fs.existsSync(src)) continue;
+  const dest = path.join(tmpDir, item);
+  fs.cpSync(src, dest, { recursive: true });
+}
+
+// ─── 3. Resolve workspace:* refs to real versions ────────────────────────
+const pkg = JSON.parse(fs.readFileSync(path.join(tmpDir, 'package.json'), 'utf8'));
+for (const [name, ver] of Object.entries(pkg.dependencies || {})) {
+  if (ver.startsWith('workspace:')) {
+    const depPkg = JSON.parse(fs.readFileSync(path.join(ROOT, 'packages', name.split('/').pop(), 'package.json'), 'utf8'));
+    pkg.dependencies[name] = depPkg.version;
+  }
+}
+fs.writeFileSync(path.join(tmpDir, 'package.json'), JSON.stringify(pkg, null, 2) + '\n');
+
+console.log(`\n=== Copied to ${tmpDir} ===`);
+
+// ─── 4. npm install (clean, no symlinks) ──────────────────────────────────
+console.log('\n=== Installing dependencies ===');
+run('npm install --production', { cwd: tmpDir });
+
+// ─── 5. Package / Publish ─────────────────────────────────────────────────
+if (publish) {
+  console.log('\n=== Publishing to VS Code Marketplace ===');
+  run('npx @vscode/vsce publish', { cwd: tmpDir });
+} else {
+  console.log('\n=== Packaging VSIX ===');
+  run('npx @vscode/vsce package', { cwd: tmpDir });
+  // Copy VSIX back to packages/vscode
+  const vsix = fs.readdirSync(tmpDir).find(f => f.endsWith('.vsix'));
+  if (vsix) {
+    fs.cpSync(path.join(tmpDir, vsix), path.join(VSCODE_PKG, vsix));
+    console.log(`\nVSIX: packages/vscode/${vsix}`);
+  }
+}
+
+console.log('\nDone!');

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -216,6 +216,13 @@ importers:
 
   packages/vscode:
     dependencies:
+      '@playwright-repl/core':
+        specifier: workspace:*
+        version: link:../core
+      '@playwright-repl/runner':
+        specifier: workspace:*
+        version: link:../runner
+    devDependencies:
       '@babel/core':
         specifier: ^7.23.2
         version: 7.29.0
@@ -231,22 +238,6 @@ importers:
       '@babel/traverse':
         specifier: ^7.23.2
         version: 7.29.0
-      '@playwright-repl/core':
-        specifier: ^0.21.3
-        version: 0.21.3
-      '@playwright-repl/runner':
-        specifier: ^0.21.3
-        version: 0.21.3(@playwright/test@1.58.2)
-      stack-utils:
-        specifier: ^2.0.6
-        version: 2.0.6
-      which:
-        specifier: ^4.0.0
-        version: 4.0.0
-      ws:
-        specifier: ^8.17.1
-        version: 8.19.0
-    devDependencies:
       '@types/babel__core':
         specifier: ^7.20.3
         version: 7.20.5
@@ -277,6 +268,15 @@ importers:
       esbuild:
         specifier: ^0.25.0
         version: 0.25.12
+      stack-utils:
+        specifier: ^2.0.6
+        version: 2.0.6
+      which:
+        specifier: ^4.0.0
+        version: 4.0.0
+      ws:
+        specifier: ^8.17.1
+        version: 8.19.0
 
 packages:
 
@@ -1075,18 +1075,9 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
-  '@playwright-repl/core@0.21.3':
-    resolution: {integrity: sha512-F1VdFaey6IxAGvV3Cqw/2zJjwlMpgPuabYDRjc0SXBlVGlV6dVE6h6YwQCeLo5Tf1eBPchTzfRPETOvJZENOag==}
-
   '@playwright-repl/playwright-crx@0.15.3':
     resolution: {integrity: sha512-sxcJMHhCf/4uLXoB5J1dd1riRWc7BoO/VcOtqixL41jqMcYewrX2photoyoUqbbqlS+uriNP2SyeCyhSLTg36Q==}
     engines: {node: '>=18'}
-
-  '@playwright-repl/runner@0.21.3':
-    resolution: {integrity: sha512-NHKrDI3fH/jgwOc0qHtzTqri9d8iB3/iDmWxekdMy/zFwjDmeKCGx8K5JfQIyGY8u2n3x4htim9Rq6y9PWok4g==}
-    hasBin: true
-    peerDependencies:
-      '@playwright/test': '>=1.57.0'
 
   '@playwright/test@1.58.2':
     resolution: {integrity: sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==}
@@ -4286,28 +4277,7 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
 
-  '@playwright-repl/core@0.21.3':
-    dependencies:
-      js-yaml: 4.1.1
-      minimist: 1.2.8
-      ws: 8.19.0
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
-
   '@playwright-repl/playwright-crx@0.15.3': {}
-
-  '@playwright-repl/runner@0.21.3(@playwright/test@1.58.2)':
-    dependencies:
-      '@playwright-repl/core': 0.21.3
-      '@playwright/test': 1.58.2
-      acorn: 8.16.0
-      acorn-walk: 8.3.5
-      esbuild: 0.25.12
-      magic-string: 0.30.21
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
 
   '@playwright/test@1.58.2':
     dependencies:


### PR DESCRIPTION
## Summary
- Add `packages/vscode/publish.mjs` — automated VSIX packaging via temp directory (avoids pnpm/vsce symlink conflict)
- Bundle runtime deps (`@playwright-repl/core`, `@playwright-repl/runner`, `esbuild`) into VSIX so bridge-mode tests work for marketplace users
- Move `@babel/*`, `stack-utils`, `which` to devDependencies (already bundled by esbuild at build time)
- Bump all packages to 0.21.4

Closes #524

## Test plan
- [x] `pnpm run package` produces valid VSIX (26MB)
- [x] Installed VSIX — bridge-mode test passes
- [x] Published to marketplace v0.21.4

🤖 Generated with [Claude Code](https://claude.com/claude-code)