### PR TITLE
feat: tracing-start/tracing-stop via CLI/MCP bridge

### DIFF
--- a/packages/cli/examples/11-tracing.pw
+++ b/packages/cli/examples/11-tracing.pw
@@ -1,0 +1,23 @@
+# Record a trace of adding todos
+# App: https://demo.playwright.dev/todomvc/
+# Trace saved to ~/pw-traces/
+# View with: npx playwright show-trace ~/pw-traces/trace-*.zip
+
+goto https://demo.playwright.dev/todomvc/
+localstorage-clear
+reload
+
+tracing-start
+fill textbox "What needs to be done?" "Buy groceries"
+press Enter
+fill textbox "What needs to be done?" "Write tests"
+press Enter
+
+check "Buy groceries"
+click link "Completed"
+verify-text "Buy groceries"
+
+tracing-stop
+
+# Cleanup
+localstorage-clear

--- a/packages/cli/src/repl.ts
+++ b/packages/cli/src/repl.ts
@@ -649,18 +649,8 @@ function attachGhostCompletion(rl: any, items: CompletionItem[]): void {
   rl._ttyWrite = function (s: string, key: { name: string }) {
     // Tab handling — based on matches, not ghost text
     if (key && key.name === 'tab') {
-      // Cycle through multiple matches
-      if (matches.length > 1) {
-        rl.output.write('\x1b[K');
-        ghost = '';
-        matchIdx = (matchIdx + 1) % matches.length;
-        const input = rl.line || '';
-        const suffix = matches[matchIdx].slice(input.length);
-        if (suffix) renderGhost(suffix);
-        return;
-      }
-      // Single match — accept it
-      if (ghost && matches.length === 1) {
+      if (matches.length >= 1 && ghost) {
+        // Accept the currently shown ghost text
         const text = ghost;
         rl.output.write('\x1b[K');
         ghost = '';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -21,5 +21,5 @@ export type { CompletionItem } from './completion-data.js';
 export type { CommandInfo } from './resolve.js';
 export { parseSnapshot, refToLocator, allRefLocators } from './snapshot-parser.js';
 export type { SnapshotNode, LocatorResult, RefLocatorEntry } from './snapshot-parser.js';
-export { isLocalCommand, handleLocalCommand, isVideoCommand, handleVideoCommand } from './local-commands.js';
+export { isLocalCommand, handleLocalCommand, isVideoCommand, handleVideoCommand, isTracingCommand, handleTracingCommand } from './local-commands.js';
 export type { LocalCommandResult } from './local-commands.js';

--- a/packages/core/src/local-commands.ts
+++ b/packages/core/src/local-commands.ts
@@ -68,10 +68,46 @@ export async function handleVideoCommand(cmd: string, context: BrowserContext): 
   return { text: `Unknown video command: ${trimmed}`, isError: true };
 }
 
+// ─── Tracing commands ──────────────────────────────────────────────────────
+
+export function isTracingCommand(cmd: string): boolean {
+  const trimmed = cmd.trim();
+  return trimmed === 'tracing-start' || trimmed === 'tracing-stop';
+}
+
+let tracingActive = false;
+
+export async function handleTracingCommand(cmd: string, context: BrowserContext): Promise<LocalCommandResult> {
+  const trimmed = cmd.trim();
+
+  if (trimmed === 'tracing-start') {
+    if (tracingActive) return { text: 'Tracing is already active.', isError: true };
+    await context.tracing.start({ screenshots: true, snapshots: true });
+    tracingActive = true;
+    return { text: 'Tracing started' };
+  }
+
+  if (trimmed === 'tracing-stop') {
+    if (!tracingActive) return { text: 'No active tracing session.', isError: true };
+    const outDir = path.join(os.homedir(), 'pw-traces');
+    fs.mkdirSync(outDir, { recursive: true });
+    const d = new Date();
+    const timestamp = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}T${String(d.getHours()).padStart(2, '0')}-${String(d.getMinutes()).padStart(2, '0')}-${String(d.getSeconds()).padStart(2, '0')}`;
+    const outPath = path.join(outDir, `trace-${timestamp}.zip`);
+    await context.tracing.stop({ path: outPath });
+    tracingActive = false;
+    const size = fs.statSync(outPath).size;
+    const sizeStr = size < 1024 * 1024 ? `${(size / 1024).toFixed(0)} KB` : `${(size / (1024 * 1024)).toFixed(1)} MB`;
+    return { text: `Trace saved to ${outPath} (${sizeStr})` };
+  }
+
+  return { text: `Unknown tracing command: ${trimmed}`, isError: true };
+}
+
 // ─── Local command dispatcher ───────────────────────────────────────────────
 
 export function isLocalCommand(cmd: string): boolean {
-  return isVideoCommand(cmd);
+  return isVideoCommand(cmd) || isTracingCommand(cmd);
 }
 
 /**
@@ -84,6 +120,7 @@ export async function handleLocalCommand(cmd: string, context: BrowserContext | 
   if (!context) return null;
 
   if (isVideoCommand(cmd)) return handleVideoCommand(cmd, context);
+  if (isTracingCommand(cmd)) return handleTracingCommand(cmd, context);
 
   return null;
 }

--- a/packages/core/src/resolve.ts
+++ b/packages/core/src/resolve.ts
@@ -167,6 +167,8 @@ export const COMMANDS: Record<string, CommandInfo> = {
   'video-chapter':     { desc: 'Add video chapter marker', options: ['--description', '--duration'],
                          usage: 'video-chapter <title> [--description <text>] [--duration <ms>]',
                          examples: ['video-chapter "Login flow"', 'video-chapter "Setup" --duration 3000'] },
+  'tracing-start':     { desc: 'Start trace recording', options: [] },
+  'tracing-stop':      { desc: 'Stop tracing and save trace file', options: [] },
   'install-browser':   { desc: 'Install browser', options: [] },
   'list':              { desc: 'List sessions', options: [] },
   'close-all':         { desc: 'Close all sessions', options: [] },
@@ -184,6 +186,7 @@ export const CATEGORIES: Record<string, string[]> = {
   'SessionStorage': ['sessionstorage-list', 'sessionstorage-get', 'sessionstorage-set', 'sessionstorage-delete', 'sessionstorage-clear'],
   'State':          ['state-save', 'state-load'],
   'Video':          ['video-start', 'video-stop', 'video-chapter'],
+  'Tracing':        ['tracing-start', 'tracing-stop'],
   'Other':          ['dialog-accept', 'dialog-dismiss', 'route', 'route-list', 'unroute', 'resize', 'pdf', 'upload', 'config-print'],
 };
 

--- a/packages/mcp/src/bridge.ts
+++ b/packages/mcp/src/bridge.ts
@@ -17,7 +17,8 @@ export const descriptions = {
    snapshot, goto <url>, click <text>, fill <label> <value>, press <key>,
    verify-text <text>, verify-no-text <text>, screenshot,
    check <label>, select <label> <value>, localstorage-list, localstorage-clear,
-   video-start, video-stop, video-chapter <title>
+   video-start, video-stop, video-chapter <title>,
+   tracing-start, tracing-stop
 
 2. PLAYWRIGHT — Playwright API (page.* / crxApp.*):
    await page.url(), await page.title(),


### PR DESCRIPTION
## Summary
- Add `tracing-start`/`tracing-stop` to `local-commands.ts` for CLI evaluate, MCP evaluate, and VS Code modes — saves trace ZIP to `~/pw-traces/`
- Bridge mode falls through to extension's existing `handleBridgeCommand()` — no changes needed
- Add tracing commands to `COMMANDS` + `CATEGORIES` in `resolve.ts` for help output and ghost completion
- Fix Tab completion to accept the shown ghost text instead of cycling past it
- Add `tracing-start`/`tracing-stop` to MCP tool description
- Add example script `11-tracing.pw`

Closes #603

## Test plan
- [x] CLI evaluate mode: `tracing-start` → run commands → `tracing-stop` → trace ZIP created in `~/pw-traces/`
- [x] CLI bridge mode: same flow → trace saved via extension's chrome.downloads
- [ ] MCP evaluate mode: same flow
- [ ] VS Code REPL: same flow
- [x] Tab completion: typing `tracing` + Tab accepts `tracing-start`

🤖 Generated with [Claude Code](https://claude.com/claude-code)