### PR TITLE
fix: locator generation for paragraph and long-text elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## v0.23.1
+
+**2026-04-05**
+
+### Fixes
+
+- **Element picker**: Fix locator generation for `<p>` and other long-text elements — use `getByText()` with a truncated substring instead of falling back to a generic CSS selector like `locator('p')`. ([#579](https://github.com/stevez/playwright-repl/issues/579))
+- **ARIA roles**: Add `paragraph` implicit role for `<p>` elements.
+
 ## v0.23.0 — Upgrade to Playwright 1.59.1
 
 **2026-04-05**

--- a/packages/extension/src/content/locator.ts
+++ b/packages/extension/src/content/locator.ts
@@ -25,6 +25,7 @@ export const IMPLICIT_ROLES: Record<string, string | ((el: Element) => string | 
     MAIN: 'main',
     HEADER: 'banner',
     FOOTER: 'contentinfo',
+    P: 'paragraph',
     UL: 'list', OL: 'list',
     LI: 'listitem',
     TABLE: 'table',
@@ -320,9 +321,12 @@ export function generateLocator(el: Element): string {
     const title = el.getAttribute('title');
     if (title) return `getByTitle(${escapeString(title)})`;
 
-    // 7. Text content
+    // 7. Text content (use substring for long text — getByText does partial matching)
     const text = (el.textContent || '').trim();
-    if (text && text.length <= 80) return `getByText(${escapeString(text)})`;
+    if (text) {
+        const snippet = text.length <= 80 ? text : text.slice(0, 50).replace(/\s+\S*$/, '');
+        if (snippet) return `getByText(${escapeString(snippet)})`;
+    }
 
     // 8. Role without name
     if (role) return `getByRole(${escapeString(role)})`;

--- a/packages/vscode/CHANGELOG.md
+++ b/packages/vscode/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.23.1
+
+**2026-04-05**
+
+### Fixes
+
+- Fix locator generation for `<p>` and long-text elements — use `getByText()` with substring instead of generic CSS selector
+
 ## 0.23.0
 
 **2026-04-05**


### PR DESCRIPTION
## Summary

- Add `paragraph` implicit ARIA role for `<p>` elements
- Use `getByText()` with a truncated substring (50 chars at word boundary) for elements with text > 80 chars, instead of falling back to generic CSS selectors like `locator('p')`

Closes #579

## Test plan

- [x] All 119 locator unit tests pass
- [x] Manual verification on playwright.dev — paragraph now generates `getByText(...)` instead of `locator('p')`

🤖 Generated with [Claude Code](https://claude.com/claude-code)