### PR TITLE
fix: include vscode extension in root build script

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "packageManager": "pnpm@10.26.0",
   "scripts": {
-    "build": "tsc --build packages/core/tsconfig.build.json packages/cli/tsconfig.build.json packages/mcp/tsconfig.build.json packages/runner/tsconfig.build.json && pnpm --filter @playwright-repl/extension run build",
+    "build": "tsc --build packages/core/tsconfig.build.json packages/cli/tsconfig.build.json packages/mcp/tsconfig.build.json packages/runner/tsconfig.build.json && pnpm --filter @playwright-repl/extension run build && pnpm --filter playwright-repl-vscode run build",
     "test": "pnpm run --recursive --if-present test",
     "test:core": "pnpm --filter @playwright-repl/core run test",
     "test:cli": "pnpm --filter playwright-repl run test"


### PR DESCRIPTION
## Summary
- Add `pnpm --filter playwright-repl-vscode run build` to the root `build` script so `pnpm run build` at repo root builds all packages including the VS Code extension

Closes #570

🤖 Generated with [Claude Code](https://claude.com/claude-code)