### PR TITLE
feat: MCP --standalone uses serviceWorker.evaluate()

### DIFF
--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -19,6 +19,7 @@
     "dependencies": {
         "@modelcontextprotocol/sdk": "^1.10.0",
         "@playwright-repl/core": "workspace:*",
+        "@playwright/test": "^1.59.1",
         "playwright-repl": "workspace:*",
         "zod": "^3.24.0"
     }

--- a/packages/mcp/src/evaluate.ts
+++ b/packages/mcp/src/evaluate.ts
@@ -1,0 +1,71 @@
+/**
+ * Evaluate runner — connects to Chrome via serviceWorker.evaluate().
+ * No WebSocket bridge needed.
+ */
+
+import { EvaluateConnection, UPDATE_COMMANDS, parseInput } from '@playwright-repl/core';
+import type { EngineResult } from '@playwright-repl/core';
+import type { RunnerModule, SnapshotCache } from './types.js';
+import { logEvent } from './logger.js';
+import { descriptions } from './bridge.js';
+import path from 'node:path';
+import fs from 'node:fs';
+import { createRequire } from 'node:module';
+
+/** Find the Dramaturg Chrome extension dist path */
+function findExtensionPath(): string | null {
+    try {
+        const require = createRequire(import.meta.url);
+        const coreMain = require.resolve('@playwright-repl/core');
+        const coreDir = coreMain.replace(/[\\/]dist[\\/].*$/, '');
+        const monorepoExt = path.resolve(coreDir, '../extension/dist');
+        if (fs.existsSync(path.join(monorepoExt, 'manifest.json'))) return monorepoExt;
+        const bundledExt = path.resolve(coreDir, '../playwright-repl/chrome-extension');
+        if (fs.existsSync(path.join(bundledExt, 'manifest.json'))) return bundledExt;
+    } catch {}
+    return null;
+}
+
+export async function createEvaluateRunner(
+    argv: string[],
+    snapshotCache: SnapshotCache,
+): Promise<RunnerModule> {
+    const headed = argv.includes('--headed');
+    const extPath = findExtensionPath();
+    if (!extPath) throw new Error('Chrome extension not found. Run "pnpm run build" first.');
+
+    const conn = new EvaluateConnection();
+    const pwModule = '@playwright/test';
+    const { chromium } = await (Function('m', 'return import(m)')(pwModule)) as any;
+    await conn.start(extPath, { headed, chromium });
+    console.error(`playwright-repl evaluate mode (${headed ? 'headed' : 'headless'})`);
+    logEvent(`Evaluate mode started`);
+
+    return {
+        descriptions,
+        runner: {
+            async runCommand(command: string): Promise<EngineResult> {
+                const parsed = parseInput(command);
+                const cmdName = parsed?._[0];
+                const isUpdate = cmdName !== undefined && UPDATE_COMMANDS.has(cmdName);
+
+                const result = await conn.run(command, isUpdate ? { includeSnapshot: true } : undefined);
+                if (result.isError) return result;
+
+                if (result.text) {
+                    const snapMatch = result.text.match(/### Snapshot\n([\s\S]+)$/);
+                    if (snapMatch) {
+                        snapshotCache.value = { url: '', snapshotString: snapMatch[1].trim() };
+                    } else if (cmdName === 'snapshot') {
+                        snapshotCache.value = { url: '', snapshotString: result.text.trim() };
+                    }
+                }
+
+                return result;
+            },
+            async runScript(script: string, language: 'pw' | 'javascript'): Promise<EngineResult> {
+                return conn.runScript(script, language);
+            },
+        },
+    };
+}

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -5,20 +5,19 @@ import { z } from 'zod';
 import { COMMANDS, CATEGORIES, refToLocator } from '@playwright-repl/core';
 import pkg from '../package.json' with { type: 'json' };
 import { createBridgeRunner } from './bridge.js';
-import { createStandaloneRunner } from './standalone.js';
+import { createEvaluateRunner } from './evaluate.js';
 import { logStartup, logEvent, logToolCall, logToolResult, logError, LOG_FILE } from './logger.js';
 import type { SnapshotCache } from './types.js';
 
 const argv = process.argv.slice(2);
 const standalone = argv.includes('--standalone');
-const headed = argv.includes('--headed');
 
 const snapshotCache: SnapshotCache = { value: null };
 
 // ─── Create runner ───────────────────────────────────────────────────────────
 
 const { runner, descriptions } = standalone
-    ? createStandaloneRunner(headed, snapshotCache)
+    ? await createEvaluateRunner(argv, snapshotCache)
     : await createBridgeRunner(argv, snapshotCache);
 
 logStartup(standalone ? 'standalone' : 'bridge', `log → ${LOG_FILE}`);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -182,6 +182,9 @@ importers:
       '@playwright-repl/core':
         specifier: workspace:*
         version: link:../core
+      '@playwright/test':
+        specifier: ^1.59.1
+        version: 1.59.1
       playwright-repl:
         specifier: workspace:*
         version: link:../cli


### PR DESCRIPTION
## Summary
- Replace old Engine standalone with EvaluateConnection
- \`--standalone\` now uses \`serviceWorker.evaluate()\` — same as CLI (#559)
- Supports keyword commands AND JavaScript
- Default bridge mode unchanged

## Test plan
- [x] MCP initialize handshake works in standalone mode
- [x] Build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)