### PR TITLE
feat: use page.pickLocator() API for VS Code element picker

### DIFF
--- a/packages/vscode/README.md
+++ b/packages/vscode/README.md
@@ -132,7 +132,7 @@ REPL, Test Explorer, Recorder, and Picker all share the same headed browser via 
 
 - VS Code 1.93+
 - Node.js 18+
-- `@playwright/test` 1.58+ in your project
+- `@playwright/test` 1.59+ in your project
 - `esbuild` in your project for bridge execution (`npm install -D esbuild`) — without it, falls back to `esbuild-wasm` (bundled), which is slower but requires no installation
 
 ## Panels

--- a/packages/vscode/src/picker.ts
+++ b/packages/vscode/src/picker.ts
@@ -1,11 +1,8 @@
 /**
  * Locator Picker
  *
- * V1: Simple pick and insert.
- * 1. Click "Pick Locator" → browser enters pick mode (hover highlight)
- * 2. User clicks an element → locator sent back via bridge event
- * 3. Locator inserted at cursor in the active editor
- * 4. Pick mode ends automatically
+ * Uses Playwright's page.pickLocator() API (1.59+) for element picking.
+ * Single await — no polling, no content script injection.
  */
 
 import * as vscode from 'vscode';
@@ -47,90 +44,95 @@ export class Picker {
 
   async start() {
     if (this._picking) return;
-    if (!this._browserManager.isRunning()) {
+    const page = this._browserManager.page;
+    if (!page) {
       vscode.window.showWarningMessage('Launch browser first.');
-      return;
-    }
-
-    // Start pick mode
-    const result = await this._browserManager.runCommand('pick-start');
-    if (result.isError) {
-      vscode.window.showErrorMessage(`Pick failed: ${result.text}`);
       return;
     }
 
     this._picking = true;
     this._outputChannel.appendLine('Pick mode started. Click an element in the browser.');
 
-    // Listen for pick events
-    this._browserManager.onEvent(async (event) => {
-      if (!this._picking) return;
+    try {
+      const locator = await page.pickLocator();
+      const fullLocator = `page.${locator.toString()}`;
+      this._outputChannel.appendLine(`Picked: ${fullLocator}`);
 
-      if (event.type === 'element-picked-raw') {
-        const info = event.info as {
-          locator?: string;
-          tag?: string;
-          text?: string;
-          value?: string;
-          checked?: boolean;
-          attributes?: Record<string, string>;
-        };
-        const locator = info?.locator;
-        if (locator) {
-          const fullLocator = `page.${locator}`;
-          this._outputChannel.appendLine(`Picked: ${fullLocator}`);
+      // Get aria snapshot
+      let ariaSnapshot = '';
+      try {
+        ariaSnapshot = await locator.ariaSnapshot();
+      } catch {}
 
-          // Get aria snapshot for the picked element
-          let ariaSnapshot = '';
-          try {
-            const ariaResult = await this._browserManager.runCommand(`await ${fullLocator}.ariaSnapshot()`);
-            if (!ariaResult.isError && ariaResult.text)
-              ariaSnapshot = ariaResult.text;
-          } catch {}
+      // Derive assertion from element info
+      const info = await this._getElementInfo(locator);
+      const assertion = deriveAssertion(info, fullLocator);
 
-          // Derive assertion from element info
-          const assertion = deriveAssertion(info, fullLocator);
+      // Copy to clipboard if setting is enabled
+      const copyOnPick = vscode.workspace.getConfiguration('playwright-repl').get('pickLocatorCopyToClipboard', false);
+      if (copyOnPick)
+        await vscode.env.clipboard.writeText(fullLocator);
 
-          // Copy to clipboard if setting is enabled
-          const copyOnPick = vscode.workspace.getConfiguration('playwright-repl').get('pickLocatorCopyToClipboard', false);
-          if (copyOnPick)
-            await vscode.env.clipboard.writeText(fullLocator);
-
-          if (this._locatorsView)
-            this._locatorsView.showLocator(fullLocator, ariaSnapshot);
-          if (this._assertView && this._sendToAssert)
-            this._assertView.showAssertion(fullLocator, assertion, info, ariaSnapshot);
-          this._sendToAssert = false;
-        }
-        this._stop();
-      }
-
-      if (event.type === 'pick-cancelled') {
-        this._stop();
-      }
-    });
+      if (this._locatorsView)
+        this._locatorsView.showLocator(fullLocator, ariaSnapshot);
+      if (this._assertView && this._sendToAssert)
+        this._assertView.showAssertion(fullLocator, assertion, info, ariaSnapshot);
+      this._sendToAssert = false;
+    } catch (e: unknown) {
+      const msg = (e as Error).message || String(e);
+      if (!msg.includes('cancelled'))
+        this._outputChannel.appendLine(`Pick failed: ${msg}`);
+    } finally {
+      this._picking = false;
+      this._outputChannel.appendLine('Pick mode ended.');
+    }
   }
 
   async stop() {
     if (!this._picking) return;
-    await this._browserManager.runCommand('pick-stop');
-    this._stop();
-  }
-
-  private _stop() {
+    const page = this._browserManager.page;
+    if (page) {
+      try { await page.cancelPickLocator(); } catch {}
+    }
     this._picking = false;
-    this._browserManager.onEvent(null);
     this._outputChannel.appendLine('Pick mode ended.');
   }
 
+  private async _getElementInfo(locator: any): Promise<ElementInfo> {
+    const info: ElementInfo = {};
+    try {
+      const tag = await locator.evaluate((el: Element) => el.tagName);
+      info.tag = tag;
+      const attrs = await locator.evaluate((el: Element) => {
+        const result: Record<string, string> = {};
+        for (const attr of el.attributes)
+          result[attr.name] = attr.value;
+        return result;
+      });
+      info.attributes = attrs;
+      info.text = await locator.innerText().catch(() => '');
+      if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT')
+        info.value = await locator.inputValue().catch(() => undefined);
+      if (tag === 'INPUT' && (attrs.type === 'checkbox' || attrs.type === 'radio'))
+        info.checked = await locator.isChecked().catch(() => undefined);
+    } catch {}
+    return info;
+  }
+}
+
+// ─── Types ──────────────────────────────────────────────────────────────────
+
+interface ElementInfo {
+  tag?: string;
+  text?: string;
+  value?: string;
+  checked?: boolean;
+  attributes?: Record<string, string>;
 }
 
 // ─── Assertion derivation ─────────────────────────────────────────────────
 
-function deriveAssertion(
-  info: { tag?: string; text?: string; value?: string; checked?: boolean; attributes?: Record<string, string> },
-  locator: string,
-): string {
+function deriveAssertion(info: ElementInfo, locator: string): string {
   const tag = info.tag?.toLowerCase() ?? '';
   const inputType = (info.attributes?.type || '').toLowerCase();
 


### PR DESCRIPTION
## Summary
- Replace custom content-script-based picker with Playwright's native `page.pickLocator()` API (1.59+)
- Single `await` instead of polling event queue — no content script injection, no message passing
- `toString()` for friendly locator format, `ariaSnapshot()` for element semantics
- Element info (tag, value, checked) fetched via Locator API for assertion derivation
- `stop()` uses `cancelPickLocator()`
- Bump requirement to `@playwright/test` 1.59+ in VS Code README

## Test plan
- [x] Pick locator → locator panel shows friendly format + aria snapshot
- [x] Pick for assert → assert builder shows correct assertion
- [x] Cancel pick (Escape) → no error
- [x] Copy to clipboard setting works

Closes #614

🤖 Generated with [Claude Code](https://claude.com/claude-code)