### PR TITLE
fix: auto-kill stale process on bridge port EADDRINUSE

### DIFF
--- a/packages/core/src/bridge-server.ts
+++ b/packages/core/src/bridge-server.ts
@@ -1,4 +1,5 @@
 import { WebSocketServer, WebSocket } from 'ws';
+import { execSync } from 'node:child_process';
 import type { EngineResult } from './types.js';
 
 export class BridgeServer {
@@ -16,7 +17,7 @@ export class BridgeServer {
     get port()                   { return (this.wss.address() as { port: number }).port; }
 
     async start(port = 9876): Promise<void> {
-        this.wss = new WebSocketServer({
+        const createServer = () => new WebSocketServer({
             port,
             verifyClient: ({ origin }: { origin: string }) => {
                 // Allow: no origin (Node.js ws clients, curl, tests)
@@ -26,10 +27,22 @@ export class BridgeServer {
                 return origin.startsWith('chrome-extension://');
             },
         });
-        await new Promise<void>((resolve, reject) => {
-            this.wss.on('listening', resolve);
-            this.wss.on('error', reject);
-        });
+
+        this.wss = createServer();
+        try {
+            await new Promise<void>((resolve, reject) => {
+                this.wss.on('listening', resolve);
+                this.wss.on('error', reject);
+            });
+        } catch (err: any) {
+            if (err?.code !== 'EADDRINUSE') throw err;
+            await killProcessOnPort(port);
+            this.wss = createServer();
+            await new Promise<void>((resolve, reject) => {
+                this.wss.on('listening', resolve);
+                this.wss.on('error', reject);
+            });
+        }
         this.wss.on('connection', (ws) => {
             this.socket = ws;
             this._onConnect?.();
@@ -109,5 +122,20 @@ export class BridgeServer {
     async close(): Promise<void> {
         this.socket?.close();
         await new Promise<void>(r => this.wss.close(() => r()));
+    }
+}
+
+async function killProcessOnPort(port: number): Promise<void> {
+    try {
+        if (process.platform === 'win32') {
+            const out = execSync(`netstat -ano | findstr :${port} | findstr LISTENING`, { encoding: 'utf8' });
+            const pid = out.trim().split(/\s+/).pop();
+            if (pid) execSync(`taskkill /PID ${pid} /F`, { stdio: 'ignore' });
+        } else {
+            execSync(`lsof -ti :${port} | xargs kill -9`, { stdio: 'ignore' });
+        }
+        await new Promise(resolve => setTimeout(resolve, 500));
+    } catch {
+        // Process may already be gone
     }
 }

--- a/packages/mcp/src/bridge.ts
+++ b/packages/mcp/src/bridge.ts
@@ -6,23 +6,6 @@ import { BridgeServer, UPDATE_COMMANDS, parseInput } from '@playwright-repl/core
 import type { EngineResult } from '@playwright-repl/core';
 import type { RunnerModule, SnapshotCache } from './types.js';
 import { logEvent } from './logger.js';
-import { execSync } from 'node:child_process';
-
-async function killProcessOnPort(port: number): Promise<void> {
-    try {
-        if (process.platform === 'win32') {
-            const out = execSync(`netstat -ano | findstr :${port} | findstr LISTENING`, { encoding: 'utf8' });
-            const pid = out.trim().split(/\s+/).pop();
-            if (pid) execSync(`taskkill /PID ${pid} /F`, { stdio: 'ignore' });
-        } else {
-            execSync(`lsof -ti :${port} | xargs kill -9`, { stdio: 'ignore' });
-        }
-        // Wait for port to be released
-        await new Promise(resolve => setTimeout(resolve, 500));
-    } catch {
-        // Process may already be gone
-    }
-}
 
 export const descriptions = {
     runCommandInput: `A keyword command ('snapshot', 'goto https://example.com', 'click Submit', \
@@ -68,17 +51,7 @@ export async function createBridgeRunner(
         : (process.env.BRIDGE_PORT ? parseInt(process.env.BRIDGE_PORT) : 9876);
 
     const srv = new BridgeServer();
-    try {
-        await srv.start(port);
-    } catch (err: any) {
-        if (err?.code === 'EADDRINUSE') {
-            console.error(`Port ${port} in use — killing stale process...`);
-            await killProcessOnPort(port);
-            await srv.start(port);
-        } else {
-            throw err;
-        }
-    }
+    await srv.start(port);
     console.error(`playwright-repl bridge listening on ws://localhost:${port}`);
     logEvent(`Bridge listening on ws://localhost:${port}`);
     srv.onConnect(() => { console.error('Extension connected'); logEvent('Extension connected'); });


### PR DESCRIPTION
## Summary
- Move `killProcessOnPort` into `BridgeServer.start()` so EADDRINUSE is handled automatically for all consumers (MCP, bench.js, pw-repl-extension)
- Remove duplicate `killProcessOnPort` and retry logic from MCP's `bridge.ts`

## Test plan
- [x] `pnpm --filter @playwright-repl/core test` — 106 tests pass
- [ ] Run `node packages/runner/script-examples/bench.js --headless` in CI to verify bridge iterations no longer timeout

Closes #512

🤖 Generated with [Claude Code](https://claude.com/claude-code)