### PR TITLE
feat: VS Code recorder without extension dependency

### DIFF
--- a/packages/vscode/build.mjs
+++ b/packages/vscode/build.mjs
@@ -39,12 +39,26 @@ const options = {
   minify: !watch,
 };
 
+// Recorder inject script — runs in browser, not Node
+const injectOptions = {
+  entryPoints: ['src/recorder-inject.ts'],
+  bundle: true,
+  outdir: 'dist',
+  format: 'iife',
+  platform: 'browser',
+  target: 'ES2019',
+  sourcemap: false,
+  minify: !watch,
+};
+
 if (watch) {
   const ctx = await esbuild.context(options);
   await ctx.watch();
+  await esbuild.build(injectOptions);
   console.log('Watching for changes...');
 } else {
   await esbuild.build(options);
+  await esbuild.build(injectOptions);
 
   // Copy Chrome extension dist into VSIX bundle
   const src = path.resolve('..', 'extension', 'dist');

--- a/packages/vscode/src/recorder-inject.ts
+++ b/packages/vscode/src/recorder-inject.ts
@@ -1,0 +1,150 @@
+/**
+ * Recorder injection script — runs inside the browser page.
+ * Captures DOM events transparently (no preventDefault), marks elements
+ * with data-pw-rec-id, and calls exposed Node functions for action recording.
+ *
+ * Does NOT generate locators — Node side resolves them via Playwright API.
+ */
+
+declare global {
+  interface Window {
+    __pwRecordAction: (action: string, recId: string, opts: Record<string, unknown>) => void;
+    __pwRecordFillUpdate: (action: string, recId: string, opts: Record<string, unknown>) => void;
+    __pwRecorderActive: boolean;
+    __pwRecorderCleanup: () => void;
+  }
+}
+
+const SPECIAL_KEYS = new Set([
+  'Enter', 'Tab', 'Escape', 'Backspace', 'Delete',
+  'ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight',
+  'Home', 'End', 'PageUp', 'PageDown',
+  'F1', 'F2', 'F3', 'F4', 'F5', 'F6', 'F7', 'F8', 'F9', 'F10', 'F11', 'F12',
+]);
+
+function isTextField(el: Element): boolean {
+  if (el instanceof HTMLTextAreaElement) return true;
+  if (el instanceof HTMLInputElement) {
+    const type = el.type.toLowerCase();
+    return !['checkbox', 'radio', 'button', 'submit', 'reset', 'file', 'image', 'hidden', 'range', 'color'].includes(type);
+  }
+  return el.getAttribute('contenteditable') === 'true';
+}
+
+function isCheckable(el: Element): boolean {
+  if (!(el instanceof HTMLInputElement)) return false;
+  const type = el.type.toLowerCase();
+  return type === 'checkbox' || type === 'radio';
+}
+
+let recIdCounter = 0;
+function markElement(el: Element): string {
+  const existing = el.getAttribute('data-pw-rec-id');
+  if (existing) return existing;
+  const id = `rec-${++recIdCounter}-${Date.now()}`;
+  el.setAttribute('data-pw-rec-id', id);
+  return id;
+}
+
+// ─── Fill buffering ──────────────────────────────────────────────────────
+
+let pendingFill: { el: Element; recId: string; value: string } | null = null;
+
+function flushPendingFill() {
+  pendingFill = null;
+}
+
+// ─── Event handlers (capture phase, transparent) ─────────────────────────
+
+function onClickCapture(e: MouseEvent) {
+  const target = e.target as Element;
+  if (!target) return;
+  if (isTextField(target)) return;
+  if (isCheckable(target)) return;
+  flushPendingFill();
+  const recId = markElement(target);
+  window.__pwRecordAction('click', recId, {});
+}
+
+function onInputCapture(e: Event) {
+  const target = e.target as Element;
+  if (!target || !isTextField(target)) return;
+  const value = (target as HTMLInputElement | HTMLTextAreaElement).value ?? '';
+  const recId = markElement(target);
+
+  if (pendingFill && pendingFill.el === target) {
+    pendingFill.value = value;
+    window.__pwRecordFillUpdate('fill', pendingFill.recId, { value });
+  } else {
+    flushPendingFill();
+    pendingFill = { el: target, recId, value };
+    window.__pwRecordAction('fill', recId, { value });
+  }
+}
+
+function onChangeCapture(e: Event) {
+  const target = e.target as Element;
+  if (!target) return;
+
+  if (isCheckable(target)) {
+    flushPendingFill();
+    const checked = (target as HTMLInputElement).checked;
+    const recId = markElement(target);
+    window.__pwRecordAction(checked ? 'check' : 'uncheck', recId, {});
+    return;
+  }
+
+  if (target instanceof HTMLSelectElement) {
+    flushPendingFill();
+    const recId = markElement(target);
+    window.__pwRecordAction('select', recId, { option: target.value });
+    return;
+  }
+}
+
+function onKeyDownCapture(e: KeyboardEvent) {
+  if (!SPECIAL_KEYS.has(e.key)) return;
+  const target = e.target as Element;
+  if (e.key === 'Tab') { flushPendingFill(); return; }
+  if (e.key !== 'Enter' && target && isTextField(target)) return;
+  flushPendingFill();
+
+  if (target && target !== document.body && target !== document.documentElement) {
+    const recId = markElement(target);
+    window.__pwRecordAction('press', recId, { key: e.key });
+  } else {
+    // Global key press — no element context, use empty recId
+    window.__pwRecordAction('press', '', { key: e.key });
+  }
+}
+
+function onFocusOutCapture(e: FocusEvent) {
+  if (pendingFill && e.target === pendingFill.el) {
+    flushPendingFill();
+  }
+}
+
+// ─── Lifecycle ──────────────────────────────────────────────────────────
+
+function cleanup() {
+  flushPendingFill();
+  window.__pwRecorderActive = false;
+  document.removeEventListener('click', onClickCapture, true);
+  document.removeEventListener('input', onInputCapture, true);
+  document.removeEventListener('change', onChangeCapture, true);
+  document.removeEventListener('keydown', onKeyDownCapture, true);
+  document.removeEventListener('focusout', onFocusOutCapture, true);
+}
+
+function initRecorder() {
+  if (window.__pwRecorderActive) return;
+  window.__pwRecorderActive = true;
+  window.__pwRecorderCleanup = cleanup;
+  document.addEventListener('click', onClickCapture, true);
+  document.addEventListener('input', onInputCapture, true);
+  document.addEventListener('change', onChangeCapture, true);
+  document.addEventListener('keydown', onKeyDownCapture, true);
+  document.addEventListener('focusout', onFocusOutCapture, true);
+}
+
+initRecorder();

--- a/packages/vscode/src/recorder.ts
+++ b/packages/vscode/src/recorder.ts
@@ -1,16 +1,18 @@
 /**
  * Recorder
  *
- * Manages the recording flow in VS Code:
- * 1. Detects cursor context (inside/outside test function)
- * 2. Generates test template if needed
- * 3. Starts recording via bridge
- * 4. Receives streamed actions via bridge events
- * 5. Inserts each action at cursor in the active editor
+ * Manages the recording flow in VS Code using Playwright Page API directly.
+ * No extension dependency — injects capture script via page.exposeFunction()
+ * and resolves locators on the Node side via locator.normalize().toString().
  */
 
 import * as vscode from 'vscode';
 import type { BrowserManager } from './browser.js';
+import fs from 'node:fs';
+import path from 'node:path';
+
+// __filename is available at runtime in esbuild's CJS output
+declare const __filename: string;
 
 // ─── Cursor Context Detection ──────────────────────────────────────────────
 
@@ -109,6 +111,27 @@ function replaceLastInsert(editor: vscode.TextEditor, text: string, indent: numb
   });
 }
 
