### PR TITLE
feat: open trace in browser directly from extension

### DIFF
--- a/packages/extension/src/background.ts
+++ b/packages/extension/src/background.ts
@@ -322,6 +322,10 @@ async function stopVideoCapture(): Promise<{ ok: boolean; error?: string; blobUr
   return result ?? { ok: false, error: 'No response from offscreen document' };
 }
 
+// ─── Tracing ─────────────────────────────────────────────────────────────────
+
+let lastTraceData: Uint8Array | null = null;
+
 // ─── Pick Element ────────────────────────────────────────────────────────────
 
 async function startPicking(): Promise<{ ok: boolean; error?: string }> {
@@ -575,6 +579,8 @@ async function handleBridgeCommand(msg: {
       // Read trace from memfs and download via chrome.downloads
       const data = crx.fs.readFileSync(tracePath);
       const bytes = data instanceof Uint8Array ? data : new Uint8Array(data as any);
+      // Keep a copy for "View Trace" in browser
+      lastTraceData = bytes;
       let binary = '';
       for (let i = 0; i < bytes.length; i++) binary += String.fromCharCode(bytes[i]);
       const dataUrl = `data:application/zip;base64,${btoa(binary)}`;
@@ -673,6 +679,7 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
       await app.context().tracing.stop({ path: tracePath });
       const data = crx.fs.readFileSync(tracePath);
       const bytes = data instanceof Uint8Array ? data : new Uint8Array(data as any);
+      lastTraceData = bytes;
       let binary = '';
       for (let i = 0; i < bytes.length; i++) binary += String.fromCharCode(bytes[i]);
       const dataUrl = `data:application/zip;base64,${btoa(binary)}`;
@@ -683,7 +690,7 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
       crx.fs.unlinkSync(tracePath);
       const size = bytes.length;
       const sizeStr = size < 1024 * 1024 ? `${(size / 1024).toFixed(0)} KB` : `${(size / (1024 * 1024)).toFixed(1)} MB`;
-      return { ok: true, text: `Trace saved to Downloads/${filename} (${sizeStr})` };
+      return { ok: true, text: `Trace saved to Downloads/${filename} (${sizeStr})`, size };
     })().then(sendResponse).catch((e: Error) => sendResponse({ ok: false, error: e.message }));
     return true;
   }
@@ -699,6 +706,29 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
   }
   if (msg.type === 'video-preview') {
     chrome.windows.create({ url: msg.blobUrl, type: 'popup', width: 1280, height: 720 });
+    sendResponse({ ok: true });
+    return false;
+  }
+  if (msg.type === 'tracing-view') {
+    if (!lastTraceData) { sendResponse({ ok: false, error: 'No trace data available' }); return false; }
+    const traceBytes = lastTraceData;
+    (async () => {
+      const win = await chrome.windows.create({ url: 'https://trace.playwright.dev/', type: 'popup', width: 1400, height: 900 });
+      const tabId = win.tabs?.[0]?.id;
+      if (!tabId) return;
+      // Wait for page to load, then inject content script and send trace data
+      const onUpdated = (tid: number, info: chrome.tabs.TabChangeInfo) => {
+        if (tid !== tabId || info.status !== 'complete') return;
+        chrome.tabs.onUpdated.removeListener(onUpdated);
+        chrome.scripting.executeScript({
+          target: { tabId },
+          files: ['content/trace-loader.js'],
+        }).then(() => {
+          chrome.tabs.sendMessage(tabId, { type: 'load-trace', data: Array.from(traceBytes) });
+        });
+      };
+      chrome.tabs.onUpdated.addListener(onUpdated);
+    })();
     sendResponse({ ok: true });
     return false;
   }

--- a/packages/extension/src/content/trace-loader.ts
+++ b/packages/extension/src/content/trace-loader.ts
@@ -1,0 +1,12 @@
+// Content script injected into trace.playwright.dev
+// Receives trace data from the background SW and loads it via postMessage.
+
+chrome.runtime.onMessage.addListener((msg) => {
+  if (msg.type !== 'load-trace' || !msg.data) return;
+  const bytes = new Uint8Array(msg.data);
+  const blob = new Blob([bytes], { type: 'application/zip' });
+  window.postMessage({ method: 'load', params: { trace: blob } }, '*');
+});
+
+// Signal ready
+chrome.runtime.sendMessage({ type: 'trace-loader-ready' });

