### PR TITLE
docs: update READMEs for serviceWorker.evaluate() architecture

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,55 +99,27 @@ browser:     locator.click()
 Chrome:      actual DOM click event
 ```
 
-### Engine (packages/core/src/engine.ts)
+### EvaluateConnection (packages/core/src/evaluate-connection.ts)
 
-The `Engine` class wraps Playwright's `BrowserServerBackend` in-process:
+The primary execution mode. Launches Chromium with the Dramaturg extension and executes commands via `serviceWorker.evaluate()`:
 
 ```js
-const engine = new Engine();
-await engine.start({ headed: true, browser: 'chrome' });
-const result = await engine.run({ _: ['click', 'e5'] });
-// result = { text: '### Result\nClicked', isError: false }
-await engine.close();
+const conn = new EvaluateConnection();
+await conn.start(extensionPath, { headed: true, chromium });
+const result = await conn.run('click e5');
+// result = { text: 'Clicked', isError: false }
+await conn.close();
 ```
 
-Three connection modes via `start(opts)`:
-- **launch** (default): `contextFactory(config)` → new browser
-- **connect**: `opts.connect = 9222` → `cdpEndpoint` → `connectOverCDP()`
-- **extension**: `opts.extension = true` → starts `CommandServer`, Chrome launched with `--remote-debugging-port`, side panel sends commands via HTTP
-- Dependency injection: constructor accepts `deps` for testing
+No WebSocket bridge, no port management. Playwright talks directly to the extension's service worker.
 
-Key Playwright internals used (via `createRequire`):
-- `playwright/lib/mcp/browser/browserServerBackend` → `BrowserServerBackend`
-- `playwright/lib/mcp/browser/browserContextFactory` → `contextFactory`
-- `playwright/lib/mcp/browser/config` → `resolveConfig`
-- `playwright/lib/cli/daemon/commands` → `commands` map
-- `playwright/lib/cli/daemon/command` → `parseCommand`
+### Engine (packages/cli/src/engine.ts)
 
-### CommandServer (packages/core/src/extension-server.ts)
+Fallback mode when the extension is not available. Wraps Playwright's `BrowserServerBackend` in-process. Only supports keyword commands (no JavaScript).
 
-When `--extension` mode is used, `CommandServer` starts an HTTP server:
+### BridgeServer (packages/core/src/bridge-server.ts)
 
-```
-┌──────────────────────────────────────────────┐
-│  Chrome Extension (Side Panel)               │
-│  panel.js ─── fetch POST /run ───────────┐   │
-│     ▲                                    │   │
-│     │ JSON response                      │   │
-└─────┼────────────────────────────────────┼───┘
-      │                                    │
-      │                                    ▼
-┌─────────────────────────────────────────────────────┐
-│  CommandServer (HTTP :6781)                          │
-│    ├── POST /run   ← panel sends commands here      │
-│    └── GET /health ← panel checks server status     │
-│  Engine → connectOverCDP → CDP :3001 → Chrome       │
-└─────────────────────────────────────────────────────┘
-```
-
-- **Direct CDP**: Engine connects to Chrome via `--remote-debugging-port` (no relay)
-- **Command channel**: panel sends commands via `fetch()` → CommandServer → `Engine.run()` → results back
-- **Recording**: extension-side (inject recorder.js via `chrome.scripting.executeScript`)
+WebSocket server for `--bridge` mode — connects to the user's existing Chrome with Dramaturg installed. Used when the user wants to automate their real browser session with cookies/auth intact.
 
 ### Element Refs (e1, e5, etc.)
 

--- a/README.md
+++ b/README.md
@@ -50,17 +50,18 @@ Test Explorer, interactive REPL, assert builder, and element picker — all insi
 
 ## CLI
 
-Terminal REPL for Playwright. Type a command, see the result.
+Terminal REPL for Playwright. Supports keyword commands and JavaScript.
 
 ```bash
 npm install -g playwright-repl
-playwright-repl --headed
+playwright-repl
 ```
 
 ```
 pw> goto https://demo.playwright.dev/todomvc/
 pw> fill "What needs to be done?" Buy groceries
 pw> press Enter
