### PR TITLE
feat: detect screencast/tracing/saveAs as Node-only APIs

### DIFF
--- a/packages/runner/src/bridge-utils.cts
+++ b/packages/runner/src/bridge-utils.cts
@@ -38,6 +38,10 @@ const NODE_API_PATTERNS: RegExp[] = [
   /\.waitForRequest\s*\(/,
   /\.\$eval\s*\(/,
   /\.\$\$eval\s*\(/,
+  // Filesystem-dependent APIs (SW uses memfs — files not persisted to disk)
+  /\.screencast\./,
+  /\.tracing\./,
+  /\.saveAs\s*\(/,
 ];
 
 /**

--- a/packages/runner/src/compiler/classify.ts
+++ b/packages/runner/src/compiler/classify.ts
@@ -17,6 +17,8 @@ const NODE_ONLY_METHODS = new Set([
   'route', 'unroute', 'routeFromHAR', 'unrouteAll',
   'waitForEvent', 'waitForResponse', 'waitForRequest',
   'frames', 'mainFrame',
+  // Filesystem-dependent APIs (SW uses memfs — files not persisted to disk)
+  'screencast', 'tracing', 'saveAs',
 ]);
 
 /**


### PR DESCRIPTION
## Summary
- Add `.screencast.`, `.tracing.`, `.saveAs(` to Node API detection patterns
- Tests using these APIs will route to Node execution instead of the service worker
- SW uses memfs which can't persist files to disk — Node has real filesystem access

Closes #576

## Files changed
- `packages/runner/src/bridge-utils.cts` — `NODE_API_PATTERNS` (used by VS Code)
- `packages/runner/src/compiler/classify.ts` — `NODE_ONLY_METHODS` (unused currently, kept in sync)

## Test plan
- [x] Build passes
- [x] Existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)