### PR TITLE
feat: CDP relay phase 2 — MCP bridge integration + CLI relay mode

### DIFF
--- a/packages/cli/src/playwright-repl.ts
+++ b/packages/cli/src/playwright-repl.ts
@@ -16,8 +16,8 @@ import { minimist } from '@playwright-repl/core';
 import { startRepl } from './repl.js';
 
 const args = minimist(process.argv.slice(2), {
-  boolean: ['headed', 'headless', 'persistent', 'help', 'step', 'silent', 'spawn', 'bridge', 'include-snapshot', 'verbose'],
-  string: ['session', 'browser', 'profile', 'config', 'replay', 'record', 'connect', 'port', 'cdp-port', 'bridge-port'],
+  boolean: ['headed', 'headless', 'persistent', 'help', 'step', 'silent', 'spawn', 'bridge', 'relay', 'include-snapshot', 'verbose'],
+  string: ['session', 'browser', 'profile', 'config', 'replay', 'record', 'connect', 'port', 'cdp-port', 'bridge-port', 'relay-port'],
   alias: { s: 'session', h: 'help', b: 'browser', q: 'silent' },
   default: { session: 'default' },
 });
@@ -42,6 +42,8 @@ Options:
   --connect [port]       Connect to existing Chrome via CDP (default: 9222)
   --bridge               Connect to extension via WebSocket bridge (no CDP required)
   --bridge-port <port>   WebSocket bridge port (default: 9876)
