### PR TITLE
fix: toolbar test broken by video-state useEffect

### DIFF
--- a/packages/extension/test/components/Toolbar.browser.test.tsx
+++ b/packages/extension/test/components/Toolbar.browser.test.tsx
@@ -428,7 +428,9 @@ describe('Toolbar component tests', () => {
     const screen = await renderToolbar();
     await screen.getByRole('button', { name: 'Record' }).click();
 
-    expect(window.chrome.runtime.sendMessage).not.toHaveBeenCalled();
+    expect(window.chrome.runtime.sendMessage).not.toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'record-start' })
+    );
   });
 
   it('should dispatch error when record-start fails', async () => {


### PR DESCRIPTION
## Summary
- Fix failing test "should not record when chrome.tabs.query is unavailable"
- The video-state sync `useEffect` added in #594 calls `sendMessage({ type: 'video-state' })` on mount
- Test was asserting `sendMessage` was never called; now asserts `record-start` specifically was not called

## Test plan
- [ ] CI passes — all 60 toolbar tests green

🤖 Generated with [Claude Code](https://claude.com/claude-code)