### PR TITLE
ci: add esbuild-wasm benchmark

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -90,6 +90,13 @@ jobs:
         working-directory: packages/runner
         timeout-minutes: 5
 
+      - name: 'Benchmark: todomvc via bridge direct (esbuild-wasm)'
+        run: node e2e/benchmark-bridge.js
+        working-directory: packages/runner
+        timeout-minutes: 5
+        env:
+          PW_USE_ESBUILD_WASM: '1'
+
       - name: 'Benchmark: pw repl (CDP) vs pw repl-extension (bridge)'
         run: node packages/runner/script-examples/bench.js --headless
         timeout-minutes: 5


### PR DESCRIPTION
## Summary
Add benchmark step comparing native esbuild vs esbuild-wasm for bridge-mode compilation.

Runs the same `benchmark-bridge.js` test twice:
1. Native esbuild (default)
2. esbuild-wasm (`PW_USE_ESBUILD_WASM=1`)

## Test plan
- [ ] CI passes, compare times in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)