### PR TITLE
fix: VSIX missing node_modules on marketplace

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "playwright-repl",
-  "version": "0.21.6",
+  "version": "0.21.7",
   "description": "Interactive REPL for Playwright — keyword commands, recording, and replay",
   "type": "module",
   "bin": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@playwright-repl/core",
   "description": "Shared parser, servers, and utilities for playwright-repl",
-  "version": "0.21.6",
+  "version": "0.21.7",
   "type": "module",
   "main": "./dist/index.js",
   "exports": {

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@playwright-repl/extension",
-  "version": "0.21.6",
+  "version": "0.21.7",
   "private": true,
   "description": "Dramaturg — Chrome extension with console, recorder, and element picker",
   "type": "module",

--- a/packages/extension/public/manifest.json
+++ b/packages/extension/public/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Dramaturg",
-  "version": "0.21.6",
+  "version": "0.21.7",
   "description": "Playwright engineer's companion — console, editor, runner, debugger, and recorder in a Chrome side panel.",
   "permissions": [
     "activeTab",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@playwright-repl/mcp",
     "description": "MCP server — AI agents control your real Chrome browser",
-    "version": "0.21.6",
+    "version": "0.21.7",
     "type": "module",
     "bin": {
         "playwright-repl-mcp": "./dist/index.js"

--- a/packages/runner/package.json
+++ b/packages/runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@playwright-repl/runner",
-  "version": "0.21.6",
+  "version": "0.21.7",
   "description": "Playwright test utilities — bridge-mode compilation, node detection, and CLI subcommands",
   "type": "module",
   "bin": {
@@ -24,7 +24,6 @@
     "@playwright-repl/core": "workspace:*",
     "acorn": "^8.16.0",
     "acorn-walk": "^8.3.5",
-    "esbuild": "^0.25.0",
     "esbuild-wasm": "^0.27.4",
     "magic-string": "^0.30.21"
   },

--- a/packages/vscode/CHANGELOG.md
+++ b/packages/vscode/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.21.7
+
+**2026-04-02**
+
+### Fixes
+
+- Fix VSIX missing `node_modules` on marketplace — restore legacy packaging with `npm install --production`
+- Remove platform-specific `esbuild` binary from VSIX — use portable `esbuild-wasm` only
+
 ## 0.21.6
 
 **2026-04-02**

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -7,7 +7,7 @@
     "color": "#ffffff",
     "theme": "light"
   },
-  "version": "0.21.6",
+  "version": "0.21.7",
   "private": true,
   "publisher": "playwright-repl",
   "repository": {

--- a/packages/vscode/publish.mjs
+++ b/packages/vscode/publish.mjs
@@ -1,12 +1,10 @@
 #!/usr/bin/env node
 /**
- * Package/publish VS Code extension using @vercel/nft.
+ * Publish VS Code extension to marketplace.
  *
- * 1. Build monorepo + extension
- * 2. nft-build: trace deps, assemble .vsce-build/
- * 3. vsce package --no-dependencies (creates VSIX without node_modules)
- * 4. Append nft-traced node_modules to VSIX using yazl/yauzl
- * 5. Optionally publish to marketplace
+ * Why a temp directory?  vsce uses npm internally and follows workspace
+ * symlinks, pulling the entire monorepo into the VSIX.  Copying to a
+ * standalone directory gives npm a clean install with no symlinks.
  *
  * Usage:
  *   node publish.mjs          # package only (creates .vsix)
@@ -16,111 +14,71 @@
 import { execSync } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
-import yazl from 'yazl';
-import yauzl from 'yauzl';
+import os from 'node:os';
 
 const VSCODE_PKG = import.meta.dirname;
 const ROOT = path.resolve(VSCODE_PKG, '..', '..');
-const BUILD = path.join(VSCODE_PKG, '.vsce-build');
-const doPublish = process.argv.includes('publish');
+const publish = process.argv.includes('publish');
 
 function run(cmd, opts = {}) {
   console.log(`\n> ${cmd}`);
   execSync(cmd, { stdio: 'inherit', ...opts });
 }
 
-// ─── 1. Build ────────────────────────────────────────────────────────────
-console.log('=== Step 1: Build ===');
+// ─── 1. Build monorepo ────────────────────────────────────────────────────
+console.log('=== Building monorepo ===');
 run('pnpm run build', { cwd: ROOT });
 run('node build.mjs', { cwd: VSCODE_PKG });
 
-// ─── 2. nft-build ────────────────────────────────────────────────────────
-console.log('\n=== Step 2: Trace dependencies ===');
-run('node nft-build.mjs', { cwd: VSCODE_PKG });
+// ─── 2. Copy to temp directory ────────────────────────────────────────────
+const tmpDir = path.join(os.tmpdir(), 'vscode-publish');
+if (fs.existsSync(tmpDir)) fs.rmSync(tmpDir, { recursive: true });
+fs.mkdirSync(tmpDir, { recursive: true });
 
-// ─── 3. vsce package ─────────────────────────────────────────────────────
-console.log('\n=== Step 3: Package VSIX ===');
-run('npx @vscode/vsce package --no-dependencies', { cwd: BUILD });
+const items = [
+  'dist', 'chrome-extension', 'images', 'media', 'l10n',
+  'package.json', 'README.md', 'CHANGELOG.md', 'LICENSE', 'NOTICE',
+  '.vscodeignore',
+  // localization files
+  ...fs.readdirSync(VSCODE_PKG).filter(f => f.startsWith('package.nls')),
+];
 
-// ─── 4. Append node_modules to VSIX ─────────────────────────────────────
-console.log('\n=== Step 4: Append node_modules ===');
-const vsixName = fs.readdirSync(BUILD).find(f => f.endsWith('.vsix'));
-if (!vsixName) throw new Error('No .vsix file found');
-const vsixPath = path.join(BUILD, vsixName);
-const tmpPath = vsixPath + '.tmp';
+for (const item of items) {
+  const src = path.join(VSCODE_PKG, item);
+  if (!fs.existsSync(src)) continue;
+  const dest = path.join(tmpDir, item);
+  fs.cpSync(src, dest, { recursive: true });
+}
 
-await new Promise((resolve, reject) => {
-  yauzl.open(vsixPath, { lazyEntries: true }, (err, zipReader) => {
-    if (err) return reject(err);
+// ─── 3. Resolve workspace:* refs to real versions ────────────────────────
+const pkg = JSON.parse(fs.readFileSync(path.join(tmpDir, 'package.json'), 'utf8'));
+for (const [name, ver] of Object.entries(pkg.dependencies || {})) {
+  if (ver.startsWith('workspace:')) {
+    const depPkg = JSON.parse(fs.readFileSync(path.join(ROOT, 'packages', name.split('/').pop(), 'package.json'), 'utf8'));
+    pkg.dependencies[name] = depPkg.version;
+  }
+}
+fs.writeFileSync(path.join(tmpDir, 'package.json'), JSON.stringify(pkg, null, 2) + '\n');
 
-    const zipWriter = new yazl.ZipFile();
-    const output = fs.createWriteStream(tmpPath);
-    let added = 0;
+console.log(`\n=== Copied to ${tmpDir} ===`);
 
-    zipReader.on('entry', (entry) => {
-      zipReader.openReadStream(entry, (err, stream) => {
-        if (err) return reject(err);
+// ─── 4. npm install (clean, no symlinks) ──────────────────────────────────
+console.log('\n=== Installing dependencies ===');
+run('npm install --production', { cwd: tmpDir });
 
-        // Fix Content_Types — add .mjs if missing
-        if (entry.fileName === '[Content_Types].xml') {
-          const chunks = [];
-          stream.on('data', c => chunks.push(c));
-          stream.on('end', () => {
-            let ct = Buffer.concat(chunks).toString('utf8');
-            if (!ct.includes('.mjs')) {
-              ct = ct.replace('</Types>', '<Default Extension=".mjs" ContentType="application/javascript"/></Types>');
-            }
-            zipWriter.addBuffer(Buffer.from(ct), entry.fileName);
-            zipReader.readEntry();
-          });
-        } else {
-          zipWriter.addReadStream(stream, entry.fileName, {
-            compress: entry.fileName.endsWith('.map') ? false : true,
-          });
-          zipReader.readEntry();
-        }
-      });
-    });
-
-    zipReader.on('end', () => {
-      // Add node_modules files
-      const nmDir = path.join(BUILD, 'node_modules');
-      (function walk(dir) {
-        for (const f of fs.readdirSync(dir, { withFileTypes: true })) {
-          const fp = path.join(dir, f.name);
-          if (f.isDirectory()) walk(fp);
-          else {
-            const arcname = 'extension/' + path.relative(BUILD, fp).split(path.sep).join('/');
-            zipWriter.addFile(fp, arcname);
-            added++;
-          }
-        }
-      })(nmDir);
-
-      zipWriter.end();
-      console.log(`Added ${added} node_modules files`);
-    });
-
-    zipWriter.outputStream.pipe(output);
-    output.on('close', () => {
-      fs.renameSync(tmpPath, vsixPath);
-      const size = fs.statSync(vsixPath).size;
-      console.log(`VSIX: ${(size / 1024 / 1024).toFixed(1)} MB`);
-      resolve();
-    });
-
-    zipReader.readEntry();
-  });
-});
-
-// ─── 5. Copy VSIX / Publish ─────────────────────────────────────────────
-fs.cpSync(vsixPath, path.join(VSCODE_PKG, vsixName));
-
-if (doPublish) {
-  console.log('\n=== Step 5: Publish ===');
-  run(`npx @vscode/vsce publish -i ${vsixName}`, { cwd: BUILD });
+// ─── 5. Package / Publish ─────────────────────────────────────────────────
+if (publish) {
+  console.log('\n=== Publishing to VS Code Marketplace ===');
+  run('npx @vscode/vsce publish', { cwd: tmpDir });
 } else {
-  console.log(`\nVSIX: packages/vscode/${vsixName}`);
+  console.log('\n=== Packaging VSIX ===');
+  run('npx @vscode/vsce package', { cwd: tmpDir });
+  // Copy VSIX back to packages/vscode
+  const vsix = fs.readdirSync(tmpDir).find(f => f.endsWith('.vsix'));
+  if (vsix) {
+    fs.cpSync(path.join(tmpDir, vsix), path.join(VSCODE_PKG, vsix));
+    console.log(`\nVSIX: packages/vscode/${vsix}`);
+  }
 }
 
 console.log('\nDone!');

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -200,9 +200,6 @@ importers:
       acorn-walk:
         specifier: ^8.3.5
         version: 8.3.5
-      esbuild:
-        specifier: ^0.25.0
-        version: 0.25.12
       esbuild-wasm:
         specifier: ^0.27.4
         version: 0.27.4


### PR DESCRIPTION
## Summary
- Restore legacy VSIX packaging (`npm install --production` in temp dir) — vsce natively includes node_modules
- Remove platform-specific `esbuild` from `@playwright-repl/runner` dependencies, keep portable `esbuild-wasm` only
- Bump all packages to 0.21.7

## Context
The nft-based packaging (v0.21.5–0.21.6) appended node_modules to the VSIX after `vsce package`, but `vsce publish -i` stripped them. The marketplace VSIX was 12.7 MB (missing deps) vs 34 MB locally. This caused the extension to hang on fresh installs (e.g. Mac) because `@playwright-repl/core` was missing.

## Test plan
- [ ] `node publish.mjs` produces VSIX with node_modules
- [ ] VSIX installs and activates on Mac (Intel)
- [ ] No `@esbuild/win32-x64` or `esbuild` in VSIX
- [ ] Bridge mode works using `esbuild-wasm` fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)