+pw> await page.title()
 pw> verify text 1 item left
 pw> screenshot
 ```
@@ -69,8 +70,10 @@ pw> screenshot
 
 | Mode | Flag | How it works |
 |------|------|--------------|
-| **Standalone** | *(default)* | Launches Chromium via Playwright |
+| **Standalone** | *(default)* | Launches Chromium with Dramaturg extension |
 | **Bridge** | `--bridge` | Connects to your real Chrome via Dramaturg extension |
+
+Standalone launches a fresh Chromium with the extension pre-installed — keyword commands and JavaScript both work. Use `--headless` for CI/scripting.
 
 > **[Full CLI docs](packages/cli/README.md)**
 
@@ -85,11 +88,9 @@ npm install -D @playwright-repl/runner
 ```
 
 ```bash
-pw test                              # run Playwright tests with context reuse
-pw launch --port 9222                # launch Chrome with extension + CDP port
-pw repl --port 9222                  # Node REPL with Playwright globals (page, context, browser, expect)
-pw repl-extension --bridge-port 9877 # REPL via extension bridge
-pw close --port 9222                 # close browser
+pw test                              # run Playwright tests (2.8x faster via extension)
+pw repl                              # interactive REPL with keyword + JS support
+pw repl --headless                   # headless mode for scripting
 ```
 
 > **[Full runner docs](packages/runner/README.md)**
