### PR TITLE
fix: remove video-chapter from E2E test to fix slow CI

### DIFF
--- a/packages/cli/examples/10-video-recording.pw
+++ b/packages/cli/examples/10-video-recording.pw
@@ -7,7 +7,6 @@ localstorage-clear
 reload
 
 video-start
-video-chapter "Adding todos"
 fill textbox "What needs to be done?" "Buy groceries"
 press Enter
 fill textbox "What needs to be done?" "Write tests"
@@ -15,11 +14,9 @@ press Enter
 fill textbox "What needs to be done?" "Deploy to production"
 press Enter
 
-video-chapter "Completing a todo"
 check "Buy groceries"
 verify-text "2 items left"
 
-video-chapter "Filtering"
 click link "Completed"
 verify-text "Buy groceries"
 


### PR DESCRIPTION
## Summary
Remove `video-chapter` lines from `10-video-recording.pw` example. Each chapter takes ~2.3s (Playwright's default overlay duration), adding ~7s to the CLI E2E suite.

Before: 10 tests, ~11s
After: 10 tests, ~4s (expected)

The `video-start` / `video-stop` coverage is preserved.

Closes #610

🤖 Generated with [Claude Code](https://claude.com/claude-code)