--- a/packages/extension/src/panel/components/Console/ConsoleEntry.tsx
+++ b/packages/extension/src/panel/components/Console/ConsoleEntry.tsx
@@ -60,6 +60,14 @@ export function ConsoleEntry({ entry }: { entry: Entry }) {
                             <div data-type="success"><ObjectTree data={entry.value} getProperties={entry.getProperties} /></div>
                         ) : entry.codeBlock !== undefined ? (
                             <SnapshotCodeBlock codeBlock={entry.codeBlock} />
+                        ) : entry.trace ? (
+                            <div data-type="trace" className="flex items-center gap-2 py-1">
+                                <span className="text-(--color-success)">Trace saved{entry.traceSize ? ` (${formatSize(entry.traceSize)})` : ''}</span>
+                                <button
+                                    className="bg-(--bg-button) text-(--text-default) border border-solid border-(--border-button) rounded-[3px] py-[2px] px-2 font-[inherit] text-[11px] cursor-pointer hover:bg-(--bg-button-hover)"
+                                    onClick={() => chrome.runtime.sendMessage({ type: 'tracing-view' })}
+                                >View Trace</button>
+                            </div>
                         ) : entry.video !== undefined ? (
                             <div data-type="video" className="flex items-center gap-2 py-1">
                                 <span className="text-(--color-success)">Video recorded{entry.videoDuration !== undefined ? ` (${formatDuration(entry.videoDuration)}, ${formatSize(entry.videoSize ?? 0)})` : ''}</span>

--- a/packages/extension/src/panel/components/Console/index.tsx
+++ b/packages/extension/src/panel/components/Console/index.tsx
@@ -19,7 +19,11 @@ function outputLinesToEntries(lines: OutputLine[]): ConsoleEntry[] {
             if (next && next.type !== 'command' && next.type !== 'comment') {
                 const entry: ConsoleEntry = { id, input: line.text, status: next.type === 'error' ? 'error' : 'done', time: next.time };
                 if (next.type === 'success') {
-                    if (next.video) {
+                    if (next.trace) {
+                        entry.trace = true;
+                        entry.traceSize = next.traceSize;
+                        entry.text = next.text;
+                    } else if (next.video) {
                         entry.video = next.video;
                         entry.videoDuration = next.videoDuration;
                         entry.videoSize = next.videoSize;

--- a/packages/extension/src/panel/components/Console/types.ts
+++ b/packages/extension/src/panel/components/Console/types.ts
@@ -26,6 +26,8 @@ export interface ConsoleEntry {
   video?: string;
   videoDuration?: number;
   videoSize?: number;
+  trace?: boolean;
+  traceSize?: number;
   codeBlock?: string;
   errorText?: string;
   getProperties?: (objectId: string) => Promise<unknown>;

--- a/packages/extension/src/panel/components/Console/useConsole.ts
+++ b/packages/extension/src/panel/components/Console/useConsole.ts
@@ -29,6 +29,7 @@ const executors = {
         }
         if (result.image) return { image: result.image as string };
         if ('video' in result && result.video) return { video: result.video, duration: result.duration, size: result.size };
+        if ('trace' in result && result.trace) return { text: result.text || 'Tracing stopped', trace: true, traceSize: result.traceSize };
         const cmd = command.trim().split(/\s+/)[0].toLowerCase();
         if (SNAPSHOT_CMDS.has(cmd)) return { codeBlock: result.text as string };
         return { text: (result.text || 'Done') as string };
@@ -135,10 +136,12 @@ export function useConsole(dispatch: React.Dispatch<Action>) {
 
         try {
             const start = performance.now();
-            const result = await (mode === 'pw' ? executors.pw(trimmed) : executors.js(trimmed)) as { value?: ConsoleEntry['value']; text?: string; image?: string; video?: string; duration?: number; size?: number; codeBlock?: string; getProperties?: ConsoleEntry['getProperties'] };
+            const result = await (mode === 'pw' ? executors.pw(trimmed) : executors.js(trimmed)) as { value?: ConsoleEntry['value']; text?: string; image?: string; video?: string; duration?: number; size?: number; trace?: boolean; traceSize?: number; codeBlock?: string; getProperties?: ConsoleEntry['getProperties'] };
             const time = Math.round(performance.now() - start);
             if (result.value !== undefined) {
                 dispatch({ type: 'COMMAND_SUCCESS', line: { text: '', type: 'success', time, value: result.value, getProperties: result.getProperties } });
+            } else if (result.trace) {
+                dispatch({ type: 'COMMAND_SUCCESS', line: { text: result.text ?? 'Tracing stopped', type: 'success', time, trace: true, traceSize: result.traceSize } });
             } else if (result.video !== undefined) {
                 dispatch({ type: 'COMMAND_SUCCESS', line: { text: 'Video recorded', type: 'success', time, video: result.video, videoDuration: result.duration, videoSize: result.size } });
             } else if (result.image !== undefined) {

--- a/packages/extension/src/panel/lib/bridge.ts
+++ b/packages/extension/src/panel/lib/bridge.ts
@@ -2,7 +2,7 @@ export type CommandResult = { text: string; isError: boolean; image?: string };
 export type { CdpRemoteObject } from '@/components/Console/cdpToSerialized';
 import type { CdpRemoteObject } from '@/components/Console/cdpToSerialized';
 import { parseReplCommand } from './commands';
-export type ConsoleCommandResult = { cdpResult: CdpRemoteObject } | { text: string; image?: string; video?: string; duration?: number; size?: number };
+export type ConsoleCommandResult = { cdpResult: CdpRemoteObject } | { text: string; image?: string; video?: string; duration?: number; size?: number; trace?: boolean; traceSize?: number };
 
 type CdpResult = { type?: string; value?: unknown; description?: string; objectId?: string };
 
@@ -104,7 +104,8 @@ export async function executeCommandForConsole(command: string): Promise<Console
   if (cmdName === 'tracing-start' || cmdName === 'tracing-stop') {
     const r = await chrome.runtime.sendMessage({ type: cmdName });
     if (!r?.ok) throw new Error(r?.error || 'Failed');
-    return { text: r.text || (cmdName === 'tracing-start' ? 'Tracing started' : 'Tracing stopped') };
+    if (cmdName === 'tracing-stop') return { text: r.text || 'Tracing stopped', trace: true, traceSize: r.size };
+    return { text: 'Tracing started' };
   }
 
   const parsed = parseReplCommand(command);

--- a/packages/extension/src/panel/types.ts
+++ b/packages/extension/src/panel/types.ts
@@ -6,6 +6,8 @@ export type OutputLine = {
     video?: string
     videoDuration?: number
     videoSize?: number
+    trace?: boolean
+    traceSize?: number
     value?: unknown
     getProperties?: (objectId: string) => Promise<unknown>
     pickResult?: PickResultData

--- a/packages/extension/vite.config.ts
+++ b/packages/extension/vite.config.ts
@@ -14,6 +14,7 @@ function contentScriptPlugin(): Plugin {
   const contentScripts = [
     { entry: resolve(__dirname, "src/content/picker.ts"), out: "content/picker.js" },
     { entry: resolve(__dirname, "src/content/recorder.ts"), out: "content/recorder.js" },
+    { entry: resolve(__dirname, "src/content/trace-loader.ts"), out: "content/trace-loader.js" },
   ];
   return {
     name: 'content-script-bundle',


### PR DESCRIPTION
## Summary
- After `tracing-stop`, the console shows a **View Trace** button alongside the save confirmation
- Clicking it opens `trace.playwright.dev` in a popup window and loads the trace automatically via `postMessage`
- No file upload, no external service — trace data stays local

## How it works
1. `tracing-stop` keeps trace bytes in `lastTraceData` in the background SW
2. Console renders a "View Trace" button (like video's Preview/Save buttons)
3. Button sends `{ type: 'tracing-view' }` message to background SW
4. Background opens a popup window to `trace.playwright.dev`
5. Injects `content/trace-loader.js` content script
6. Content script receives trace bytes and calls `window.postMessage({ method: 'load', params: { trace: blob } })`
7. Trace Viewer's built-in `postMessage` listener picks it up and loads the trace

## Test plan
- [x] `tracing-start` → actions → `tracing-stop` → "View Trace" button appears in console
- [x] Click "View Trace" → popup opens → trace loads in Trace Viewer
- [x] Popup window doesn't affect the automated page

Closes #605

🤖 Generated with [Claude Code](https://claude.com/claude-code)