@@ -116,11 +117,12 @@ Install from the [Chrome Web Store](https://chromewebstore.google.com/detail/dra
 
 ## MCP Server — AI Browser Agent
 
-AI agents control your **real** Chrome session — already logged in, cookies intact.
+AI agents control the browser — standalone or connected to your real Chrome.
 
 ```bash
 npm install -g @playwright-repl/mcp
-playwright-repl-mcp
+playwright-repl-mcp --standalone     # launch fresh browser (keyword + JS)
+playwright-repl-mcp                  # connect to existing Chrome via bridge
 ```
 
 | | `@playwright-repl/mcp` | Playwright MCP | Playwriter |

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,16 +1,17 @@
 # playwright-repl
 
-Interactive terminal REPL for browser automation powered by Playwright. Type a command, see the result — no code, no boilerplate.
+Interactive terminal REPL for browser automation powered by Playwright. Supports keyword commands and JavaScript.
 
 ```bash
 npm install -g playwright-repl
-playwright-repl --headed
+playwright-repl
 ```
 
 ```
 pw> goto https://demo.playwright.dev/todomvc/
 pw> fill "What needs to be done?" Buy groceries
 pw> press Enter
+pw> await page.title()
 pw> verify text 1 item left
 pw> screenshot
 ```
@@ -20,26 +21,24 @@ pw> screenshot
 ```bash
 npm install -g playwright-repl
 
-# Browser binaries (only needed for standalone mode)
-npx playwright install
+# Install Chromium (needed for standalone mode)
+npx playwright install chromium
 ```
 
 ## Connection Modes
 
 | Mode | Flag | How it works |
 |------|------|--------------|
-| **Standalone** | *(default)* | Launches Chromium via Playwright |
+| **Standalone** | *(default)* | Launches Chromium with Dramaturg extension — keyword + JS |
 | **Bridge** | `--bridge` | Connects to your real Chrome via Dramaturg extension — cookies and logins intact |
 
 ### Standalone
 
-Playwright launches and manages the browser. Headless by default, headed with `--headed`.
+Launches Chromium with the Dramaturg extension pre-installed. Headed by default — use `--headless` for CI/scripting. Supports both keyword commands and JavaScript.
 
 ```bash
-playwright-repl
-playwright-repl --headed
-playwright-repl --browser firefox
-playwright-repl --persistent   # keeps profile between sessions
+playwright-repl                # headed (default)
+playwright-repl --headless     # headless for CI/scripting
 ```
 
 ### Bridge
@@ -87,19 +86,16 @@ echo -e "goto https://example.com\nsnapshot" | playwright-repl
 | Mode | Standalone | Bridge |
 |------|:---:|:---:|
 | **Keyword** — `click "Sign in"`, `goto https://...` | Yes | Yes |
-| **Playwright API / JS** — `await page.title()`, `1 + 1` | No | Yes (auto-detected) |
+| **Playwright API / JS** — `await page.title()`, `1 + 1` | Yes | Yes |
 
-Bridge mode auto-detects Playwright API and JavaScript expressions. For DOM access use `await page.evaluate(() => document.title)`. For keyword commands, see [Command Reference](#command-reference).
+Both modes auto-detect keyword commands and JavaScript expressions. For DOM access use `await page.evaluate(() => document.title)`. For keyword commands, see [Command Reference](#command-reference).
 
 ## CLI Options
 
 | Option | Description |
 |--------|-------------|
-| `-b, --browser <type>` | Browser: `chrome`, `firefox`, `webkit`, `msedge` |
-| `--headed` | Run browser in headed (visible) mode |
-| `--persistent` | Use persistent browser profile |
-| `--profile <dir>` | Persistent profile directory |
-| `--bridge` | Start WebSocket bridge server; Chrome extension connects to CLI |
+| `--headless` | Run browser in headless mode (default: headed) |
+| `--bridge` | Connect to existing Chrome via WebSocket bridge |
 | `--bridge-port <port>` | Bridge server port (default: `9876`) |
 | `--config <file>` | Path to config file |
 | `--replay <files...>` | Replay `.pw` or `.js` file(s) or folder(s) |

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,8 +1,8 @@
 # @playwright-repl/core
 
-Shared parser, servers, and utilities for the playwright-repl ecosystem.
+Shared parser, connections, and utilities for the playwright-repl ecosystem.
 
-Used by [`playwright-repl`](../cli/README.md) (CLI), [`@playwright-repl/runner`](../runner/README.md) (runner), and [`@playwright-repl/mcp`](../mcp/README.md) (MCP server).
+Used by [`playwright-repl`](../cli/README.md) (CLI), [`@playwright-repl/runner`](../runner/README.md) (runner), [`@playwright-repl/mcp`](../mcp/README.md) (MCP server), and the [VS Code extension](../vscode/README.md).
 
 ## Install
 
@@ -12,53 +12,66 @@ npm install @playwright-repl/core
 
 ## Key Exports
 
-### `BridgeServer`
+### `EvaluateConnection`
 
-WebSocket server that the Dramaturg Chrome extension connects to. Used by the CLI (`--bridge`), MCP server, and `pw repl-extension`.
+Launch Chromium with the Dramaturg extension and execute commands via `serviceWorker.evaluate()`. No WebSocket bridge needed.
 
 ```typescript
-import { BridgeServer } from '@playwright-repl/core';
+import { EvaluateConnection, findExtensionPath } from '@playwright-repl/core';
 
-const bridge = new BridgeServer();
-await bridge.start(9876);  // default port
+const conn = new EvaluateConnection();
+const { chromium } = await import('@playwright/test');
+const extPath = findExtensionPath(import.meta.url);
 
-bridge.onConnect(() => console.log('Extension connected'));
-bridge.onDisconnect(() => console.log('Extension disconnected'));
+await conn.start(extPath, { headed: true, chromium });
 
-await bridge.waitForConnection();
-
-const result = await bridge.run('snapshot');
+const result = await conn.run('snapshot');
 console.log(result.text);
 
-await bridge.close();
+await conn.runScript('await page.title()', 'javascript');
+
+await conn.close();
 ```
 
 **Methods:**
 
 | Method | Description |
 |--------|-------------|
-| `start(port?)` | Start WebSocket server (default port `9876`) |
-| `run(command)` | Send a command to the extension, returns `EngineResult` |
-| `runScript(script, language)` | Send a multi-line script (`'pw'` or `'javascript'`) |
-| `waitForConnection(timeoutMs?)` | Wait until extension connects (default 30s) |
-| `onConnect(fn)` | Callback when extension connects |
-| `onDisconnect(fn)` | Callback when extension disconnects |
-| `connected` | `boolean` — whether extension is connected |
-| `close()` | Shut down the server |
+| `start(extensionPath, opts)` | Launch Chromium with extension |
+| `run(command, opts?)` | Execute a keyword command or JS expression |
+| `runScript(script, language)` | Execute a multi-line script (`'pw'` or `'javascript'`) |
+| `evaluate(fn, arg?)` | Run arbitrary code in the service worker |
+| `connected` | `boolean` — whether the connection is active |
+| `context` | Playwright browser context |
+| `serviceWorker` | Extension service worker handle |
+| `close()` | Close the browser |
 
----
+### `BridgeServer`
 
-### `CommandServer`
+WebSocket server for connecting to an existing Chrome with the Dramaturg extension installed. Used by CLI `--bridge` mode and MCP bridge mode.
 
-HTTP server for external command execution. Used by `--server` mode (AI agents) and extension mode.
+```typescript
+import { BridgeServer } from '@playwright-repl/core';
 
-**Endpoints:**
+const bridge = new BridgeServer();
+await bridge.start(9876);
 
-| Endpoint | Description |
-|----------|-------------|
-| `POST /run` | Execute a command via `engine.run()` |
-| `POST /select-tab` | Switch active page by URL |
-| `GET /health` | Server status check |
+await bridge.waitForConnection();
+const result = await bridge.run('snapshot');
+
+await bridge.close();
+```
+
+### `findExtensionPath`
+
+Find the Dramaturg Chrome extension dist path. Checks monorepo first, then bundled npm location.
+
+```typescript
+import { findExtensionPath } from '@playwright-repl/core';
+
+const extPath = findExtensionPath(import.meta.url);
+// → '/path/to/packages/extension/dist' or null
+```
 
 ---
 
@@ -71,27 +84,6 @@ import { parseInput } from '@playwright-repl/core';
 
 parseInput('click "Submit"');
 // → { _: ['click', 'Submit'] }
-
-parseInput('fill "Email" user@example.com');
-// → { _: ['fill', 'Email', 'user@example.com'] }
-
-parseInput('snapshot');
-// → { _: ['snapshot'] }
-```
-
-Returns `null` for unrecognized commands.
-
----
-
-### `buildCompletionItems`
-
-Autocomplete data for all `.pw` commands, with descriptions and usage hints.
-
-```typescript
-import { buildCompletionItems } from '@playwright-repl/core';
-
-const items = buildCompletionItems();
-// → [{ label: 'goto', detail: 'Navigate to a URL', ... }, ...]
 ```
 
 ---
@@ -115,14 +107,15 @@ interface ParsedArgs {
 
 ```
 src/
-├── bridge-server.ts    # WebSocket bridge server (BridgeServer)
-├── extension-server.ts # HTTP command server (CommandServer)
-├── parser.ts           # Command parsing + alias resolution
-├── page-scripts.ts     # Text locators + assertion helpers
-├── completion-data.ts  # Autocomplete items for all commands
-├── filter.ts           # Response filtering
-├── resolve.ts          # COMMANDS map, minimist re-export, version
-├── colors.ts           # ANSI color helpers
-├── types.ts            # Shared type definitions
-└── index.ts            # Public exports
+├── evaluate-connection.ts # serviceWorker.evaluate() connection + findExtensionPath
+├── bridge-server.ts       # WebSocket bridge server (BridgeServer)
+├── parser.ts              # Command parsing, alias resolution, resolveArgs
+├── page-scripts.ts        # Text locators + assertion helpers
+├── completion-data.ts     # Autocomplete items for all commands
+├── snapshot-parser.ts     # Snapshot tree parsing + ref-to-locator
+├── filter.ts              # Response filtering
+├── resolve.ts             # COMMANDS map, minimist re-export, version
+├── colors.ts              # ANSI color helpers
+├── types.ts               # Shared type definitions
+└── index.ts               # Public exports
 ```

--- a/packages/extension/src/background.ts
+++ b/packages/extension/src/background.ts
@@ -427,10 +427,8 @@ async function handleBridgeCommand(msg: {
   return result;
 }
 
-// Expose for VS Code CDP injection when chrome.offscreen is unavailable
+// Expose for serviceWorker.evaluate() and VS Code CDP injection
 (self as any).handleBridgeCommand = handleBridgeCommand;
-// Expose for serviceWorker.evaluate() — direct command execution without bridge
-(self as any)._runCommand = executeSingleCommand;
 
 // ─── Message Handler ─────────────────────────────────────────────────────────
 

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -4,7 +4,7 @@ MCP server that lets AI agents (Claude Desktop, Claude Code, or any MCP client) 
 
 Two modes:
 - **Bridge mode** (default) — controls your real Chrome browser through the **Dramaturg** Chrome extension
-- **Standalone mode** (`--standalone`) — launches its own browser via Playwright, no extension needed
+- **Standalone mode** (`--standalone`) — launches Chromium with the Dramaturg extension, supports keyword commands and JavaScript
 
 ## Why
 
@@ -53,10 +53,10 @@ Playwright running in your real Chrome session
 Claude Desktop / Claude Code (or any MCP client)
   ↕ MCP (stdio)
 playwright-repl MCP server
-  ↕ Engine.run() (in-process)
-Playwright BrowserServerBackend
-  ↕ CDP
-Browser (launched by Playwright)
+  ↕ serviceWorker.evaluate()
+Dramaturg extension (service worker)
+  ↕ playwright-crx
+Chromium (launched with extension)
 ```
 
 ## Setup
@@ -77,12 +77,12 @@ Load `packages/extension/dist/` as an unpacked extension in Chrome (`chrome://ex
 
 Or install from the [Chrome Web Store](https://chromewebstore.google.com/detail/dramaturg/ppbkmncnmjkfppilnmplpokdfagobipa).
 
-#### Standalone mode — no extension needed
+#### Standalone mode — launches browser with extension
 
-Add `--standalone` to the MCP server command. The server launches its own browser via Playwright.
+Add `--standalone` to the MCP server command. The server launches Chromium with the Dramaturg extension pre-installed.
 
 - Default: headless. Add `--headed` to show the browser window.
-- Only `.pw` keyword commands are supported (no raw Playwright API or JavaScript expressions). Use `run-code` or `eval` keywords within `.pw` mode for Playwright API / JS.
+- Supports both keyword commands and JavaScript/Playwright API.
 
 ### 3. Configure your MCP client
 
@@ -180,9 +180,9 @@ select "Country" "United States"     # select dropdown option
 localstorage-list                    # list localStorage
 ```
 
-### Playwright API / JavaScript (bridge mode only)
+### Playwright API / JavaScript
 
-In bridge mode, `run_command` also accepts raw Playwright expressions and JavaScript:
+Both modes accept raw Playwright expressions and JavaScript:
 
 ```
 await page.url()
@@ -192,9 +192,6 @@ await page.getByRole('link', { name: 'Get started', exact: true }).click()
 await page.evaluate(() => document.title)
 await page.evaluate(() => document.querySelectorAll('a').length)
 ```
-
-> In standalone mode, use the `run-code` or `eval` keywords to run Playwright API / JavaScript:
-> `run-code await page.url()` or `eval document.title`.
 
 ## Tool: `run_script`
 
@@ -211,9 +208,7 @@ press Enter
 verify-text "Buy groceries"
 ```
 
-> In standalone mode, `run_script` only accepts `.pw` keyword scripts (no `language` parameter needed).
-
-### JavaScript (`language="javascript"`) — bridge mode only
+### JavaScript (`language="javascript"`)
 
 Runs the entire block as one evaluation — use for Playwright API with assertions:
 

--- a/packages/runner/README.md
+++ b/packages/runner/README.md
@@ -1,12 +1,12 @@
 # @playwright-repl/runner
 
-Drop-in replacement for `npx playwright test` with context reuse. Keeps the browser open between tests — no teardown/recreate per test.
+Drop-in replacement for `npx playwright test` — 2.8x faster for browser-only tests.
 
 ## Performance
 
-Bridge mode sends test scripts directly to the browser, bypassing the Playwright test runner entirely. This eliminates the per-run overhead (worker startup, TypeScript compilation, fixture setup) that dominates single-test execution time in the IDE.
+`pw test` compiles tests with esbuild and executes them directly in the browser via the Dramaturg Chrome extension's service worker (`serviceWorker.evaluate()`). This bypasses the Playwright test runner overhead (worker startup, TypeScript compilation, fixture setup).
 
-Node-mode tests that need server-side APIs fall back to the standard Playwright test runner, but reuse the existing browser via CDP instead of launching a new one.
+Node-mode tests that need server-side APIs fall back to the standard Playwright test runner automatically.
 
 ## Quick Start
 
@@ -19,72 +19,40 @@ Replace `npx playwright test` with `pw test`:
 ```bash
 pw test                         # run all tests
 pw test todomvc/                # run tests in a folder
-pw test --workers 1             # single worker
-pw test --reporter list         # custom reporter
+pw test --headless              # headless mode
 ```
-
-All Playwright CLI flags work — `pw` passes them through.
 
 ## How It Works
 
-Standard Playwright creates a new browser context for every test. `pw test` reuses the same persistent browser context across tests in the same worker.
+1. **Compile** — esbuild bundles the test with a lightweight shim replacing `@playwright/test`
+2. **Launch** — Chromium starts with the Dramaturg extension via `launchPersistentContext`
+3. **Execute** — compiled test sent to the service worker via `serviceWorker.evaluate()`
+4. **Results** — pass/fail returned directly, no test runner process needed
 
-- **Bridge mode** — compiles the test with esbuild, sends it to the Chrome extension for in-browser execution. Bypasses the Playwright test runner for near-instant feedback in the IDE
-- **Node mode** — falls back to standard Playwright for tests that use Node-only APIs (fs, net, etc.). Reuses the existing browser via CDP when available
-- **Automatic routing** — static analysis detects which mode each test needs
+Tests that use Node-only APIs (`fs`, `net`, `child_process`) are detected by static analysis and fall back to standard Playwright automatically.
 
 ## pw Commands
 
 ```bash
-pw test [files...]                       # run Playwright tests with context reuse
-pw launch --port 9222                    # launch Chrome with extension + CDP port
-pw launch --port 9222 --bridge-port 9877 # custom bridge port
-pw launch --port 9222 --headless         # headless mode
-pw repl --port 9222                      # Node REPL with Playwright globals
-pw repl --port 9222 script.js            # run script, exit (browser stays alive)
-pw repl-extension --bridge-port 9877     # REPL via extension bridge
-pw close --port 9222                     # close browser
+pw test [files...]              # run Playwright tests (fast path)
+pw repl                         # interactive REPL with keyword + JS support
+pw repl --headless              # headless REPL for scripting
+pw repl --port 9222             # connect to existing Chrome via CDP
 ```
 
 ### pw repl
 
-Lightweight Node REPL with `page`, `context`, `browser`, and `expect` as globals. Powered by `node:repl` — full JavaScript with tab completion and history.
-
-```bash
-pw launch --port 9222
-pw repl --port 9222
-```
+Interactive REPL with keyword commands and JavaScript support. Launches Chromium with the extension by default.
 
 ```
-pw> await page.goto('https://example.com')
+pw> goto https://example.com
 pw> await page.title()
 Example Domain
-(3.2ms)
+(5ms)
 pw> await page.locator('a').count()
 1
-(12.4ms)
-pw> 1 + 1
-2
+(12ms)
 ```
-
-### pw repl-extension
-
-REPL that routes commands through the Chrome extension bridge. Useful for testing the extension path.
-
-```bash
-pw launch --port 9222 --bridge-port 9877
-pw repl-extension --bridge-port 9877
-```
-
-## Options
-
-| Option | Description |
-|--------|-------------|
-| `--port <n>` | Chrome CDP port (default: 9222) |
-| `--bridge-port <n>` | BridgeServer WebSocket port (default: 9877) |
-| `--headless` | Launch browser in headless mode |
-
-All `pw test` options are passed through to Playwright.
 
 ## CI Setup
 
@@ -96,7 +64,7 @@ All `pw test` options are passed through to Playwright.
   run: npx playwright install --with-deps chromium
 
 - name: Run tests
-  run: npx pw test
+  run: npx pw test --headless
 ```
 
 ## Compatibility
@@ -105,7 +73,7 @@ Works with standard `@playwright/test` tests. No changes needed to your test fil
 
 **Supported:** All Playwright test features — fixtures, assertions, test.describe, test.beforeEach, etc.
 
-**Bridge mode limitations:** Tests that use Node-only APIs (`fs`, `net`, `child_process`) automatically fall back to Node mode.
+**Automatic fallback:** Tests that use Node-only APIs automatically fall back to standard Playwright.
 
 ## Development
 


### PR DESCRIPTION
## Summary
- Update all READMEs and CLAUDE.md for the new architecture
- Remove unused `_runCommand` from extension background.ts
- 120 additions, 196 deletions

## Changes
- **Root README**: standalone launches Chromium with extension, JS support, pw commands updated
- **CLI README**: headed default, --headless flag, JS in both modes, removed --extension/--server
- **Core README**: EvaluateConnection as primary export, updated file structure
- **MCP README**: standalone uses evaluate, JS in both modes, updated architecture diagram
- **Runner README**: rewritten for 2.8x faster evaluate mode, removed pw launch/close/repl-extension
- **CLAUDE.md**: EvaluateConnection replaces Engine/CommandServer in architecture section
- **background.ts**: remove unused `_runCommand` line

🤖 Generated with [Claude Code](https://claude.com/claude-code)