### PR TITLE
chore: release v0.21.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## v0.21.5 — nft Packaging & Bridge Fallback
+
+**2026-04-01**
+
+### Features
+
+- **nft-based VSIX packaging**: Use @vercel/nft to trace runtime dependencies — VSIX reduced from 26 MB to 12.7 MB. Key insight: `readlink: null` prevents nft from following pnpm symlinks. ([#530](https://github.com/stevez/playwright-repl/pull/530))
+- **esbuild fallback**: Bridge-mode gracefully falls back to standard Playwright test runner when esbuild platform binary is not available. ([#530](https://github.com/stevez/playwright-repl/pull/530))
+
+### Fixes
+
+- **Static imports**: Changed `createRequire` calls for `ws` and `bridge-utils.cjs` to static imports — esbuild bundles ws inline, nft traces bridge-utils automatically.
+
 ## v0.21.4 — VS Code Extension Fix
 
 **2026-04-01**

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "playwright-repl",
-  "version": "0.21.4",
+  "version": "0.21.5",
   "description": "Interactive REPL for Playwright — keyword commands, recording, and replay",
   "type": "module",
   "bin": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@playwright-repl/core",
   "description": "Shared parser, servers, and utilities for playwright-repl",
-  "version": "0.21.4",
+  "version": "0.21.5",
   "type": "module",
   "main": "./dist/index.js",
   "exports": {

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@playwright-repl/extension",
-  "version": "0.21.4",
+  "version": "0.21.5",
   "private": true,
   "description": "Dramaturg — Chrome extension with console, recorder, and element picker",
   "type": "module",

--- a/packages/extension/public/manifest.json
+++ b/packages/extension/public/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Dramaturg",
-  "version": "0.21.4",
+  "version": "0.21.5",
   "description": "Playwright engineer's companion — console, editor, runner, debugger, and recorder in a Chrome side panel.",
   "permissions": [
     "activeTab",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@playwright-repl/mcp",
     "description": "MCP server — AI agents control your real Chrome browser",
-    "version": "0.21.4",
+    "version": "0.21.5",
     "type": "module",
     "bin": {
         "playwright-repl-mcp": "./dist/index.js"

--- a/packages/runner/package.json
+++ b/packages/runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@playwright-repl/runner",
-  "version": "0.21.4",
+  "version": "0.21.5",
   "description": "Playwright test utilities — bridge-mode compilation, node detection, and CLI subcommands",
   "type": "module",
   "bin": {

--- a/packages/vscode/CHANGELOG.md
+++ b/packages/vscode/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.21.5
+
+**2026-04-01**
+
+### Features
+
+- VSIX reduced from 26 MB to 12.7 MB using @vercel/nft dependency tracing
+- Bridge-mode falls back to standard test runner when esbuild is unavailable
+- Static imports for `ws` and `bridge-utils.cjs` — cleaner dependency resolution
+
 ## 0.21.4
 
 **2026-04-01**

--- a/packages/vscode/README.md
+++ b/packages/vscode/README.md
@@ -26,6 +26,8 @@ With Show Browser enabled, browser-only tests bypass the Playwright test runner 
 
 Node tests that need `fs`, `net`, etc. fall back to the standard Playwright test runner with CDP browser reuse. Headless mode uses standard Playwright with parallel workers.
 
+> **Note:** Bridge execution requires `esbuild` installed in your project (`npm install -D esbuild`). Without it, tests fall back to the standard Playwright test runner automatically.
+
 ## Features
 
 ### Test Explorer

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -7,7 +7,7 @@
     "color": "#ffffff",
     "theme": "light"
   },
-  "version": "0.21.4",
+  "version": "0.21.5",
   "private": true,
   "publisher": "playwright-repl",
   "repository": {


### PR DESCRIPTION
## Summary
- Bump all packages to 0.21.5
- Document esbuild requirement for bridge-mode in VS Code README
- Update root and VS Code CHANGELOG

Closes #531

## Test plan
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)