### PR TITLE
revert: restore content script picker for Chrome extension

### DIFF
--- a/packages/extension/src/background.ts
+++ b/packages/extension/src/background.ts
@@ -324,54 +324,20 @@ let lastTraceData: Uint8Array | null = null;
 
 // ─── Pick Element ────────────────────────────────────────────────────────────
 
-async function pickElement(): Promise<{ ok: boolean; info?: any; error?: string }> {
-  if (!currentPage) {
-    const tabId = await getActiveTabId();
-    if (tabId) await attachToTab(tabId);
-    if (!currentPage) return { ok: false, error: 'No active page' };
-  }
-
+async function startPicking(): Promise<{ ok: boolean; error?: string }> {
   try {
-    const locator = await currentPage.pickLocator();
-    const locatorStr = locator.toString();
-    const ariaSnapshot = await locator.ariaSnapshot().catch(() => '');
-    const elementInfo = await locator.evaluate((el: Element) => {
-      const attrs: Record<string, string> = {};
-      for (const attr of el.attributes) attrs[attr.name] = attr.value;
-      const tag = el.tagName;
-      const inputType = (attrs.type || '').toLowerCase();
-      return {
-        tag,
-        text: (el as HTMLElement).innerText?.slice(0, 200) ?? '',
-        html: el.outerHTML?.slice(0, 500) ?? '',
-        attributes: attrs,
-        visible: true,
-        enabled: !(el as HTMLInputElement).disabled,
-        box: el.getBoundingClientRect().toJSON(),
-        value: ('value' in el) ? (el as HTMLInputElement).value : undefined,
-        checked: (tag === 'INPUT' && (inputType === 'checkbox' || inputType === 'radio'))
-          ? (el as HTMLInputElement).checked : undefined,
-      };
-    }).catch(() => null);
-
-    return {
-      ok: true,
-      info: {
-        locator: locatorStr,
-        ariaSnapshot,
-        ...(elementInfo || {}),
-      },
-    };
-  } catch (e: any) {
-    if (e?.message?.includes('cancelled')) return { ok: false, error: 'cancelled' };
-    return { ok: false, error: e?.message ?? String(e) };
+    const tabId = await getActiveTabId();
+    if (!tabId) return { ok: false, error: 'No active tab' };
+    await chrome.scripting.executeScript({ target: { tabId }, files: ['content/picker.js'] });
+    return { ok: true };
+  } catch (e) {
+    return { ok: false, error: String(e) };
   }
 }
 
-async function cancelPick(): Promise<{ ok: boolean }> {
-  if (currentPage) {
-    try { await currentPage.cancelPickLocator(); } catch { /* ignore */ }
-  }
+async function stopPicking(): Promise<{ ok: boolean }> {
+  const tabId = await getActiveTabId();
+  if (tabId) await chrome.tabs.sendMessage(tabId, { type: 'pick-stop' }).catch(e => console.debug('[pw-repl] pick-stop:', e));
   return { ok: true };
 }
 
@@ -563,14 +529,13 @@ async function handleBridgeCommand(msg: {
     const r = await stopRecording();
     return { text: r.ok ? 'Recording stopped' : 'Failed', isError: !r.ok };
   }
-  // pick-start/pick-stop handled via direct chrome.runtime.sendMessage (not bridge command queue)
-  // because pickLocator() blocks until user clicks — would freeze the command queue
   if (cmd === 'pick-start') {
-    return { text: 'Use pick message instead of bridge command', isError: true };
+    const r = await startPicking();
+    return { text: r.ok ? 'Pick mode started' : (r.error || 'Failed'), isError: !r.ok };
   }
   if (cmd === 'pick-stop') {
-    await cancelPick();
-    return { text: 'Pick mode stopped', isError: false };
+    const r = await stopPicking();
+    return { text: r.ok ? 'Pick mode stopped' : 'Failed', isError: !r.ok };
   }
   if (cmd === 'video-start') {
     const r = await startVideoCapture();
@@ -693,8 +658,8 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
   if (msg.type === 'health')        { sendResponse({ ok: !!crxApp }); return false; }
   if (msg.type === 'record-start')  { startRecording().then(sendResponse); return true; }
   if (msg.type === 'record-stop')   { stopRecording().then(sendResponse); return true; }
-  if (msg.type === 'pick')           { pickElement().then(sendResponse); return true; }
-  if (msg.type === 'pick-cancel')   { cancelPick().then(sendResponse); return true; }
+  if (msg.type === 'pick-start')    { startPicking().then(sendResponse); return true; }
+  if (msg.type === 'pick-stop')     { stopPicking().then(sendResponse); return true; }
   if (msg.type === 'video-start')   { startVideoCapture().then(sendResponse); return true; }
   if (msg.type === 'video-stop')    { stopVideoCapture().then(sendResponse); return true; }
   if (msg.type === 'tracing-start') {

--- a/packages/extension/src/content/picker.ts
+++ b/packages/extension/src/content/picker.ts
@@ -1,0 +1,136 @@
+/**
+ * Element picker content script.
+ * Injected into the active tab via chrome.scripting.executeScript.
+ * Highlights elements on hover, captures click, generates locator + element info.
+ */
+import { generateLocator, getImplicitRole } from './locator';
+
+// ─── Element retargeting ────────────────────────────────────────────────
+
+/** Interactive roles that should be retargeted to (like Playwright codegen). */
+const INTERACTIVE_ROLES = new Set(['link', 'button', 'checkbox', 'radio', 'textbox', 'combobox', 'tab', 'menuitem', 'menuitemcheckbox', 'menuitemradio', 'option', 'switch', 'treeitem']);
+
+/**
+ * Walk up from the clicked element to the nearest interactive ancestor.
+ * Playwright codegen does this to ensure locators target the semantic element
+ * (e.g. the <a> link) rather than a child <span> inside it.
+ */
+function retarget(el: Element): Element {
+    let current: Element | null = el;
+    while (current && current !== document.body && current !== document.documentElement) {
+        const role = getImplicitRole(current);
+        if (role && INTERACTIVE_ROLES.has(role)) return current;
+        current = current.parentElement;
+    }
+    return el;
+}
+
+// ─── Element info gathering ──────────────────────────────────────────────
+
+export function getOuterHtml(el: Element): string {
+    const outer = el.outerHTML;
+    if (outer.length <= 200) return outer;
+    const tag = el.tagName.toLowerCase();
+    const open = outer.slice(0, outer.indexOf('>') + 1);
+    return `${open}...</${tag}>`;
+}
+
+export function gatherInfo(el: Element) {
+    const rect = el.getBoundingClientRect();
+    const attrs: Record<string, string> = {};
+    for (const a of el.attributes) attrs[a.name] = a.value;
+    return {
+        locator: generateLocator(el),
+        tag: el.tagName.toLowerCase(),
+        text: (el.textContent || '').trim().slice(0, 200),
+        html: getOuterHtml(el),
+        attributes: attrs,
+        visible: rect.width > 0 && rect.height > 0,
+        enabled: !(el as HTMLButtonElement).disabled,
+        box: { x: rect.x, y: rect.y, width: rect.width, height: rect.height },
+        value: (el instanceof HTMLInputElement || el instanceof HTMLTextAreaElement || el instanceof HTMLSelectElement)
+            ? el.value : undefined,
+        checked: (el instanceof HTMLInputElement && (el.type === 'checkbox' || el.type === 'radio'))
+            ? el.checked : undefined,
+    };
+}
+
+// ─── Overlay + state ─────────────────────────────────────────────────────
+
+export const highlight = document.createElement('div');
+highlight.style.cssText = 'position:fixed;pointer-events:none;z-index:2147483646;border:2px solid #6fa8dc;background:rgba(111,168,220,0.2);display:none;box-sizing:border-box;';
+
+export let currentElement: Element | null = null;
+
+// ─── Event handlers ──────────────────────────────────────────────────────
+
+export function onMouseMove(e: MouseEvent) {
+    const raw = document.elementFromPoint(e.clientX, e.clientY);
+    if (!raw || raw === highlight) return;
+    const target = retarget(raw);
+    if (target === currentElement) return;
+    currentElement = target;
+
+    const rect = target.getBoundingClientRect();
+    highlight.style.display = 'block';
+    highlight.style.left = rect.left + 'px';
+    highlight.style.top = rect.top + 'px';
+    highlight.style.width = rect.width + 'px';
+    highlight.style.height = rect.height + 'px';
+}
+
+export function onClick(e: MouseEvent) {
+    e.preventDefault();
+    e.stopPropagation();
+    e.stopImmediatePropagation();
+
+    if (!currentElement) return;
+    const info = gatherInfo(currentElement);
+    // Mark element so CDP can find it for _generateLocatorString()
+    const pickId = Math.random().toString(36).slice(2);
+    currentElement.setAttribute('data-pw-pick-id', pickId);
+    cleanup();
+    chrome.runtime.sendMessage({ type: 'element-picked-raw', pickId, info });
+}
+
+export function onKeyDown(e: KeyboardEvent) {
+    if (e.key === 'Escape') {
+        e.preventDefault();
+        e.stopImmediatePropagation();
+        cleanup();
+        chrome.runtime.sendMessage({ type: 'pick-cancelled' });
+    }
+}
+
+// ─── Lifecycle ───────────────────────────────────────────────────────────
+
+export function cleanup() {
+    (window as any).__pw_picker_active = false;
+    currentElement = null;
+    highlight.remove();
+    document.removeEventListener('mousemove', onMouseMove, true);
+    document.removeEventListener('click', onClick, true);
+    document.removeEventListener('keydown', onKeyDown, true);
+    chrome.runtime.onMessage.removeListener(onMessage);
+}
+
+function onMessage(msg: any) {
+    if (msg.type === 'pick-stop') cleanup();
+}
+
+// ─── Init ────────────────────────────────────────────────────────────────
+
+export function init() {
+    // Guard against double-injection
+    if ((window as any).__pw_picker_active) return;
+    (window as any).__pw_picker_active = true;
+
+    document.documentElement.appendChild(highlight);
+
+    chrome.runtime.onMessage.addListener(onMessage);
+    document.addEventListener('mousemove', onMouseMove, true);
+    document.addEventListener('click', onClick, true);
+    document.addEventListener('keydown', onKeyDown, true);
+}
+
+init();

--- a/packages/extension/src/panel/components/Toolbar.tsx
+++ b/packages/extension/src/panel/components/Toolbar.tsx
@@ -2,11 +2,10 @@ import { useRef, useMemo, useState, useEffect } from 'react';
 import type { PanelState, Action } from "@/reducer";
 import { attachToTab } from '@/lib/bridge';
 import { runAndDispatch, runJsScript, runJsScriptStep } from '@/lib/run';
-import { swTerminateExecution, swDebugResume } from '@/lib/sw-debugger';
+import { swTerminateExecution, swDebugResume, swDebugEval } from '@/lib/sw-debugger';
 import { SunIcon, MoonIcon, FolderOpenIcon, SaveIcon, RecordIcon, StopIcon, StepForwardIcon, BugIcon, CrosshairIcon, PlugIcon, UnplugIcon, ScreencastIcon } from './Icons';
 import type { EditorHandle } from './CodeMirrorEditorPane';
-import { buildPickResult } from '@/lib/pick-info';
-import type { ElementPickInfo } from '@/types';
+import { buildPickResult, resolvePlaywrightLocator } from '@/lib/pick-info';
 import { loadSettings, storeSettings } from '@/lib/settings'
 
 interface ToolbarProps extends Pick<PanelState, 'editorContent' | 'editorMode' | 'stepLine' | 'attachedUrl' | 'attachedTabId' | 'isAttaching' | 'isRunning' | 'isStepDebugging' | 'breakPoints'> {
@@ -291,33 +290,54 @@ function Toolbar({ editorContent, editorMode, stepLine, attachedUrl, attachedTab
 
     // ─── Pick element ───
 
+    useEffect(() => {
+        if (!chrome.runtime?.onMessage) return;
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const listener = (msg: any) => {
+            if (msg.type === 'element-picked-raw') {
+                setIsPicking(false);
+                resolvePlaywrightLocator(msg.pickId).then(async cdpLocator => {
+                    const pickResult = buildPickResult(msg.info, cdpLocator);
+                    // Fetch aria snapshot for the picked element
+                    try {
+                        const jsLocator = cdpLocator ?? msg.info.locator;
+                        const expr = `await page.${jsLocator}.ariaSnapshot()`;
+                        const result = await swDebugEval(expr) as { result?: { type?: string; value?: string } };
+                        if (result?.result?.type === 'string' && result.result.value)
+                            pickResult.ariaSnapshot = result.result.value;
+                    } catch { /* aria snapshot is optional */ }
+                    dispatch({ type: 'ADD_LINE', line: { text: '', type: 'info', pickResult } });
+                });
+            }
+            if (msg.type === 'pick-cancelled') {
+                setIsPicking(false);
+            }
+        };
+        chrome.runtime.onMessage.addListener(listener);
+        return () => chrome.runtime.onMessage.removeListener(listener);
+    }, [dispatch]);
+
     async function handlePick() {
         if (!chrome.tabs?.query) return;
 
         if (isPicking) {
             setIsPicking(false);
-            await chrome.runtime.sendMessage({ type: 'pick-cancel' }).catch(e => console.debug('[pw-repl] pick-cancel:', e));
+            await chrome.runtime.sendMessage({ type: 'pick-stop' }).catch(e => console.debug('[pw-repl] pick-stop:', e));
             return;
         }
 
-        setIsPicking(true);
+        let result: { ok: boolean; error?: string } | undefined;
         try {
-            const result = await chrome.runtime.sendMessage({ type: 'pick' }) as { ok: boolean; info?: ElementPickInfo & { ariaSnapshot?: string }; error?: string };
-            if (!result?.ok || !result.info) {
-                if (result?.error !== 'cancelled')
-                    dispatch({ type: 'ADD_LINE', line: { text: `Pick failed: ${result?.error ?? 'unknown error'}`, type: 'error' } });
-                return;
-            }
-            const info = result.info;
-            const pickResult = buildPickResult(info, info.locator);
-            if (info.ariaSnapshot)
-                pickResult.ariaSnapshot = info.ariaSnapshot;
-            dispatch({ type: 'ADD_LINE', line: { text: '', type: 'info', pickResult } });
+            result = await chrome.runtime.sendMessage({ type: 'pick-start' });
         } catch (e) {
             dispatch({ type: 'ADD_LINE', line: { text: `Pick failed: ${String(e)}`, type: 'error' } });
-        } finally {
-            setIsPicking(false);
+            return;
         }
+        if (!result?.ok) {
+            dispatch({ type: 'ADD_LINE', line: { text: `Pick failed: ${result?.error ?? 'unknown error'}`, type: 'error' } });
+            return;
+        }
+        setIsPicking(true);
     }
 
     function handleDetach() {

--- a/packages/extension/src/panel/lib/pick-info.ts
+++ b/packages/extension/src/panel/lib/pick-info.ts
@@ -1,3 +1,4 @@
+import { swDebugEval } from '@/lib/sw-debugger';
 import type { ElementPickInfo, PickResultData } from '@/types';
 import type { SerializedValue } from '@/components/Console/types';
 
@@ -252,4 +253,20 @@ export function pickResultToSerialized(data: PickResultData): SerializedValue {
     return { __type: 'object', cls: 'PickResult', props };
 }
 
+/**
+ * Resolve Playwright's locator for a picked element via locator.normalize().
+ * The element must be marked with data-pw-pick-id by the content script.
+ */
+export async function resolvePlaywrightLocator(pickId: string): Promise<string | null> {
+    try {
+        const selector = `[data-pw-pick-id="${pickId}"]`;
+        const expr = `page.locator('${selector}').normalize().then(async loc => { await page.locator('${selector}').evaluate(e => e.removeAttribute('data-pw-pick-id')); return loc.toString(); })`;
+        const result = await swDebugEval(expr) as { result?: { type?: string; value?: string } };
+        if (result?.result?.type === 'string' && result.result.value)
+            return result.result.value;
+        return null;
+    } catch {
+        return null;
+    }
+}
 

--- a/packages/extension/test/content/picker.test.ts
+++ b/packages/extension/test/content/picker.test.ts
@@ -1,0 +1,311 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+    getOuterHtml,
+    gatherInfo,
+    highlight,
+    onMouseMove,
+    onClick,
+    onKeyDown,
+    cleanup,
+} from '../../src/content/picker';
+
+describe('picker', () => {
+    beforeEach(() => {
+        document.body.innerHTML = '';
+        cleanup();
+        vi.mocked(chrome.runtime.sendMessage).mockClear();
+        vi.restoreAllMocks();
+    });
+
+    // ─── getOuterHtml ────────────────────────────────────────────────────
+
+    describe('getOuterHtml', () => {
+        it('returns full outerHTML for short elements', () => {
+            const el = document.createElement('button');
+            el.textContent = 'OK';
+            expect(getOuterHtml(el)).toBe('<button>OK</button>');
+        });
+
+        it('truncates long outerHTML', () => {
+            const el = document.createElement('div');
+            el.textContent = 'x'.repeat(300);
+            const result = getOuterHtml(el);
+            expect(result).toContain('<div>');
+            expect(result).toContain('...</div>');
+            expect(result.length).toBeLessThan(250);
+        });
+
+        it('preserves attributes in truncated output', () => {
+            const el = document.createElement('div');
+            el.id = 'main';
+            el.className = 'container';
+            el.textContent = 'x'.repeat(300);
+            const result = getOuterHtml(el);
+            expect(result).toContain('id="main"');
+            expect(result).toContain('class="container"');
+            expect(result).toMatch(/\.\.\.<\/div>$/);
+        });
+
+        it('handles self-closing-style elements', () => {
+            const el = document.createElement('img');
+            el.setAttribute('src', 'logo.png');
+            el.setAttribute('alt', 'Logo');
+            const result = getOuterHtml(el);
+            expect(result).toContain('src="logo.png"');
+        });
+    });
+
+    // ─── gatherInfo ──────────────────────────────────────────────────────
+
+    describe('gatherInfo', () => {
+        it('returns basic element info', () => {
+            document.body.innerHTML = '<button>Submit</button>';
+            const btn = document.querySelector('button')!;
+            const info = gatherInfo(btn);
+            expect(info.tag).toBe('button');
+            expect(info.text).toBe('Submit');
+            expect(info.locator).toContain('Submit');
+            expect(info.html).toContain('<button>');
+        });
+
+        it('collects attributes', () => {
+            document.body.innerHTML = '<input type="text" id="name" placeholder="Enter name">';
+            const input = document.querySelector('input')!;
+            const info = gatherInfo(input);
+            expect(info.attributes.type).toBe('text');
+            expect(info.attributes.id).toBe('name');
+            expect(info.attributes.placeholder).toBe('Enter name');
+        });
+
+        it('returns value for input elements', () => {
+            document.body.innerHTML = '<input type="text" value="hello">';
+            const input = document.querySelector('input')! as HTMLInputElement;
+            const info = gatherInfo(input);
+            expect(info.value).toBe('hello');
+        });
+
+        it('returns undefined value for non-input elements', () => {
+            document.body.innerHTML = '<div>text</div>';
+            const div = document.querySelector('div')!;
+            const info = gatherInfo(div);
+            expect(info.value).toBeUndefined();
+        });
+
+        it('returns checked state for checkbox', () => {
+            document.body.innerHTML = '<input type="checkbox" checked>';
+            const input = document.querySelector('input')! as HTMLInputElement;
+            const info = gatherInfo(input);
+            expect(info.checked).toBe(true);
+        });
+
+        it('returns undefined checked for non-checkable', () => {
+            document.body.innerHTML = '<input type="text">';
+            const input = document.querySelector('input')!;
+            const info = gatherInfo(input);
+            expect(info.checked).toBeUndefined();
+        });
+
+        it('includes enabled state', () => {
+            document.body.innerHTML = '<button disabled>No</button>';
+            const btn = document.querySelector('button')!;
+            const info = gatherInfo(btn);
+            expect(info.enabled).toBe(false);
+        });
+
+        it('includes bounding box', () => {
+            document.body.innerHTML = '<div>test</div>';
+            const div = document.querySelector('div')!;
+            const info = gatherInfo(div);
+            expect(info.box).toHaveProperty('x');
+            expect(info.box).toHaveProperty('y');
+            expect(info.box).toHaveProperty('width');
+            expect(info.box).toHaveProperty('height');
+        });
+
+        it('truncates long text content', () => {
+            document.body.innerHTML = `<div>${'x'.repeat(300)}</div>`;
+            const div = document.querySelector('div')!;
+            const info = gatherInfo(div);
+            expect(info.text.length).toBe(200);
+        });
+    });
+
+    // ─── onMouseMove ──────────────────────────────────────────────────────
+
+    describe('onMouseMove', () => {
+        it('updates highlight style for target element', () => {
+            document.body.innerHTML = '<button>Click me</button>';
+            const btn = document.querySelector('button')!;
+            vi.spyOn(document, 'elementFromPoint').mockReturnValue(btn);
+
+            onMouseMove(new MouseEvent('mousemove', { clientX: 50, clientY: 50 }));
+
+            expect(highlight.style.display).toBe('block');
+        });
+
+        it('skips when elementFromPoint returns null', () => {
+            vi.spyOn(document, 'elementFromPoint').mockReturnValue(null);
+            highlight.style.display = 'none';
+
+            onMouseMove(new MouseEvent('mousemove', { clientX: 0, clientY: 0 }));
+
+            expect(highlight.style.display).toBe('none');
+        });
+
+        it('skips when target is the highlight overlay', () => {
+            vi.spyOn(document, 'elementFromPoint').mockReturnValue(highlight);
+            highlight.style.display = 'none';
+
+            onMouseMove(new MouseEvent('mousemove', { clientX: 50, clientY: 50 }));
+
+            expect(highlight.style.display).toBe('none');
+        });
+
+        it('skips when target is same as current element', () => {
+            document.body.innerHTML = '<button>Click me</button>';
+            const btn = document.querySelector('button')!;
+            const rectSpy = vi.spyOn(btn, 'getBoundingClientRect');
+            vi.spyOn(document, 'elementFromPoint').mockReturnValue(btn);
+
+            // First call sets currentElement
+            onMouseMove(new MouseEvent('mousemove', { clientX: 50, clientY: 50 }));
+            expect(rectSpy).toHaveBeenCalledTimes(1);
+
+            // Second call with same element — should skip (no getBoundingClientRect)
+            onMouseMove(new MouseEvent('mousemove', { clientX: 60, clientY: 60 }));
+            expect(rectSpy).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    // ─── onClick ────────────────────────────────────────────────────────
+
+    describe('onClick', () => {
+        it('does nothing when currentElement is null', () => {
+            const event = new MouseEvent('click', { bubbles: true });
+            onClick(event);
+
+            expect(chrome.runtime.sendMessage).not.toHaveBeenCalled();
+        });
+
+        it('sends element-picked-raw message', () => {
+            document.body.innerHTML = '<button>Submit</button>';
+            const btn = document.querySelector('button')!;
+            vi.spyOn(document, 'elementFromPoint').mockReturnValue(btn);
+            onMouseMove(new MouseEvent('mousemove', { clientX: 50, clientY: 50 }));
+            vi.mocked(chrome.runtime.sendMessage).mockClear();
+
+            onClick(new MouseEvent('click', { bubbles: true }));
+
+            expect(chrome.runtime.sendMessage).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    type: 'element-picked-raw',
+                    pickId: expect.any(String),
+                    info: expect.objectContaining({ tag: 'button' }),
+                })
+            );
+        });
+
+        it('sets data-pw-pick-id on the picked element', () => {
+            document.body.innerHTML = '<button>Submit</button>';
+            const btn = document.querySelector('button')!;
+            vi.spyOn(document, 'elementFromPoint').mockReturnValue(btn);
+            onMouseMove(new MouseEvent('mousemove', { clientX: 50, clientY: 50 }));
+
+            onClick(new MouseEvent('click', { bubbles: true }));
+
+            expect(btn.hasAttribute('data-pw-pick-id')).toBe(true);
+        });
+
+        it('calls preventDefault, stopPropagation, stopImmediatePropagation', () => {
+            document.body.innerHTML = '<button>Submit</button>';
+            const btn = document.querySelector('button')!;
+            vi.spyOn(document, 'elementFromPoint').mockReturnValue(btn);
+            onMouseMove(new MouseEvent('mousemove', { clientX: 50, clientY: 50 }));
+
+            const event = new MouseEvent('click', { bubbles: true, cancelable: true });
+            const preventSpy = vi.spyOn(event, 'preventDefault');
+            const stopSpy = vi.spyOn(event, 'stopPropagation');
+            const stopImmSpy = vi.spyOn(event, 'stopImmediatePropagation');
+
+            onClick(event);
+
+            expect(preventSpy).toHaveBeenCalled();
+            expect(stopSpy).toHaveBeenCalled();
+            expect(stopImmSpy).toHaveBeenCalled();
+        });
+
+        it('calls cleanup after picking', () => {
+            document.body.innerHTML = '<button>Submit</button>';
+            const btn = document.querySelector('button')!;
+            vi.spyOn(document, 'elementFromPoint').mockReturnValue(btn);
+            onMouseMove(new MouseEvent('mousemove', { clientX: 50, clientY: 50 }));
+
+            (window as any).__pw_picker_active = true;
+            onClick(new MouseEvent('click', { bubbles: true }));
+
+            expect((window as any).__pw_picker_active).toBe(false);
+        });
+    });
+
+    // ─── onKeyDown ──────────────────────────────────────────────────────
+
+    describe('onKeyDown', () => {
+        it('sends pick-cancelled on Escape', () => {
+            const event = new KeyboardEvent('keydown', { key: 'Escape', bubbles: true, cancelable: true });
+            onKeyDown(event);
+
+            expect(chrome.runtime.sendMessage).toHaveBeenCalledWith(
+                expect.objectContaining({ type: 'pick-cancelled' })
+            );
+        });
+
+        it('calls preventDefault and stopImmediatePropagation on Escape', () => {
+            const event = new KeyboardEvent('keydown', { key: 'Escape', bubbles: true, cancelable: true });
+            const preventSpy = vi.spyOn(event, 'preventDefault');
+            const stopImmSpy = vi.spyOn(event, 'stopImmediatePropagation');
+
+            onKeyDown(event);
+
+            expect(preventSpy).toHaveBeenCalled();
+            expect(stopImmSpy).toHaveBeenCalled();
+        });
+
+        it('calls cleanup on Escape', () => {
+            (window as any).__pw_picker_active = true;
+            const event = new KeyboardEvent('keydown', { key: 'Escape', bubbles: true, cancelable: true });
+
+            onKeyDown(event);
+
+            expect((window as any).__pw_picker_active).toBe(false);
+        });
+
+        it('ignores non-Escape keys', () => {
+            onKeyDown(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+            expect(chrome.runtime.sendMessage).not.toHaveBeenCalled();
+        });
+
+        it('ignores regular character keys', () => {
+            onKeyDown(new KeyboardEvent('keydown', { key: 'a', bubbles: true }));
+            expect(chrome.runtime.sendMessage).not.toHaveBeenCalled();
+        });
+    });
+
+    // ─── cleanup ────────────────────────────────────────────────────────
+
+    describe('cleanup', () => {
+        it('sets __pw_picker_active to false', () => {
+            (window as any).__pw_picker_active = true;
+            cleanup();
+            expect((window as any).__pw_picker_active).toBe(false);
+        });
+
+        it('removes highlight from DOM', () => {
+            document.body.appendChild(highlight);
+            expect(document.body.contains(highlight)).toBe(true);
+
+            cleanup();
+
+            expect(document.body.contains(highlight)).toBe(false);
+        });
+    });
+});

--- a/packages/extension/vite.config.ts
+++ b/packages/extension/vite.config.ts
@@ -12,6 +12,7 @@ import { writeFileSync, mkdirSync } from 'fs';
  */
 function contentScriptPlugin(): Plugin {
   const contentScripts = [
+    { entry: resolve(__dirname, "src/content/picker.ts"), out: "content/picker.js" },
     { entry: resolve(__dirname, "src/content/recorder.ts"), out: "content/recorder.js" },
     { entry: resolve(__dirname, "src/content/trace-loader.ts"), out: "content/trace-loader.js" },
   ];


### PR DESCRIPTION
## Summary
- Revert Chrome extension picker from `page.pickLocator()` back to content script (`picker.ts`) — `pickLocator()` is unsupported in playwright-crx and causes "Frame has been detached" on first attach
- VS Code picker still uses `pickLocator()` (runs through regular Playwright, not crx)
- Remove dead pick event forwarding from offscreen bridge (VS Code no longer polls for pick events)

## Test plan
- [ ] Chrome extension: attach to tab works on first attempt
- [ ] Chrome extension: picker works via content script
- [ ] VS Code: pickLocator still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)