+// ─── Command building ──────────────────────────────────────────────────────
+
+function escapeString(s: string): string {
+  return `'${s.replace(/\\/g, '\\\\').replace(/'/g, "\\'")}'`;
+}
+
+function buildJsCommand(locatorStr: string, action: string, opts: Record<string, unknown>): string {
+  const loc = `page.${locatorStr}`;
+  switch (action) {
+    case 'click': return `await ${loc}.click();`;
+    case 'fill': return `await ${loc}.fill(${escapeString(String(opts.value ?? ''))});`;
+    case 'check': return `await ${loc}.check();`;
+    case 'uncheck': return `await ${loc}.uncheck();`;
+    case 'select': return `await ${loc}.selectOption(${escapeString(String(opts.option ?? ''))});`;
+    case 'press':
+      if (locatorStr) return `await ${loc}.press(${escapeString(String(opts.key ?? ''))});`;
+      return `await page.keyboard.press(${escapeString(String(opts.key ?? ''))});`;
+    default: return `// unknown action: ${action}`;
+  }
+}
+
 // ─── Recorder Class ────────────────────────────────────────────────────────
 
 export class Recorder {
@@ -118,6 +141,8 @@ export class Recorder {
   private _statusBarItem: vscode.StatusBarItem;
   private _indentation = 4;
   private _editor: vscode.TextEditor | undefined;
+  private _functionsExposed = false;
+  private _locatorCache = new Map<string, string>();
 
   constructor(browserManager: BrowserManager, outputChannel: vscode.OutputChannel) {
     this._browserManager = browserManager;
@@ -137,9 +162,60 @@ export class Recorder {
     this._statusBarItem.dispose();
   }
 
+  private async _resolveLocator(page: any, recId: string, keepMarker = false): Promise<string> {
+    if (!recId) return '';  // global key press, no element
+    // Return cached locator if available (avoids repeated normalize() calls during fill)
+    const cached = this._locatorCache.get(recId);
+    if (cached) {
+      if (!keepMarker) {
+        this._locatorCache.delete(recId);
+        await page.locator(`[data-pw-rec-id="${recId}"]`).evaluate((el: any) => el.removeAttribute('data-pw-rec-id')).catch(() => {});
+      }
+      return cached;
+    }
+    try {
+      const loc = page.locator(`[data-pw-rec-id="${recId}"]`);
+      const normalized = await loc.normalize();
+      const locatorStr = normalized.toString();
+      if (keepMarker) {
+        this._locatorCache.set(recId, locatorStr);
+      } else {
+        await loc.evaluate((el: any) => el.removeAttribute('data-pw-rec-id')).catch(() => {});
+      }
+      return locatorStr;
+    } catch (e) {
+      this._outputChannel.appendLine(`[recorder] locator resolve failed for ${recId}: ${(e as Error).message}`);
+      return '';
+    }
+  }
+
+  private async _exposeRecorderFunctions(page: any) {
+    if (this._functionsExposed) return;
+
+    await page.exposeFunction('__pwRecordAction', async (action: string, recId: string, opts: Record<string, unknown>) => {
+      if (!this._recording || !this._editor) return;
+      const keepMarker = action === 'fill';  // fill needs marker for subsequent updates
+      const locatorStr = await this._resolveLocator(page, recId, keepMarker);
+      if (!locatorStr && action !== 'press') return;  // skip if locator resolution failed (except global press)
+      const js = buildJsCommand(locatorStr, action, opts);
+      insertAtCursor(this._editor!, js, this._indentation);
+    });
+
+    await page.exposeFunction('__pwRecordFillUpdate', async (_action: string, recId: string, opts: Record<string, unknown>) => {
+      if (!this._recording || !this._editor) return;
+      const locatorStr = await this._resolveLocator(page, recId, true);  // keep marker for more updates
+      if (!locatorStr) return;  // skip if locator resolution failed
+      const js = buildJsCommand(locatorStr, 'fill', opts);
+      replaceLastInsert(this._editor!, js, this._indentation);
+    });
+
+    this._functionsExposed = true;
+  }
+
   async start() {
     if (this._recording) return;
-    if (!this._browserManager.isRunning()) {
+    const page = this._browserManager.page;
+    if (!page) {
       vscode.window.showWarningMessage('Launch browser first.');
       return;
     }
@@ -160,61 +236,57 @@ export class Recorder {
       lastInsertLength = 0;
     }
 
-    // Register event listener BEFORE starting recording to avoid race condition
     this._recording = true;
     this._statusBarItem.text = '$(debug-stop) Stop Recording';
     this._statusBarItem.tooltip = 'Playwright REPL: Stop Recording';
     this._statusBarItem.command = 'playwright-repl.stopRecording';
     this._statusBarItem.backgroundColor = new vscode.ThemeColor('statusBarItem.errorBackground');
 
-    this._browserManager.onEvent((event) => {
-      if (!this._recording || !this._editor) return;
+    try {
+      // Expose callback functions on the page
+      await this._exposeRecorderFunctions(page);
 
-      if (event.type === 'recorded-action') {
-        const action = event.action as { js: string; pw: string };
-        insertAtCursor(this._editor!, action.js, this._indentation);
+      // Inject the capture script
+      const injectPath = path.resolve(path.dirname(__filename), 'recorder-inject.js');
+      const injectCode = fs.readFileSync(injectPath, 'utf-8');
+      await page.evaluate(injectCode);
+
+      // Insert goto for current page URL
+      if (!ctx || !ctx.inside) {
+        const url = page.url();
+        if (url && url !== 'about:blank' && this._editor) {
+          insertAtCursor(this._editor, `await page.goto('${url}');`, this._indentation);
+        }
       }
 
-      if (event.type === 'recorded-fill-update') {
-        const action = event.action as { js: string; pw: string };
-        replaceLastInsert(this._editor!, action.js, this._indentation);
-      }
-    });
-
-    // Start recording via bridge — returns URL of current page
-    const result = await this._browserManager.runCommand('record-start');
-    if (result.isError) {
+      this._outputChannel.appendLine('Recording started.');
+    } catch (e: unknown) {
       this._recording = false;
       this._statusBarItem.text = '$(circle-filled) Record';
       this._statusBarItem.command = 'playwright-repl.startRecording';
       this._statusBarItem.backgroundColor = undefined;
-      this._browserManager.onEvent(null);
-      vscode.window.showErrorMessage(`Recording failed: ${result.text}`);
-      return;
+      vscode.window.showErrorMessage(`Recording failed: ${(e as Error).message}`);
     }
-
-    // Insert goto only when starting a new test (template was inserted or cursor is at first line)
-    if (!ctx || !ctx.inside) {
-      const urlMatch = result.text?.match(/Recording started:\s*(.+)/);
-      const url = urlMatch?.[1]?.trim() || '';
-      if (url && this._editor) {
-        insertAtCursor(this._editor, `await page.goto('${url}');`, this._indentation);
-      }
-    }
-
-    this._outputChannel.appendLine('Recording started.');
   }
 
   async stop() {
     if (!this._recording) return;
+    const page = this._browserManager.page;
 
-    await this._browserManager.runCommand('record-stop');
+    // Clean up event listeners in the page
+    if (page) {
+      try {
+        await page.evaluate(() => {
+          if (window.__pwRecorderCleanup) window.__pwRecorderCleanup();
+        });
+      } catch { /* page may have navigated */ }
+    }
+
     this._recording = false;
     this._statusBarItem.text = '$(circle-filled) Record';
     this._statusBarItem.tooltip = 'Playwright REPL: Start Recording';
     this._statusBarItem.command = 'playwright-repl.startRecording';
     this._statusBarItem.backgroundColor = undefined;
-    this._browserManager.onEvent(null);
     this._outputChannel.appendLine('Recording stopped.');
   }
 


### PR DESCRIPTION
## Summary
- Replace extension-based recording with direct Playwright Page API
- No content script injection, no event polling — `page.exposeFunction()` for callbacks
- `locator.normalize().toString()` for best-practice locators (getByRole, getByLabel, filter)
- Locator cache for fill updates — avoids repeated `normalize()` calls during typing
- New `recorder-inject.ts`: lightweight IIFE event capture script built separately via esbuild

## Example output
```js
test('new test', async ({ page }) => {
  await page.goto('https://demo.playwright.dev/todomvc/#/');
  await page.getByRole('textbox', { name: 'What needs to be done?' }).fill('reading');
  await page.getByRole('textbox', { name: 'What needs to be done?' }).press('Enter');
  await page.getByRole('listitem').filter({ hasText: 'learning' }).getByLabel('Toggle Todo').check();
});
```

## Test plan
- [x] Record click, fill, press Enter, check — all produce correct locators
- [x] Fill captures full text (not just first character)
- [x] List item disambiguation uses `filter({ hasText })` 
- [x] Checkbox uses `getByLabel('Toggle Todo')`
- [ ] Stop recording cleans up listeners
- [ ] Navigation during recording handled gracefully

Closes #619

🤖 Generated with [Claude Code](https://claude.com/claude-code)