+  --relay                Connect to extension via CDP relay (full Playwright API)
+  --relay-port <port>    CDP relay port (default: 9877)
   --cdp-port <number>    Chrome CDP port (default: 9222)
   --include-snapshot     Include snapshot in update command responses
   --verbose              Show raw response headers (### Result, ### Snapshot, etc.)
@@ -104,6 +106,8 @@ startRepl({
   silent: args.silent as boolean,
   bridge: args.bridge as boolean,
   bridgePort: args['bridge-port'] ? parseInt(args['bridge-port'] as string, 10) : undefined,
+  relay: args.relay as boolean,
+  relayPort: args['relay-port'] ? parseInt(args['relay-port'] as string, 10) : undefined,
   includeSnapshot: args['include-snapshot'] as boolean,
   verbose: args.verbose as boolean,
 }).catch((err: Error) => {

--- a/packages/cli/src/repl.ts
+++ b/packages/cli/src/repl.ts
@@ -28,6 +28,8 @@ export interface ReplOpts extends EngineOpts {
   silent?: boolean;
   bridge?: boolean;
   bridgePort?: number;
+  relay?: boolean;
+  relayPort?: number;
   includeSnapshot?: boolean;
   verbose?: boolean;
 }
@@ -1018,7 +1020,7 @@ export async function startRepl(opts: ReplOpts = {}): Promise<void> {
 
   // ─── Standalone mode (new: serviceWorker.evaluate) ─────────────
 
-  if (!opts.bridge && !opts.connect) {
+  if (!opts.bridge && !opts.relay && !opts.connect) {
     const { EvaluateConnection, findExtensionPath } = await import('@playwright-repl/core');
     const extPath = process.env.VITEST ? null : findExtensionPath(import.meta.url);
     if (extPath) {
@@ -1041,6 +1043,78 @@ export async function startRepl(opts: ReplOpts = {}): Promise<void> {
         log(`${c.dim}Falling back to standard engine...${c.reset}\n`);
       }
     }
+  }
+
+  // ─── Relay mode (CDP relay → full Playwright API) ────────────────
+
+  if (opts.relay) {
+    const { CdpRelay } = await import('@playwright-repl/core');
+    const relayPort = opts.relayPort ?? 9877;
+    const relay = new CdpRelay();
+    await relay.start(relayPort);
+    log(`CDP relay listening on port ${relayPort}`);
+    log('Waiting for extension to connect...');
+    log(`${c.dim}Set cdpRelayPort to ${relayPort} in extension preferences${c.reset}`);
+    await relay.waitForExtension(120000);
+    log(`${c.green}✓${c.reset} Extension connected`);
+
+    const { chromium } = await import('playwright');
+    const browser = await chromium.connectOverCDP(relay.wsUrl, { isLocal: true });
+    const context = browser.contexts()[0];
+    const pages = context?.pages() ?? [];
+    log(`${c.green}✓${c.reset} Connected — ${pages.length} page(s)`);
+    for (const p of pages) log(`  ${c.dim}${p.url()}${c.reset}`);
+
+    const page = pages[0];
+    if (!page) { console.error('No page found'); process.exit(1); }
+
+    log(`\n${c.dim}Globals: browser, context, page${c.reset}`);
+    log(`${c.dim}Type .quit to exit${c.reset}\n`);
+
+    const rl = readline.createInterface({ input: process.stdin, output: process.stdout, prompt: `${c.cyan}relay>${c.reset} ` });
+    rl.prompt();
+
+    rl.on('line', async (line) => {
+      const cmd = line.trim();
+      if (cmd === '.quit' || cmd === '.exit') { rl.close(); return; }
+      if (!cmd) { rl.prompt(); return; }
+
+      // Local commands (video, etc.)
+      if (isLocalCommand(cmd)) {
+        const result = await handleLocalCommand(cmd, context);
+        if (result) console.log(result.isError ? `${c.red}✗${c.reset} ${result.text}` : result.text);
+        rl.prompt();
+        return;
+      }
+
+      // Evaluate as JavaScript with page/context/browser in scope
+      try {
+        const result = await eval(`(async () => { return ${cmd}; })()`);
+        if (result !== undefined) {
+          if (typeof result === 'string' || typeof result === 'number' || typeof result === 'boolean')
+            console.log(result);
+          else if (result === null)
+            console.log('null');
+          else if (typeof result?.status === 'function' && typeof result?.url === 'function')
+            console.log(`Response: ${result.status()} ${result.url()}`);
+          else if (typeof result?.toString === 'function' && result.toString() !== '[object Object]')
+            console.log(result.toString());
+          else
+            console.log(JSON.stringify(result, null, 2));
+        }
+      } catch (err: unknown) {
+        console.error(`${c.red}Error:${c.reset} ${(err as Error).message}`);
+      }
+      rl.prompt();
+    });
+
+    rl.on('close', async () => {
+      log('\nCleaning up...');
+      await browser.close().catch(() => {});
+      await relay.close();
+      process.exit(0);
+    });
+    return;
   }
 
   // ─── Bridge mode ─────────────────────────────────────────────────

--- a/packages/extension/src/lib/cdp-relay-handler.ts
+++ b/packages/extension/src/lib/cdp-relay-handler.ts
@@ -89,14 +89,27 @@ async function doAttachToTab(): Promise<{ targetInfo: Record<string, unknown> }>
   });
   attachedTabId = tabId;
 
-  // Get targetInfo from CDP (matches Playwright MCP extension approach)
-  const result: any = await new Promise((resolve, reject) => {
-    chrome.debugger.sendCommand({ tabId }, 'Target.getTargetInfo', {}, (r: unknown) => {
-      if (chrome.runtime.lastError) reject(new Error(chrome.runtime.lastError.message));
-      else resolve(r);
+  // Get targetInfo from CDP, fall back to chrome.tabs data
+  let targetInfo: Record<string, unknown> | undefined;
+  try {
+    const result: any = await new Promise((resolve, reject) => {
+      chrome.debugger.sendCommand({ tabId }, 'Target.getTargetInfo', {}, (r: unknown) => {
+        if (chrome.runtime.lastError) reject(new Error(chrome.runtime.lastError.message));
+        else resolve(r);
+      });
     });
-  });
-  return { targetInfo: result?.targetInfo };
+    targetInfo = result?.targetInfo;
+  } catch { /* fall through to fallback */ }
+  if (!targetInfo || !targetInfo.targetId) {
+    targetInfo = {
+      targetId: String(tabId),
+      type: 'page',
+      title: tab.title || '',
+      url: tab.url || '',
+      browserContextId: 'default',
+    };
+  }
+  return { targetInfo };
 }
 
 async function doForwardCommand(method: string, params?: Record<string, unknown>, sessionId?: string): Promise<unknown> {

--- a/packages/mcp/src/bridge.ts
+++ b/packages/mcp/src/bridge.ts
@@ -2,7 +2,7 @@
  * Bridge runner — connects to Chrome via the Dramaturg extension over WebSocket.
  */
 
-import { BridgeServer, UPDATE_COMMANDS, parseInput } from '@playwright-repl/core';
+import { BridgeServer, CdpRelay, UPDATE_COMMANDS, parseInput, handleLocalCommand, isLocalCommand } from '@playwright-repl/core';
 import type { EngineResult } from '@playwright-repl/core';
 import type { RunnerModule, SnapshotCache } from './types.js';
 import { logEvent } from './logger.js';
@@ -57,12 +57,41 @@ export async function createBridgeRunner(
     srv.onConnect(() => { console.error('Extension connected'); logEvent('Extension connected'); });
     srv.onDisconnect(() => { console.error('Extension disconnected'); logEvent('Extension disconnected'); });
 
+    // CDP relay for local commands (screencast, tracing) — optional
+    const relayPortIdx = argv.indexOf('--relay-port');
+    const relayPort = relayPortIdx !== -1
+        ? parseInt(argv[relayPortIdx + 1])
+        : (process.env.CDP_RELAY_PORT ? parseInt(process.env.CDP_RELAY_PORT) : 9877);
+
+    const relay = new CdpRelay();
+    let relayContext: any = null;
+    relay.start(relayPort).then(() => {
+        console.error(`CDP relay listening on port ${relayPort}`);
+        logEvent(`CDP relay on port ${relayPort}`);
+        relay.waitForExtension(0).then(async () => {
+            const pw = 'playwright';
+            const { chromium } = await import(pw);
+            const browser = await chromium.connectOverCDP(relay.wsUrl, { isLocal: true });
+            relayContext = browser.contexts()[0] ?? null;
+            console.error('CDP relay connected — local commands available');
+            logEvent('CDP relay connected');
+        }).catch(() => {});
+    }).catch(() => {});
+
     return {
         descriptions,
         runner: {
             async runCommand(command: string): Promise<EngineResult> {
                 if (!srv.connected) {
                     return { text: 'Browser not connected. Open Chrome with the playwright-repl extension — it connects automatically.', isError: true };
+                }
+
+                // Local commands (video, etc.) — route through CDP relay's context
+                if (isLocalCommand(command)) {
+                    if (!relayContext)
+                        return { text: 'Local commands require CDP relay. Ensure the extension is connected on the relay port.', isError: true };
+                    const localResult = await handleLocalCommand(command, relayContext);
+                    if (localResult) return localResult;
                 }
 
                 // Determine command name for snapshot logic


### PR DESCRIPTION
## Summary

- **MCP bridge mode**: Start CdpRelay alongside BridgeServer, route local commands (screencast, tracing) through CDP relay's context
- **CLI `--relay` mode**: Full Playwright REPL with real `page` object on user's existing browser
- **Screencast works**: `video-start`/`video-stop` and `page.screencast.start()/stop()` both work through CDP relay

### Changes

- `packages/mcp/src/bridge.ts` — CdpRelay alongside BridgeServer, local command routing
- `packages/cli/src/playwright-repl.ts` — `--relay` and `--relay-port` flags
- `packages/cli/src/repl.ts` — relay mode branch with Playwright REPL, smart output formatting
- `packages/extension/src/lib/cdp-relay-handler.ts` — fallback targetInfo from chrome.tabs

Closes #584

## Test plan

- [x] `playwright-repl --relay` → connects, `page.title()` works
- [x] `page.screencast.start()/stop()` — records video on user's existing browser
- [x] `video-start`/`video-stop` keyword commands work in relay mode
- [x] Build passes
- [ ] MCP bridge mode with CDP relay

🤖 Generated with [Claude Code](https://claude.com/claude-code)