### PR TITLE
chore: release v0.21.9

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "playwright-repl",
-  "version": "0.21.8",
+  "version": "0.21.9",
   "description": "Interactive REPL for Playwright — keyword commands, recording, and replay",
   "type": "module",
   "bin": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@playwright-repl/core",
   "description": "Shared parser, servers, and utilities for playwright-repl",
-  "version": "0.21.8",
+  "version": "0.21.9",
   "type": "module",
   "main": "./dist/index.js",
   "exports": {

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@playwright-repl/extension",
-  "version": "0.21.8",
+  "version": "0.21.9",
   "private": true,
   "description": "Dramaturg — Chrome extension with console, recorder, and element picker",
   "type": "module",

--- a/packages/extension/public/manifest.json
+++ b/packages/extension/public/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Dramaturg",
-  "version": "0.21.8",
+  "version": "0.21.9",
   "description": "Playwright engineer's companion — console, editor, runner, debugger, and recorder in a Chrome side panel.",
   "permissions": [
     "activeTab",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@playwright-repl/mcp",
     "description": "MCP server — AI agents control your real Chrome browser",
-    "version": "0.21.8",
+    "version": "0.21.9",
     "type": "module",
     "bin": {
         "playwright-repl-mcp": "./dist/index.js"

--- a/packages/runner/package.json
+++ b/packages/runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@playwright-repl/runner",
-  "version": "0.21.8",
+  "version": "0.21.9",
   "description": "Playwright test utilities — bridge-mode compilation, node detection, and CLI subcommands",
   "type": "module",
   "bin": {

--- a/packages/vscode/CHANGELOG.md
+++ b/packages/vscode/CHANGELOG.md
@@ -1,14 +1,14 @@
 # Changelog
 
-## 0.21.8
+## 0.21.9
 
 **2026-04-02**
 
 ### Fixes
 
-- Fix VSIX missing `node_modules` on marketplace — restore legacy packaging with `npm install --production`
+- Fix Mac: bridge connection timeout — use `127.0.0.1`, dynamic CDP port, SW fallback injection
+- Fix VSIX missing `node_modules` on marketplace — restore legacy packaging
 - Remove platform-specific `esbuild` binary from VSIX — use portable `esbuild-wasm` only
-- Fix `workspace:*` in published npm packages — use `pnpm publish` instead of `npm publish`
 
 ## 0.21.6
 

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -7,7 +7,7 @@
     "color": "#ffffff",
     "theme": "light"
   },
-  "version": "0.21.8",
+  "version": "0.21.9",
   "private": true,
   "publisher": "playwright-repl",
   "repository": {


### PR DESCRIPTION
## Summary
- Bump all packages to 0.21.9
- Mac bridge connection fix (127.0.0.1, dynamic CDP port, SW fallback injection)
- VSIX packaging fix (legacy npm install, no platform-specific esbuild)

## Release steps after merge
1. `pnpm publish` for npm packages (core, runner, mcp, cli)
2. `node publish.mjs publish` for VSIX
3. `git tag v0.21.9 && git push origin v0.21.9`

🤖 Generated with [Claude Code](https://claude.com/claude-code)