### PR TITLE
fix: reset crxApp on stale frame attach failure

### DIFF
--- a/packages/extension/src/background.ts
+++ b/packages/extension/src/background.ts
@@ -150,14 +150,16 @@ async function attachToTab(tabId: number): Promise<{ ok: boolean; url?: string; 
       return { ok: true, url: currentPage.url() };
     }
 
-    const app = await ensureCrxApp();
+    let app = await ensureCrxApp();
 
     try {
       currentPage = await app.attach(tabId);
     } catch {
       // "Frame has been detached" — stale frame tree from previous attach.
-      // Detach and retry once to get a fresh frame tree.
-      await app.detach(tabId).catch(() => {});
+      // app.detach() doesn't fully clean up transport state (_tabToTarget maps),
+      // so close the app entirely and get a fresh instance.
+      await app.close().catch(() => {});
+      app = await ensureCrxApp();
       currentPage = await app.attach(tabId);
     }
     activeTabId = tabId;

--- a/packages/extension/test/background.test.ts
+++ b/packages/extension/test/background.test.ts
@@ -17,6 +17,7 @@ vi.mock('@playwright-repl/playwright-crx', () => {
   mockCrxApp = {
     attach: vi.fn().mockResolvedValue(mockPage),
     detach: vi.fn().mockResolvedValue(undefined),
+    close: vi.fn().mockResolvedValue(undefined),
     on: vi.fn(),
     context: vi.fn().mockReturnValue(mockContext),
   };
@@ -59,6 +60,7 @@ describe("background.ts message handlers", () => {
       attach: vi.fn().mockResolvedValue(mockPage),
       detach: vi.fn().mockResolvedValue(undefined),
       detachAll: vi.fn().mockResolvedValue(undefined),
+      close: vi.fn().mockResolvedValue(undefined),
       on: vi.fn(),
       context: vi.fn().mockReturnValue(mockContext),
       recorder: {
@@ -175,12 +177,13 @@ describe("background.ts message handlers", () => {
     expect(result.error).toContain('CDP failed');
   });
 
-  it("attach recovers via detach on transient error", async () => {
+  it("attach recovers via app.close() on transient error", async () => {
     mockCrxApp.attach
       .mockRejectedValueOnce(new Error('Frame has been detached'))
       .mockResolvedValueOnce(mockPage);
+    mockCrxApp.close = vi.fn().mockResolvedValue(undefined);
     const result = await sendMessage({ type: 'attach', tabId: 42 });
-    expect(mockCrxApp.detach).toHaveBeenCalledWith(42);
+    expect(mockCrxApp.close).toHaveBeenCalled();
     expect(result).toEqual({ ok: true, url: 'https://example.com' });
   });
 
@@ -248,7 +251,7 @@ describe("background.ts message handlers", () => {
 
   // ─── attach: Frame detached retry ─────────────────────────────────────────
 
-  it("attach retries on 'Frame has been detached' error via detach", async () => {
+  it("attach retries on 'Frame has been detached' error via app.close()", async () => {
     const retryPage = { url: vi.fn().mockReturnValue('https://example.com'), on: vi.fn() };
     let callCount = 0;
     mockCrxApp.attach.mockImplementation(() => {
@@ -256,10 +259,11 @@ describe("background.ts message handlers", () => {
       if (callCount === 1) return Promise.reject(new Error('Frame has been detached'));
       return Promise.resolve(retryPage);
     });
+    mockCrxApp.close = vi.fn().mockResolvedValue(undefined);
 
     const result = await sendMessage({ type: 'attach', tabId: 42 });
     expect(result.ok).toBe(true);
-    expect(mockCrxApp.detach).toHaveBeenCalledWith(42);
+    expect(mockCrxApp.close).toHaveBeenCalled();
     expect(mockCrxApp.attach).toHaveBeenCalledTimes(2);
   });
 


### PR DESCRIPTION
## Summary
- Replace `app.detach(tabId)` retry with `app.close()` + fresh `ensureCrxApp()` on attach failure
- `detach()` doesn't fully clean up playwright-crx transport state (`_tabToTarget` maps), so retrying attach hits the same stale frame tree
- Fixes "Frame has been detached" error when attaching to tabs that were open before extension reload

Closes #627

## Test plan
- [ ] Reload extension, attach to pre-existing tab — should succeed
- [ ] Attach to fresh tab — still works
- [ ] 84 background tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)