### PR TITLE
fix: CDP relay polish — detach on disconnect, default off

### DIFF
--- a/packages/cli/src/repl.ts
+++ b/packages/cli/src/repl.ts
@@ -1058,6 +1058,16 @@ export async function startRepl(opts: ReplOpts = {}): Promise<void> {
     await relay.waitForExtension(120000);
     log(`${c.green}✓${c.reset} Extension connected`);
 
+    // Prevent crashes from CDP session errors during cross-origin navigation.
+    // Playwright's CRSession throws assertions inside setImmediate — uncaughtException
+    // is the only way to catch them without crashing.
+    process.on('uncaughtException', (err) => {
+      const msg = err?.message ?? '';
+      if (msg.includes('session') || msg.includes('Session') || msg.includes('No frame'))
+        console.error(`${c.yellow}⚠${c.reset} ${c.dim}CDP session error (non-fatal)${c.reset}`);
+      else { console.error(err); process.exit(1); }
+    });
+
     const { chromium } = await import('playwright');
     const browser = await chromium.connectOverCDP(relay.wsUrl, { isLocal: true });
     const context = browser.contexts()[0];

--- a/packages/extension/src/background.ts
+++ b/packages/extension/src/background.ts
@@ -6,7 +6,7 @@ import { loadSettings } from './panel/lib/settings';
 import type { PwReplSettings } from './panel/lib/settings';
 import { parseReplCommand } from './panel/lib/commands';
 import { detectMode } from './panel/lib/execute';
-import { initCdpRelay, handleCdpCommand } from './lib/cdp-relay-handler';
+import { initCdpRelay, detachCdpRelay, handleCdpCommand } from './lib/cdp-relay-handler';
 
 // ─── Patch toMatchAriaSnapshot ──────────────────────────────────────────────
 // toMatchAriaSnapshot requires currentTestInfo() which only exists inside the
@@ -340,6 +340,14 @@ async function executeBridgeExpr(jsExpr: string): Promise<{ text: string; isErro
       if (inner !== null) return formatBridgeResult(`${r.description} {${inner}}`);
     }
 
+    // Playwright Response: extract status + url via method calls
+    if (r.objectId && /^Response\d*$/.test(r.description ?? '')) {
+      const res = await cdpCallFunctionOn(r.objectId,
+        'function(){try{return this.status()+" "+this.url()}catch{return null}}');
+      const summary = res?.result?.value;
+      if (summary) return formatBridgeResult(`Response: ${summary}`);
+    }
+
     // Plain objects/arrays: use JSON.stringify for full nested representation
     if (r.objectId && (r.description === 'Object' || /^Array\(\d+\)$/.test(r.description ?? ''))) {
       const res = await cdpCallFunctionOn(r.objectId,
@@ -583,6 +591,8 @@ async function connectCdpRelay(port: number) {
 
     ws.onclose = () => {
       if (cdpRelayWs === ws) cdpRelayWs = null;
+      // Detach debugger when relay disconnects — prevents stale banner
+      detachCdpRelay();
       cdpRelayReconnectTimer = setTimeout(() => connectCdpRelay(port), 3000);
     };
 

--- a/packages/extension/src/lib/cdp-relay-handler.ts
+++ b/packages/extension/src/lib/cdp-relay-handler.ts
@@ -23,6 +23,11 @@ export function initCdpRelay(send: SendFn): void {
 
 export function disposeCdpRelay(): void {
   sendToNode = null;
+  detachCdpRelay();
+}
+
+/** Detach debugger without clearing event forwarding (safe for reconnect). */
+export function detachCdpRelay(): void {
   if (attachedTabId !== null) {
     chrome.debugger.detach({ tabId: attachedTabId }).catch(() => {});
     attachedTabId = null;

--- a/packages/extension/src/panel/lib/settings.ts
+++ b/packages/extension/src/panel/lib/settings.ts
@@ -5,7 +5,7 @@ export type PwReplSettings = {
     languageMode: 'pw' | 'js',
 };
 
-const DEFAULT: PwReplSettings = { openAs: 'sidepanel', bridgePort: 9876, cdpRelayPort: 9877, languageMode: 'pw' };
+const DEFAULT: PwReplSettings = { openAs: 'sidepanel', bridgePort: 9876, cdpRelayPort: 0, languageMode: 'pw' };
 
 export async function loadSettings(): Promise<PwReplSettings> {
     const stored = await chrome.storage.local.get(['openAs', 'bridgePort', 'cdpRelayPort', 'languageMode']) as Partial<PwReplSettings>;


### PR DESCRIPTION
## Summary

- Detach `chrome.debugger` when relay WebSocket closes — prevents stale debugger banner
- Default `cdpRelayPort` to 0 (disabled) — CDP relay is opt-in only to avoid `chrome.debugger` interfering with normal browsing
- Catch CDP session errors in relay REPL to prevent crashes during cross-origin navigation
- Format Playwright Response objects as `Response: status url`

## Test plan

- [x] Build passes
- [x] Relay mode works with explicit port set
- [x] Bridge mode unaffected when relay port is 0
- [x] No debugger banner after relay process exits

🤖 Generated with [Claude Code](https://claude.com/claude-code)