### PR TITLE
chore: release v0.21.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## v0.21.6 — esbuild-wasm & Publish Script
+
+**2026-04-02**
+
+### Features
+
+- **esbuild-wasm fallback**: Bridge-mode now bundles `esbuild-wasm` — works on all platforms without requiring users to install esbuild. Native esbuild used when available for best performance. ([#538](https://github.com/stevez/playwright-repl/pull/538))
+
+### Fixes
+
+- **Publish script**: Replace Python zip with `adm-zip` for VSIX packaging. Fixes duplicate `[Content_Types].xml` that blocked marketplace publish. ([#535](https://github.com/stevez/playwright-repl/pull/535))
+
 ## v0.21.5 — nft Packaging & Bridge Fallback
 
 **2026-04-01**

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "playwright-repl",
-  "version": "0.21.5",
+  "version": "0.21.6",
   "description": "Interactive REPL for Playwright — keyword commands, recording, and replay",
   "type": "module",
   "bin": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@playwright-repl/core",
   "description": "Shared parser, servers, and utilities for playwright-repl",
-  "version": "0.21.5",
+  "version": "0.21.6",
   "type": "module",
   "main": "./dist/index.js",
   "exports": {

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@playwright-repl/extension",
-  "version": "0.21.5",
+  "version": "0.21.6",
   "private": true,
   "description": "Dramaturg — Chrome extension with console, recorder, and element picker",
   "type": "module",

--- a/packages/extension/public/manifest.json
+++ b/packages/extension/public/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Dramaturg",
-  "version": "0.21.5",
+  "version": "0.21.6",
   "description": "Playwright engineer's companion — console, editor, runner, debugger, and recorder in a Chrome side panel.",
   "permissions": [
     "activeTab",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@playwright-repl/mcp",
     "description": "MCP server — AI agents control your real Chrome browser",
-    "version": "0.21.5",
+    "version": "0.21.6",
     "type": "module",
     "bin": {
         "playwright-repl-mcp": "./dist/index.js"

--- a/packages/runner/package.json
+++ b/packages/runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@playwright-repl/runner",
-  "version": "0.21.5",
+  "version": "0.21.6",
   "description": "Playwright test utilities — bridge-mode compilation, node detection, and CLI subcommands",
   "type": "module",
   "bin": {

--- a/packages/vscode/CHANGELOG.md
+++ b/packages/vscode/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 0.21.6
+
+**2026-04-02**
+
+### Features
+
+- Bridge-mode now works on all platforms — bundles `esbuild-wasm` as fallback when native esbuild is unavailable
+
+### Fixes
+
+- Fix duplicate `[Content_Types].xml` in VSIX packaging
+
 ## 0.21.5
 
 **2026-04-01**

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -7,7 +7,7 @@
     "color": "#ffffff",
     "theme": "light"
   },
-  "version": "0.21.5",
+  "version": "0.21.6",
   "private": true,
   "publisher": "playwright-repl",
   "repository": {


### PR DESCRIPTION
## Summary
- Bump all packages to 0.21.6
- esbuild-wasm fallback for bridge-mode (#538)
- Publish script fix — adm-zip replaces Python (#535)
- Update CHANGELOG

## Test plan
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)