### PR TITLE
fix: Mac bridge connection — fallback when chrome.offscreen unavailable

### DIFF
--- a/packages/core/src/bridge-server.ts
+++ b/packages/core/src/bridge-server.ts
@@ -19,6 +19,7 @@ export class BridgeServer {
     async start(port = 9876): Promise<void> {
         const createServer = () => new WebSocketServer({
             port,
+            host: '127.0.0.1',
             verifyClient: ({ origin }: { origin: string }) => {
                 // Allow: no origin (Node.js ws clients, curl, tests)
                 // Allow: chrome-extension:// (our offscreen document)

--- a/packages/extension/src/background.ts
+++ b/packages/extension/src/background.ts
@@ -427,6 +427,9 @@ async function handleBridgeCommand(msg: {
   return result;
 }
 
+// Expose for VS Code CDP injection when chrome.offscreen is unavailable
+(self as any).handleBridgeCommand = handleBridgeCommand;
+
 // ─── Message Handler ─────────────────────────────────────────────────────────
 
 // Serialize bridge commands so concurrent messages don't race on currentPage / attachToTab.

--- a/packages/extension/src/offscreen/offscreen.ts
+++ b/packages/extension/src/offscreen/offscreen.ts
@@ -6,9 +6,18 @@
 let ws: WebSocket | null = null;
 let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
 
+async function reconnect() {
+    try {
+        const port: number = await chrome.runtime.sendMessage({ type: 'get-bridge-port' });
+        connect(port || 9876);
+    } catch {
+        reconnectTimer = setTimeout(() => reconnect(), 3000);
+    }
+}
+
 function connect(port: number) {
     try {
-        ws = new WebSocket(`ws://localhost:${port}`);
+        ws = new WebSocket(`ws://127.0.0.1:${port}`);
 
         ws.onmessage = async (e) => {
             const msg = JSON.parse(e.data as string) as {
@@ -40,12 +49,12 @@ function connect(port: number) {
         };
 
         ws.onclose = () => {
-            reconnectTimer = setTimeout(() => connect(port), 3000);
+            reconnectTimer = setTimeout(() => reconnect(), 3000);
         };
 
         ws.onerror = () => {};
     } catch {
-        reconnectTimer = setTimeout(() => connect(port), 3000);
+        reconnectTimer = setTimeout(() => reconnect(), 3000);
     }
 }
 

--- a/packages/vscode/src/browser.ts
+++ b/packages/vscode/src/browser.ts
@@ -9,7 +9,7 @@ import fs from 'node:fs';
 // __filename is available at runtime in esbuild's CJS output
 declare const __filename: string;
 
-const CDP_PORT = 9222;
+let CDP_PORT = 9222;
 
 // ─── Types ─────────────────────────────────────────────────────────────────
 
@@ -87,6 +87,18 @@ export class BrowserManager {
       devtools: { preferences: { currentDockState: '"bottom"' } },
     }));
 
+    // Find a free port for CDP (9222 may be taken by the user's Chrome)
+    const net = await import('node:net');
+    CDP_PORT = await new Promise<number>((resolve, reject) => {
+      const srv = net.createServer();
+      srv.listen(0, '127.0.0.1', () => {
+        const port = (srv.address() as import('node:net').AddressInfo).port;
+        srv.close(() => resolve(port));
+      });
+      srv.on('error', reject);
+    });
+    this._log.appendLine(`CDP port: ${CDP_PORT}`);
+
     this._browserServer = await pw.chromium.launchServer({
       channel: 'chromium',
       headless,
@@ -130,23 +142,57 @@ export class BrowserManager {
           res.on('end', () => { try { resolve(JSON.parse(data)); } catch (e) { reject(e); } });
         }).on('error', reject);
       });
+      this._log.appendLine(`CDP targets: ${targets.map((t: any) => `${t.type}:${t.url}`).join(', ')}`);
       const swTarget = targets.find((t: any) => t.type === 'service_worker' && t.url.includes('chrome-extension://'));
+      const hasOffscreen = targets.some((t: any) => t.url?.includes('offscreen'));
       if (swTarget) {
         this._log.appendLine(`Found service worker: ${swTarget.url}`);
-        const cdpWs = new WebSocket(swTarget.webSocketDebuggerUrl);
-        await new Promise<void>((res, rej) => {
+        // Helper to evaluate JS in the service worker via CDP
+        const swEval = (expr: string): Promise<void> => new Promise((res, rej) => {
+          const cdpWs = new WebSocket(swTarget.webSocketDebuggerUrl);
           cdpWs.on('open', () => {
-            cdpWs.send(JSON.stringify({
-              id: 1,
-              method: 'Runtime.evaluate',
-              params: { expression: `chrome.storage.local.set({ bridgePort: ${bridge.port} })` }
-            }));
+            cdpWs.send(JSON.stringify({ id: 1, method: 'Runtime.evaluate', params: { expression: expr } }));
             cdpWs.on('message', () => { cdpWs.close(); res(); });
           });
           cdpWs.on('error', rej);
-          setTimeout(() => { cdpWs.close(); rej(new Error('CDP timeout')); }, 5000);
+          setTimeout(() => { cdpWs.close(); rej(new Error('CDP timeout')); }, 10000);
         });
+
+        // Set bridge port in storage (for offscreen doc if it exists)
+        await swEval(`chrome.storage.local.set({ bridgePort: ${bridge.port} })`);
         this._log.appendLine(`Bridge port ${bridge.port} set via CDP.`);
+
+        // If no offscreen document, inject WebSocket bridge directly into SW
+        if (!hasOffscreen) {
+          this._log.appendLine('No offscreen document found — injecting WebSocket bridge into service worker.');
+          await swEval(`
+(function() {
+  if (self.__bridgeWs) { try { self.__bridgeWs.close(); } catch(e) {} }
+  const ws = new WebSocket('ws://127.0.0.1:${bridge.port}');
+  self.__bridgeWs = ws;
+  let commandQueue = Promise.resolve();
+  ws.onmessage = (e) => {
+    const msg = JSON.parse(e.data);
+    const execute = () => handleBridgeCommand({
+      command: msg.command,
+      scriptType: msg.type,
+      language: msg.language,
+      includeSnapshot: msg.includeSnapshot,
+    });
+    const queued = commandQueue.then(execute, execute);
+    commandQueue = queued.then(() => {}, () => {});
+    queued.then(result => {
+      if (ws.readyState === WebSocket.OPEN)
+        ws.send(JSON.stringify({ id: msg.id, ...result }));
+    }).catch(err => {
+      if (ws.readyState === WebSocket.OPEN)
+        ws.send(JSON.stringify({ id: msg.id, text: String(err), isError: true }));
+    });
+  };
+})()
+          `);
+          this._log.appendLine('WebSocket bridge injected into service worker.');
+        }
       }
       // Also fetch the CDP WebSocket URL for test runner
       const versionData = await new Promise<any>((resolve, reject) => {


### PR DESCRIPTION
## Summary
- Playwright's bundled Chromium on macOS does not support `chrome.offscreen`, so the offscreen document was never created and the WebSocket bridge between VS Code and the extension was never established
- When no offscreen document is detected in CDP targets, the WebSocket bridge is now injected directly into the service worker via CDP `Runtime.evaluate`
- BridgeServer binds to `127.0.0.1` explicitly to avoid IPv6 resolution issues on Mac
- CDP port is now dynamically allocated to avoid conflicts with the user's Chrome on port 9222

## Test plan
- [x] Verified on macOS — browser launches and bridge connects successfully
- [ ] Verify on Windows — offscreen document path still works (no regression)
- [ ] Verify commands execute correctly through the injected bridge

🤖 Generated with [Claude Code](https://claude.com/claude-code)