### PR TITLE
fix: auto-kill stale process on MCP bridge port

### DIFF
--- a/packages/mcp/src/bridge.ts
+++ b/packages/mcp/src/bridge.ts
@@ -6,6 +6,23 @@ import { BridgeServer, UPDATE_COMMANDS, parseInput } from '@playwright-repl/core
 import type { EngineResult } from '@playwright-repl/core';
 import type { RunnerModule, SnapshotCache } from './types.js';
 import { logEvent } from './logger.js';
+import { execSync } from 'node:child_process';
+
+async function killProcessOnPort(port: number): Promise<void> {
+    try {
+        if (process.platform === 'win32') {
+            const out = execSync(`netstat -ano | findstr :${port} | findstr LISTENING`, { encoding: 'utf8' });
+            const pid = out.trim().split(/\s+/).pop();
+            if (pid) execSync(`taskkill /PID ${pid} /F`, { stdio: 'ignore' });
+        } else {
+            execSync(`lsof -ti :${port} | xargs kill -9`, { stdio: 'ignore' });
+        }
+        // Wait for port to be released
+        await new Promise(resolve => setTimeout(resolve, 500));
+    } catch {
+        // Process may already be gone
+    }
+}
 
 export const descriptions = {
     runCommandInput: `A keyword command ('snapshot', 'goto https://example.com', 'click Submit', \
@@ -55,10 +72,12 @@ export async function createBridgeRunner(
         await srv.start(port);
     } catch (err: any) {
         if (err?.code === 'EADDRINUSE') {
-            console.error(`Error: port ${port} is already in use. Another playwright-repl bridge or MCP inspector may be running. Stop it and restart Claude Desktop.`);
-            process.exit(1);
+            console.error(`Port ${port} in use — killing stale process...`);
+            await killProcessOnPort(port);
+            await srv.start(port);
+        } else {
+            throw err;
         }
-        throw err;
     }
     console.error(`playwright-repl bridge listening on ws://localhost:${port}`);
     logEvent(`Bridge listening on ws://localhost:${port}`);


### PR DESCRIPTION
## Summary
When the MCP bridge port 9876 is already in use (stale process from a previous Claude Desktop session), automatically kill it and retry instead of exiting with an error.

Supports both Windows (`netstat + taskkill`) and Unix (`lsof + kill`).

Closes #532

## Test plan
- [ ] Start MCP server, kill Claude Desktop, restart — server auto-recovers
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)