### PR TITLE
feat: video-start/video-stop support via CLI/MCP bridge

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -187,6 +187,8 @@ verify text 1 item left
 | [06-edit-todo.pw](examples/06-edit-todo.pw) | Double-click to edit a todo |
 | [07-test-click-nth.pw](examples/07-test-click-nth.pw) | `--nth` disambiguation |
 | [08-localstorage.pw](examples/08-localstorage.pw) | localStorage commands |
+| [09-inspection-commands.pw](examples/09-inspection-commands.pw) | Inspection commands |
+| [10-video-recording.pw](examples/10-video-recording.pw) | Video recording with chapters |
 
 ```bash
 playwright-repl --replay examples/01-add-todos.pw --headed
@@ -322,6 +324,17 @@ pw> highlight --clear                # dismiss the highlight overlay
 | `dialog-dismiss` | Dismiss a browser dialog |
 | `resize <w> <h>` | Resize browser window |
 | `pdf` | Save page as PDF |
+
+### Video Recording
+
+| Command | Description |
+|---------|-------------|
+| `video-start [--size WxH]` | Start video recording |
+| `video-stop` | Stop recording and save video |
+| `video-chapter <title>` | Add chapter marker to recording |
+
+In **standalone mode**, video uses Playwright's screencast API and saves to `~/pw-videos/`.
+In **bridge mode**, video uses Chrome's tab capture and saves to `Downloads/pw-videos/`.
 
 ### Browser Control
 

--- a/packages/core/src/local-commands.ts
+++ b/packages/core/src/local-commands.ts
@@ -80,7 +80,8 @@ export function isLocalCommand(cmd: string): boolean {
  */
 export async function handleLocalCommand(cmd: string, context: BrowserContext | null): Promise<LocalCommandResult | null> {
   if (!isLocalCommand(cmd)) return null;
-  if (!context) return { text: 'Local commands require evaluate mode.', isError: true };
+  // No context → let the command fall through to the bridge (extension handles video via tabCapture)
+  if (!context) return null;
 
   if (isVideoCommand(cmd)) return handleVideoCommand(cmd, context);
 

--- a/packages/extension/src/background.ts
+++ b/packages/extension/src/background.ts
@@ -543,7 +543,20 @@ async function handleBridgeCommand(msg: {
   }
   if (cmd === 'video-stop') {
     const r = await stopVideoCapture();
-    return { text: r.ok ? 'Video recorded' : (r.error || 'Failed'), isError: !r.ok, blobUrl: r.blobUrl, duration: r.duration, size: r.size };
+    if (!r.ok) return { text: r.error || 'Failed', isError: true };
+    // Auto-save to Downloads/pw-videos/ for bridge callers (CLI, MCP)
+    const d = new Date();
+    const timestamp = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}T${String(d.getHours()).padStart(2, '0')}-${String(d.getMinutes()).padStart(2, '0')}-${String(d.getSeconds()).padStart(2, '0')}`;
+    const filename = `pw-videos/pw-video-${timestamp}.webm`;
+    if (r.blobUrl) {
+      chrome.downloads.download({ url: r.blobUrl, filename, saveAs: false });
+      chrome.runtime.sendMessage({ type: 'video-revoke' }).catch(() => {});
+    }
+    const info: string[] = [];
+    if (r.duration) info.push(`${r.duration}s`);
+    if (r.size) info.push(r.size < 1024 * 1024 ? `${(r.size / 1024).toFixed(0)} KB` : `${(r.size / (1024 * 1024)).toFixed(1)} MB`);
+    const suffix = info.length ? ` (${info.join(', ')})` : '';
+    return { text: `Video saved to Downloads/${filename}${suffix}`, isError: false };
   }
 
   if (!currentPage) {

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -178,7 +178,12 @@ screenshot                           # capture page (returned as image to AI)
 check "Remember me"                  # check a checkbox
 select "Country" "United States"     # select dropdown option
 localstorage-list                    # list localStorage
+video-start                          # start video recording
+video-stop                           # stop recording and save video
+video-chapter "Login flow"           # add chapter marker
 ```
+
+Video recordings are saved to `Downloads/pw-videos/` (bridge mode) or `~/pw-videos/` (standalone mode).
 
 ### Playwright API / JavaScript
 

--- a/packages/mcp/src/bridge.ts
+++ b/packages/mcp/src/bridge.ts
@@ -16,7 +16,8 @@ export const descriptions = {
 1. KEYWORD (.pw) — playwright-repl commands:
    snapshot, goto <url>, click <text>, fill <label> <value>, press <key>,
    verify-text <text>, verify-no-text <text>, screenshot,
-   check <label>, select <label> <value>, localstorage-list, localstorage-clear
+   check <label>, select <label> <value>, localstorage-list, localstorage-clear,
+   video-start, video-stop, video-chapter <title>
 
 2. PLAYWRIGHT — Playwright API (page.* / crxApp.*):
    await page.url(), await page.title(),


### PR DESCRIPTION
## Summary
- Video commands (`video-start`, `video-stop`) now work in CLI bridge and MCP bridge mode
- When no Playwright context is available, video commands fall through to the extension which captures via `chrome.tabCapture` and auto-saves to `Downloads/pw-videos/` using `chrome.downloads`
- Added video commands to MCP tool description and documented in CLI/MCP READMEs

## Test plan
- [x] CLI bridge: `playwright-repl --bridge` → `video-start` → actions → `video-stop` → file saved to Downloads
- [x] MCP bridge: Claude Desktop → `run_command("video-start")` → actions → `run_command("video-stop")` → file saved
- [x] Extension panel: video button still works with preview/download UI (unchanged path)
- [x] Standalone/evaluate mode: `page.screencast` path still works (unchanged)

Closes #592

🤖 Generated with [Claude Code](https://claude.com/claude-code)