### PR TITLE
refactor: use locator.normalize() for locator command

### DIFF
--- a/packages/cli/src/engine.ts
+++ b/packages/cli/src/engine.ts
@@ -119,6 +119,13 @@ export class Engine {
     if (!this._backend)
       throw new Error('Engine not started');
 
+    // ── locator → run-code translation ──
+    if (args._[0] === 'locator') {
+      const ref = args._[1];
+      if (!ref) return { text: 'Usage: locator <ref>', isError: true };
+      args = { _: ['run-code', `async (page) => { return (await page.locator('aria-ref=${ref}').normalize()).toString(); }`] };
+    }
+
     // ── highlight → run-code translation ──
     if (args._[0] === 'highlight') {
       if (args.clear) {

--- a/packages/cli/src/repl.ts
+++ b/packages/cli/src/repl.ts
@@ -10,7 +10,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import {
   replVersion, parseInput, ALIASES, ALL_COMMANDS, buildCompletionItems, c, prettyJson,
-  BridgeServer, COMMANDS, CATEGORIES, JS_CATEGORIES, refToLocator,
+  BridgeServer, COMMANDS, CATEGORIES, JS_CATEGORIES,
   filterResponse as filterResponseBase, resolveArgs,
   isLocalCommand, handleLocalCommand,
 } from '@playwright-repl/core';
@@ -42,7 +42,6 @@ export interface ReplContext {
   sessionHistory: string[];
   commandCount: number;
   errors: number;
-  lastSnapshot?: { url: string; snapshotString: string };
 }
 
 // ─── Response filtering ─────────────────────────────────────────────────────
@@ -283,22 +282,6 @@ export async function processLine(ctx: ReplContext, line: string): Promise<void>
     return;
   }
 
-  // ── Locator (local — uses cached snapshot) ───────────────────────
-  if (line.startsWith('locator ')) {
-    const ref = line.slice(8).trim();
-    if (!ctx.lastSnapshot) {
-      console.log(`${c.yellow}No snapshot cached. Run "snapshot" first.${c.reset}`);
-      return;
-    }
-    const locator = refToLocator(ctx.lastSnapshot.snapshotString, ref);
-    if (!locator) {
-      console.log(`${c.yellow}Ref "${ref}" not found in last snapshot.${c.reset}`);
-      return;
-    }
-    console.log(`js: ${locator.js}\npw: ${locator.pw}`);
-    return;
-  }
-
   // ── Regular command — parse and send ─────────────────────────────
 
   let args: ParsedArgs | null = parseInput(line);
@@ -308,9 +291,7 @@ export async function processLine(ctx: ReplContext, line: string): Promise<void>
   if (!cmdName) return;
 
   // Validate command exists
-  const knownExtras = ['help', 'highlight', 'locator', 'list', 'close-all', 'kill-all', 'install', 'install-browser',
-                       'verify', 'verify-text', 'verify-element', 'verify-value', 'verify-visible', 'verify-input-value', 'verify-list',
-                       'verify-title', 'verify-url', 'verify-no-text', 'verify-no-element'];
+  const knownExtras = ['help', 'install'];
   if (!ALL_COMMANDS.includes(cmdName) && !knownExtras.includes(cmdName)) {
     console.log(`${c.yellow}Unknown command: ${cmdName}${c.reset}`);
     console.log(`${c.dim}Type .help for available commands${c.reset}`);
@@ -338,13 +319,6 @@ export async function processLine(ctx: ReplContext, line: string): Promise<void>
   const startTime = performance.now();
   try {
     const result = await ctx.conn.run(args);
-    const snapshotMatch = result?.text?.match(/### Snapshot\n([\s\S]*?)(?=\n### |$)/);
-    if (snapshotMatch) {
-      const urlMatch = result?.text?.match(/### Page\n-\s*\[.*?\]\((.*?)\)/);
-      const raw = snapshotMatch[1].trim();
-      const yamlBody = raw.replace(/^```(?:yaml)?\n?/, '').replace(/\n?```$/, '');
-      ctx.lastSnapshot = { url: urlMatch?.[1] ?? '', snapshotString: yamlBody };
-    }
     const elapsed = (performance.now() - startTime).toFixed(0);
     if (result?.text) {
       const filterOpts = (ctx.opts.includeSnapshot || ctx.opts.verbose)
@@ -865,7 +839,6 @@ async function startBridgeLoop(opts: ReplOpts, srv: BridgeServer): Promise<void>
   const historyDir = path.join(os.homedir(), '.playwright-repl');
   const historyFile = path.join(historyDir, '.repl-history');
   const sessionHistory: string[] = [];
-  let lastSnapshot: { url: string; snapshotString: string } | null = null;
 
   const promptReady = `${c.cyan}pw>${c.reset} `;
   const promptCont  = `${c.dim}...${c.reset} `;
@@ -922,21 +895,6 @@ async function startBridgeLoop(opts: ReplOpts, srv: BridgeServer): Promise<void>
       console.error(`${c.dim}Warning: could not write history: ${(err as Error).message}${c.reset}`);
     }
 
-    // Locator (local — uses cached snapshot)
-    if (command.startsWith('locator ')) {
-      const ref = command.slice(8).trim();
-      if (!lastSnapshot) {
-        log(`${c.yellow}No snapshot cached. Run "snapshot" first.${c.reset}`);
-        return;
-      }
-      const locator = refToLocator(lastSnapshot.snapshotString, ref);
-      if (!locator) {
-        log(`${c.yellow}Ref "${ref}" not found in last snapshot.${c.reset}`);
-        return;
-      }
-      log(`js: ${locator.js}\npw: ${locator.pw}`);
-      return;
-    }
 
     // ── Local commands (video, etc. — need Node.js filesystem) ─────
     const localResult = await handleLocalCommand(command, (srv as any).context);
@@ -954,15 +912,6 @@ async function startBridgeLoop(opts: ReplOpts, srv: BridgeServer): Promise<void>
     const runOpts = opts.includeSnapshot ? { includeSnapshot: true } : undefined;
     const result = await srv.run(command, runOpts);
     const elapsed = (performance.now() - startTime).toFixed(0);
-    // Cache snapshot for locator command
-    if (result?.text && !result.isError) {
-      const snapMatch = result.text.match(/### Snapshot\n([\s\S]+)$/);
-      if (snapMatch) {
-        lastSnapshot = { url: '', snapshotString: snapMatch[1].trim() };
-      } else if (command.trim().startsWith('snapshot')) {
-        lastSnapshot = { url: '', snapshotString: result.text.trim() };
-      }
-    }
     displayBridgeResult(result, silent);
     log(`${c.dim}(${elapsed}ms)${c.reset}`);
   }

--- a/packages/extension/src/panel/components/Console/useConsole.ts
+++ b/packages/extension/src/panel/components/Console/useConsole.ts
@@ -6,8 +6,7 @@ import { executeCommandForConsole } from '@/lib/bridge';
 import { fromCdpRemoteObject, type CdpRemoteObject } from './cdpToSerialized';
 import { resolveConsoleMode } from '@/lib/execute';
 import { runJsScript } from '@/lib/run';
-import { refToLocator } from '@/lib/snapshot-parser';
-import { getLastSnapshot, setLastSnapshot } from '@/lib/last-snapshot';
+import { setLastSnapshot } from '@/lib/last-snapshot';
 import type { Action } from '@/reducer';
 import type React from 'react';
 
@@ -103,29 +102,6 @@ export function useConsole(dispatch: React.Dispatch<Action>) {
         if (trimmed.toLowerCase() === 'log time off') {
             localStorage.setItem('logTime', 'false');
             dispatch({ type: 'ADD_LINE', line: { text: 'Time logging disabled', type: 'info' } });
-            return;
-        }
-        if (trimmed.toLowerCase().startsWith('locator ')) {
-            const ref = trimmed.slice('locator '.length).trim();
-            if (!ref) {
-                dispatch({ type: 'ADD_LINE', line: { text: 'Usage: locator <ref>\nExample: locator e5', type: 'info' } });
-                return;
-            }
-            const snap = getLastSnapshot();
-            if (!snap) {
-                dispatch({ type: 'ADD_LINE', line: { text: 'No snapshot available. Run "snapshot" first.', type: 'error' } });
-                return;
-            }
-            const loc = refToLocator(snap, ref);
-            if (!loc) {
-                dispatch({ type: 'ADD_LINE', line: { text: `Element "${ref}" not found in last snapshot.`, type: 'error' } });
-                return;
-            }
-            dispatch({ type: 'ADD_LINE', line: { text: `js: ${loc.js}\npw: ${loc.pw}`, type: 'info' } });
-            return;
-        }
-        if (trimmed.toLowerCase() === 'locator') {
-            dispatch({ type: 'ADD_LINE', line: { text: 'Usage: locator <ref>\nExample: locator e5', type: 'info' } });
             return;
         }
 

--- a/packages/extension/src/panel/lib/commands.ts
+++ b/packages/extension/src/panel/lib/commands.ts
@@ -627,6 +627,13 @@ export function parseReplCommand(input: string): ParseResult {
     return { help: parts.join('\n') };
   }
 
+  // ── Locator (resolve aria-ref via Playwright) ──
+  if (trimmed.startsWith('locator ')) {
+    const ref = trimmed.slice('locator '.length).trim();
+    if (!ref) return { error: 'Usage: locator <ref>\nExample: locator e5' };
+    return { jsExpr: `(await page.locator(${ser('aria-ref=' + ref)}).normalize()).toString()` };
+  }
+
   // Parse input (tokenize + alias + options)
   const args = parseInput(input);
   if (!args) return { error: 'Empty command' };

--- a/packages/extension/src/panel/lib/run.ts
+++ b/packages/extension/src/panel/lib/run.ts
@@ -7,8 +7,7 @@ import { getCommandHistory, clearHistory, addCommand } from '@/lib/command-histo
 import { swDebugEval, swDebugEvalRaw, swGetProperties, swDebuggerEnable, swDebuggerDisable, swDebugPause, swDebugResume, onDebugPaused, swTrackBreakpoint, swSetBreakpointByUrl, swRemoveAllBreakpoints, ScopeInfo } from '@/lib/sw-debugger';
 import { fromCdpRemoteObject } from '@/components/Console/cdpToSerialized';
 import type { CdpRemoteObject } from '@/components/Console/cdpToSerialized';
-import { refToLocator } from '@/lib/snapshot-parser';
-import { getLastSnapshot, setLastSnapshot } from '@/lib/last-snapshot';
+import { setLastSnapshot } from '@/lib/last-snapshot';
 
 function trimStack(msg: string): string {
     return msg.split('\n    at ')[0].split('\nCall log:')[0].trim();
@@ -83,29 +82,6 @@ function runLocalCommand(command: string, dispatch: React.Dispatch<Action>): boo
     if (command.trim().toLowerCase() === 'log time off') {
         localStorage.setItem('logTime', 'false');
         dispatch({ type: 'ADD_LINE', line: { text: 'Time logging disabled', type: 'info' } });
-        return true;
-    }
-    if (trimmed.startsWith('locator ')) {
-        const ref = trimmed.slice('locator '.length).trim();
-        if (!ref) {
-            dispatch({ type: 'ADD_LINE', line: { text: 'Usage: locator <ref>', type: 'info' } });
-            return true;
-        }
-        const snap = getLastSnapshot();
-        if (!snap) {
-            dispatch({ type: 'ADD_LINE', line: { text: 'No snapshot available. Run "snapshot" first.', type: 'error' } });
-            return true;
-        }
-        const loc = refToLocator(snap, ref);
-        if (!loc) {
-            dispatch({ type: 'ADD_LINE', line: { text: `Element "${ref}" not found in last snapshot.`, type: 'error' } });
-            return true;
-        }
-        dispatch({ type: 'ADD_LINE', line: { text: `js: ${loc.js}\npw: ${loc.pw}`, type: 'info' } });
-        return true;
-    }
-    if (trimmed === 'locator') {
-        dispatch({ type: 'ADD_LINE', line: { text: 'Usage: locator <ref>', type: 'info' } });
         return true;
     }
 

--- a/packages/mcp/src/bridge.ts
+++ b/packages/mcp/src/bridge.ts
@@ -4,7 +4,7 @@
 
 import { BridgeServer, UPDATE_COMMANDS, parseInput } from '@playwright-repl/core';
 import type { EngineResult } from '@playwright-repl/core';
-import type { RunnerModule, SnapshotCache } from './types.js';
+import type { RunnerModule } from './types.js';
 import { logEvent } from './logger.js';
 
 export const descriptions = {
@@ -45,7 +45,6 @@ IMPORTANT: Only use commands listed by 'help'. Run run_command('help') first if 
 
 export async function createBridgeRunner(
     argv: string[],
-    snapshotCache: SnapshotCache,
 ): Promise<RunnerModule> {
     const portIdx = argv.indexOf('--port');
     const port = portIdx !== -1
@@ -75,16 +74,6 @@ export async function createBridgeRunner(
                 // Request snapshot in the same round-trip for update commands
                 const result = await srv.run(command, isUpdate ? { includeSnapshot: true } : undefined);
                 if (result.isError) return result;
-
-                // Cache snapshot (from explicit snapshot command or appended by handler)
-                if (result.text) {
-                    const snapMatch = result.text.match(/### Snapshot\n([\s\S]+)$/);
-                    if (snapMatch) {
-                        snapshotCache.value = { url: '', snapshotString: snapMatch[1].trim() };
-                    } else if (cmdName === 'snapshot') {
-                        snapshotCache.value = { url: '', snapshotString: result.text.trim() };
-                    }
-                }
 
                 return result;
             },

--- a/packages/mcp/src/evaluate.ts
+++ b/packages/mcp/src/evaluate.ts
@@ -5,13 +5,12 @@
 
 import { EvaluateConnection, findExtensionPath, UPDATE_COMMANDS, parseInput, handleLocalCommand } from '@playwright-repl/core';
 import type { EngineResult } from '@playwright-repl/core';
-import type { RunnerModule, SnapshotCache } from './types.js';
+import type { RunnerModule } from './types.js';
 import { logEvent } from './logger.js';
 import { descriptions } from './bridge.js';
 
 export async function createEvaluateRunner(
     argv: string[],
-    snapshotCache: SnapshotCache,
 ): Promise<RunnerModule> {
     const headed = argv.includes('--headed');
     const extPath = findExtensionPath(import.meta.url);
@@ -38,15 +37,6 @@ export async function createEvaluateRunner(
 
                 const result = await conn.run(command, isUpdate ? { includeSnapshot: true } : undefined);
                 if (result.isError) return result;
-
-                if (result.text) {
-                    const snapMatch = result.text.match(/### Snapshot\n([\s\S]+)$/);
-                    if (snapMatch) {
-                        snapshotCache.value = { url: '', snapshotString: snapMatch[1].trim() };
-                    } else if (cmdName === 'snapshot') {
-                        snapshotCache.value = { url: '', snapshotString: result.text.trim() };
-                    }
-                }
 
                 return result;
             },

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -2,19 +2,15 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { z } from 'zod';
-import { COMMANDS, CATEGORIES, refToLocator } from '@playwright-repl/core';
+import { COMMANDS, CATEGORIES } from '@playwright-repl/core';
 import pkg from '../package.json' with { type: 'json' };
 import { createBridgeRunner } from './bridge.js';
 import { createEvaluateRunner } from './evaluate.js';
 import { createStandaloneRunner } from './standalone.js';
 import { logStartup, logEvent, logToolCall, logToolResult, logError, LOG_FILE } from './logger.js';
-import type { SnapshotCache } from './types.js';
-
 const argv = process.argv.slice(2);
 const standalone = argv.includes('--standalone');
 const headed = argv.includes('--headed');
-
-const snapshotCache: SnapshotCache = { value: null };
 
 // ─── Create runner ───────────────────────────────────────────────────────────
 
@@ -22,12 +18,12 @@ let runnerModule;
 if (standalone) {
     // Try evaluate mode (extension + JS support), fall back to Engine (keyword only)
     try {
-        runnerModule = await createEvaluateRunner(argv, snapshotCache);
+        runnerModule = await createEvaluateRunner(argv);
     } catch {
-        runnerModule = createStandaloneRunner(headed, snapshotCache);
+        runnerModule = createStandaloneRunner(headed);
     }
 } else {
-    runnerModule = await createBridgeRunner(argv, snapshotCache);
+    runnerModule = await createBridgeRunner(argv);
 }
 
 const { runner, descriptions } = runnerModule;
@@ -56,17 +52,6 @@ server.registerTool(
                 .join('\n');
             logToolResult('run_command', false, 'help', Date.now() - start);
             return { content: [{ type: 'text' as const, text: `Available commands:\n${lines}\n\nType "help <command>" for details.` }] };
-        }
-        if (trimmed.startsWith('locator ')) {
-            const ref = command.trim().slice(8).trim();
-            if (!snapshotCache.value) {
-                return { content: [{ type: 'text' as const, text: 'No snapshot cached. Run "snapshot" first.' }], isError: true };
-            }
-            const locator = refToLocator(snapshotCache.value.snapshotString, ref);
-            if (!locator) {
-                return { content: [{ type: 'text' as const, text: `Ref "${ref}" not found in last snapshot. Run "snapshot" to refresh.` }], isError: true };
-            }
-            return { content: [{ type: 'text' as const, text: `js: ${locator.js}\npw: ${locator.pw}` }] };
         }
         if (trimmed.startsWith('help ')) {
             const cmd = trimmed.slice(5).trim();

--- a/packages/mcp/src/standalone.ts
+++ b/packages/mcp/src/standalone.ts
@@ -5,7 +5,7 @@
 import { parseInput, resolveArgs, filterResponse } from '@playwright-repl/core';
 import type { EngineResult } from '@playwright-repl/core';
 import { Engine } from 'playwright-repl';
-import type { RunnerModule, SnapshotCache } from './types.js';
+import type { RunnerModule } from './types.js';
 
 const INCLUDE_SNAPSHOT = { includeSnapshot: true } as const;
 
@@ -35,7 +35,6 @@ IMPORTANT: Only use commands listed by 'help'. Run run_command('help') first if 
 
 export function createStandaloneRunner(
     headed: boolean,
-    snapshotCache: SnapshotCache,
 ): RunnerModule {
     let engine: Engine | null = null;
     let starting: Promise<Engine> | null = null;
@@ -60,16 +59,6 @@ export function createStandaloneRunner(
         const cmdName = args._[0];
         const resolved = resolveArgs(args);
         const result = await e.run(resolved);
-
-        // Cache snapshot for locator command — strip YAML code fences
-        if (result.text && !result.isError) {
-            const snapshotMatch = result.text.match(/### Snapshot\n([\s\S]*?)(?=\n### |$)/);
-            if (snapshotMatch) {
-                const raw = snapshotMatch[1].trim();
-                const yamlBody = raw.replace(/^```(?:yaml)?\n?/, '').replace(/\n?```$/, '');
-                snapshotCache.value = { url: '', snapshotString: yamlBody };
-            }
-        }
 
         // Filter verbose Playwright response sections — keep snapshots for MCP
         if (result.text) result.text = filterResponse(result.text, cmdName, INCLUDE_SNAPSHOT);

--- a/packages/mcp/src/types.ts
+++ b/packages/mcp/src/types.ts
@@ -17,7 +17,3 @@ export interface RunnerModule {
     runner: Runner;
     descriptions: RunnerDescriptions;
 }
-
-export interface SnapshotCache {
-    value: { url: string; snapshotString: string } | null;
-}

--- a/packages/vscode/src/replView.ts
+++ b/packages/vscode/src/replView.ts
@@ -13,7 +13,6 @@ let _core: {
   COMMANDS: Record<string, { desc: string; usage?: string; examples?: string[] }>;
   CATEGORIES: Record<string, string[]>;
   ALIASES: Record<string, string>;
-  refToLocator: (yaml: string, ref: string) => { js: string; pw: string } | null;
 } | undefined;
 
 function core() {
@@ -30,7 +29,6 @@ export class ReplView extends DisposableBase implements vscodeTypes.WebviewViewP
   private _extensionUri: vscodeTypes.Uri;
   private _browserManager: BrowserManager | undefined;
   private _history: string[] = [];
-  private _lastSnapshot: string = '';
   private _commandCount = 0;
 
   constructor(vscode: vscodeTypes.VSCode, extensionUri: vscodeTypes.Uri) {
@@ -129,10 +127,6 @@ export class ReplView extends DisposableBase implements vscodeTypes.WebviewViewP
     try {
       const result = await this._browserManager.runCommand(command) as { text?: string; isError?: boolean; image?: string };
       const elapsed = Date.now() - start;
-
-      // Cache snapshot for locator command
-      if (/^(snapshot|snap|s)(\s|$)/.test(command) && result.text && !result.isError)
-        this._lastSnapshot = result.text;
 
       // PDF — offer save
       if (result.image?.startsWith('data:application/pdf')) {
@@ -235,22 +229,6 @@ export class ReplView extends DisposableBase implements vscodeTypes.WebviewViewP
       return true;
     }
 
-    // locator <ref> — convert ref to locator from last snapshot
-    if (trimmed.startsWith('locator ')) {
-      const ref = trimmed.slice(8).trim();
-      if (!this._lastSnapshot) {
-        this._appendOutput('No snapshot cached. Run "snapshot" first.', 'error');
-        return true;
-      }
-      const { refToLocator } = core();
-      const result = refToLocator(this._lastSnapshot, ref);
-      if (!result) {
-        this._appendOutput(`Ref "${ref}" not found in last snapshot. Run "snapshot" to refresh.`, 'error');
-        return true;
-      }
-      this._appendOutput(`js: page.${result.js}\npw: ${result.pw}`, 'output');
-      return true;
-    }
 
     return false;
   }


### PR DESCRIPTION
## Summary
- Replace YAML snapshot cache + `refToLocator()` parsing with Playwright's native `locator.normalize()` API
- Removes ~160 lines of duplicated locator/snapshot-cache code across extension, CLI, MCP, and VS Code
- `locator` command now resolves refs against Playwright's live internal state instead of a stale local cache

## Changes
- **Extension**: `locator` moved from local command to `parseReplCommand` (remote JS expression)
- **Engine** (`engine.ts`): `locator` → `run-code` translation (covers CLI direct + MCP standalone)
- **CLI/MCP/VS Code**: removed local `locator` handlers, snapshot caching, and `SnapshotCache` type
- **Cleanup**: removed redundant entries from `knownExtras` that were already in `ALL_COMMANDS`

## Test plan
- [x] Build passes (`pnpm run build`)
- [x] Extension: `snapshot` then `locator e5` returns resolved locator
- [x] VS Code REPL: `locator` flows through to extension handler

🤖 Generated with [Claude Code](https://claude.com/claude-code)