### PR TITLE
fix: bridge reconnect reads port from storage instead of service worker

### DIFF
--- a/packages/extension/src/offscreen/offscreen.ts
+++ b/packages/extension/src/offscreen/offscreen.ts
@@ -80,16 +80,20 @@ async function stopVideoCapture(): Promise<{ blobUrl: string; size: number }> {
 let ws: WebSocket | null = null;
 let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
 let reconnecting = false;
+async function getPort(): Promise<number> {
+    try {
+        const { bridgePort } = await chrome.storage.local.get('bridgePort');
+        if (bridgePort) return bridgePort;
+    } catch {}
+    return 9876;
+}
 
 async function reconnect() {
     if (reconnecting) return;
     if (ws && (ws.readyState === WebSocket.OPEN || ws.readyState === WebSocket.CONNECTING)) return;
     reconnecting = true;
     try {
-        const port: number = await chrome.runtime.sendMessage({ type: 'get-bridge-port' });
-        connect(port || 9876);
-    } catch {
-        scheduleReconnect();
+        connect(await getPort());
     } finally {
         reconnecting = false;
     }
@@ -160,9 +164,7 @@ function connect(port: number) {
     }
 }
 
-chrome.runtime.sendMessage({ type: 'get-bridge-port' }).then((port: number) => {
-    connect(port || 9876);
-});
+getPort().then(port => connect(port));
 
 // ─── Message routing from background SW ─────────────────────────────────────
 

--- a/packages/extension/src/offscreen/offscreen.ts
+++ b/packages/extension/src/offscreen/offscreen.ts
@@ -84,7 +84,7 @@ async function getPort(): Promise<number> {
     try {
         const { bridgePort } = await chrome.storage.local.get('bridgePort');
         if (bridgePort) return bridgePort;
-    } catch {}
+    } catch { /* storage may be unavailable */ }
     return 9876;
 }
 
@@ -168,7 +168,6 @@ getPort().then(port => connect(port));
 
 // ─── Message routing from background SW ─────────────────────────────────────
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 chrome.runtime.onMessage.addListener((msg: any, _sender: any, sendResponse: any) => {
     if (msg.type === 'bridge-port-changed') {
         if (reconnectTimer) clearTimeout(reconnectTimer);

--- a/packages/extension/test/offscreen.test.ts
+++ b/packages/extension/test/offscreen.test.ts
@@ -37,12 +37,17 @@ describe('offscreen bridge', () => {
 
     sendMessage = vi.fn().mockResolvedValue(9876);
 
-    // Mock chrome.runtime
+    // Mock chrome.runtime + chrome.storage.local
     (globalThis as any).chrome = {
       runtime: {
         sendMessage,
         onMessage: {
           addListener: vi.fn((fn: any) => { onMessageListener = fn; }),
+        },
+      },
+      storage: {
+        local: {
+          get: vi.fn().mockResolvedValue({ bridgePort: 9876 }),
         },
       },
     };
@@ -63,15 +68,15 @@ describe('offscreen bridge', () => {
     globalThis.WebSocket = OriginalWebSocket;
   });
 
-  it('requests bridge port and connects WebSocket on init', () => {
-    expect(sendMessage).toHaveBeenCalledWith({ type: 'get-bridge-port' });
+  it('reads bridge port from storage and connects WebSocket on init', () => {
+    expect((globalThis as any).chrome.storage.local.get).toHaveBeenCalledWith('bridgePort');
     expect(MockWebSocket.instances).toHaveLength(1);
     expect(MockWebSocket.instances[0].url).toBe('ws://127.0.0.1:9876');
   });
 
-  it('uses default port 9876 when get-bridge-port returns falsy', async () => {
+  it('uses default port 9876 when storage has no bridgePort', async () => {
     MockWebSocket.instances = [];
-    sendMessage.mockResolvedValue(0);
+    (globalThis as any).chrome.storage.local.get.mockResolvedValue({});
 
     vi.resetModules();
     await import('../src/offscreen/offscreen');


### PR DESCRIPTION
## Summary

- Offscreen document now reads bridge port from `chrome.storage.local` instead of `chrome.runtime.sendMessage`
- Removes dependency on service worker being awake for reconnection
- On failure, connects immediately with default port instead of deferring

## Problem

When the bridge WebSocket drops (code 1001), `reconnect()` called `chrome.runtime.sendMessage({ type: 'get-bridge-port' })` which requires the service worker. If the service worker was suspended, the `sendMessage` would fail, and reconnection would enter a retry loop that kept failing the same way.

## Fix

`getPort()` reads from `chrome.storage.local` (always available, no service worker dependency), falls back to default port 9876.

Closes #663

## Test plan

- [ ] CI passes
- [ ] Load extension, connect bridge, wait for idle, verify reconnection works

🤖 Generated with [Claude Code](https://claude.com/claude-code)