### PR TITLE
fix: skip offscreen bridge for development installs, improve reconnection

### DIFF
--- a/packages/extension/e2e/bridge/fixtures.ts
+++ b/packages/extension/e2e/bridge/fixtures.ts
@@ -52,7 +52,8 @@ export const test = base.extend<
     const bridge = new BridgeServer();
     await bridge.start(BRIDGE_PORT);
 
-    // 3. Launch browser with extension
+    // 3. Launch browser with extension (development install — offscreen doc not created
+    //    on startup because bridgePort is not in storage yet)
     const context = await chromium.launchPersistentContext('', {
       channel: 'chromium',
       headless: !process.env.HEADED,
@@ -64,12 +65,12 @@ export const test = base.extend<
       ],
     });
 
-    // 4. Get extension ID from service worker
+    // 5. Get extension ID from service worker
     let sw = context.serviceWorkers()[0];
     if (!sw) sw = await context.waitForEvent('serviceworker');
     const extensionId = sw.url().split('/')[2];
 
-    // 5. Tell the test extension to connect to our random port.
+    // 6. Tell the test extension to connect to our random port.
     //    The offscreen doc defaults to 9876, which fails (no server there).
     //    Setting bridgePort in chrome.storage triggers background.ts to broadcast
     //    'bridge-port-changed', so the offscreen doc reconnects to our port.

--- a/packages/extension/e2e/panel/panel.spec.ts
+++ b/packages/extension/e2e/panel/panel.spec.ts
@@ -142,7 +142,7 @@ test.describe("Panel page test", () => {
   });
 
   test('shows fail stats when command errors', async ({ sidePanel }) => {
-    await sidePanel.fillEditor('click missing');
+    await sidePanel.fillEditor('goto invalid://url');
 
     await sidePanel.runBtn.click();
 

--- a/packages/extension/src/background.ts
+++ b/packages/extension/src/background.ts
@@ -76,10 +76,20 @@ async function ensureOffscreen() {
     justification: 'Maintains WebSocket connection to CLI/MCP bridge server and handles video capture',
   });
 }
-ensureOffscreen().catch(e => console.warn('[pw-repl] offscreen document creation failed:', e));
+
+// Web Store installs: always create offscreen doc (auto-connect to bridge).
+// Development installs (--load-extension): only create if bridgePort was previously
+// configured, to avoid connecting to a real bridge during CLI/tests/VS Code.
+chrome.management.getSelf().then(async (info) => {
+  if (info.installType === 'normal') {
+    ensureOffscreen().catch(e => console.warn('[pw-repl] offscreen document creation failed:', e));
+  } else {
+    const { bridgePort } = await chrome.storage.local.get(['bridgePort']);
+    if (bridgePort) ensureOffscreen().catch(e => console.warn('[pw-repl] offscreen document creation failed:', e));
+  }
+});
 
 // Re-check offscreen doc periodically — Chrome may kill it after idle.
-// chrome.alarms survive service worker restarts; setTimeout does not.
 chrome.alarms.create('ensure-offscreen', { periodInMinutes: 1 });
 chrome.alarms.onAlarm.addListener((alarm) => {
   if (alarm.name === 'ensure-offscreen') {
@@ -100,7 +110,10 @@ chrome.storage.onChanged.addListener((changes, area) => {
     cachedSettings.openAs = changes.openAs.newValue;
   }
   if (area === 'local' && changes.bridgePort) {
-    chrome.runtime.sendMessage({ type: 'bridge-port-changed', port: changes.bridgePort.newValue }).catch(() => { /* panel may not be open */ });
+    // Ensure offscreen doc exists before telling it to reconnect (may not exist in development mode)
+    ensureOffscreen().then(() => {
+      chrome.runtime.sendMessage({ type: 'bridge-port-changed', port: changes.bridgePort.newValue }).catch(() => {});
+    }).catch(() => {});
   }
 });
 

--- a/packages/extension/src/offscreen/offscreen.ts
+++ b/packages/extension/src/offscreen/offscreen.ts
@@ -80,30 +80,40 @@ async function stopVideoCapture(): Promise<{ blobUrl: string; size: number }> {
 let ws: WebSocket | null = null;
 let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
 let reconnecting = false;
+let lastPort = 9876;
+let retryCount = 0;
 
 async function reconnect() {
     if (reconnecting) return;
-    if (ws && (ws.readyState === WebSocket.OPEN || ws.readyState === WebSocket.CONNECTING)) return;
+    if (ws && ws.readyState === WebSocket.OPEN) return;
+    // Kill stuck CONNECTING sockets
+    if (ws && ws.readyState === WebSocket.CONNECTING) {
+        ws.onclose = null;
+        ws.onerror = null;
+        ws.close();
+        ws = null;
+    }
     reconnecting = true;
     try {
         const port: number = await chrome.runtime.sendMessage({ type: 'get-bridge-port' });
-        connect(port || 9876);
+        lastPort = port || 9876;
     } catch {
-        scheduleReconnect();
-    } finally {
-        reconnecting = false;
+        // Service worker may be waking up — use last known port
     }
+    connect(lastPort);
+    reconnecting = false;
 }
 
 function scheduleReconnect() {
     if (reconnectTimer) clearTimeout(reconnectTimer);
-    reconnectTimer = setTimeout(() => reconnect(), 3000);
+    const delay = Math.min(3000 * Math.pow(2, retryCount), 30000);
+    reconnectTimer = setTimeout(() => reconnect(), delay);
+    retryCount++;
 }
 
-// Periodic health check — reconnect if WebSocket is dead.
-// Catches cases where setTimeout gets throttled or the offscreen doc restarts.
+// Periodic health check — reconnect if WebSocket is not open and bridge is enabled.
 setInterval(() => {
-    if (!ws || ws.readyState === WebSocket.CLOSED) {
+    if (lastPort && (!ws || ws.readyState !== WebSocket.OPEN)) {
         reconnect();
     }
 }, 10000);
@@ -113,6 +123,7 @@ function connect(port: number) {
         ws = new WebSocket(`ws://127.0.0.1:${port}`);
 
         ws.onopen = () => {
+            retryCount = 0;
             // Trigger auto-attach so the CLI knows which tab is connected
             chrome.runtime.sendMessage({ type: 'bridge-attach' }).then((result: any) => {
                 if (ws?.readyState === WebSocket.OPEN && result?.url)
@@ -161,7 +172,8 @@ function connect(port: number) {
 }
 
 chrome.runtime.sendMessage({ type: 'get-bridge-port' }).then((port: number) => {
-    connect(port || 9876);
+    lastPort = port || 9876;
+    connect(lastPort);
 });
 
 // ─── Message routing from background SW ─────────────────────────────────────
@@ -169,9 +181,10 @@ chrome.runtime.sendMessage({ type: 'get-bridge-port' }).then((port: number) => {
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 chrome.runtime.onMessage.addListener((msg: any, _sender: any, sendResponse: any) => {
     if (msg.type === 'bridge-port-changed') {
+        lastPort = msg.port as number;
         if (reconnectTimer) clearTimeout(reconnectTimer);
-        if (ws) { ws.onclose = null; ws.close(); }
-        connect(msg.port as number);
+        if (ws) { ws.onclose = null; ws.close(); ws = null; }
+        if (lastPort) connect(lastPort);
     }
 
     // Video capture messages

--- a/packages/extension/test/background.test.ts
+++ b/packages/extension/test/background.test.ts
@@ -72,6 +72,8 @@ describe("background.ts message handlers", () => {
     (crx.start as ReturnType<typeof vi.fn>).mockResolvedValue(mockCrxApp);
 
     // Set up chrome stubs
+    (chrome.management as any).getSelf = vi.fn().mockResolvedValue({ installType: 'development' });
+    (chrome.storage.local.get as any).mockResolvedValue({});
     (chrome.tabs as any).get = vi.fn().mockResolvedValue({ id: 42, url: 'https://example.com' });
     (chrome.tabs as any).query = vi.fn().mockResolvedValue([{ id: 42, url: 'https://example.com' }]);
     (chrome.tabs as any).onActivated = { addListener: vi.fn() };
@@ -423,6 +425,8 @@ describe("background.ts message handlers", () => {
 
   it("storage onChanged sends bridge-port-changed message", async () => {
     onStorageChanged({ bridgePort: { newValue: 5555 } }, 'local');
+    // ensureOffscreen is async — flush promises before checking sendMessage
+    await new Promise(r => setTimeout(r, 0));
     expect(chrome.runtime.sendMessage).toHaveBeenCalledWith(
       expect.objectContaining({ type: 'bridge-port-changed', port: 5555 })
     );

--- a/packages/extension/test/setup.ts
+++ b/packages/extension/test/setup.ts
@@ -40,6 +40,13 @@ if (!globalThis.chrome.offscreen) {
   };
 }
 
+// vitest-chrome doesn't include chrome.management — add it manually
+if (!globalThis.chrome.management) {
+  (globalThis.chrome as any).management = {
+    getSelf: async () => ({ installType: 'development' }),
+  };
+}
+
 // vitest-chrome doesn't include chrome.webNavigation — add it manually
 if (!globalThis.chrome.webNavigation) {
   (globalThis.chrome as any).webNavigation = {


### PR DESCRIPTION
## Summary

- Use `chrome.management.getSelf()` to detect install type — skip offscreen doc creation for development installs (`--load-extension`) unless `bridgePort` is already in storage
- Create offscreen doc on demand when `bridgePort` changes in storage
- Improve reconnection: cache last port, exponential backoff, kill stuck CONNECTING sockets
- Fix flaky test: `goto invalid://url` instead of `click missing` (instant fail vs 30s timeout)

## Problem

When CLI, VS Code, or E2E tests launch Chromium with `--load-extension`, the extension's offscreen doc auto-connects to `ws://localhost:9876`, disrupting any real bridge connection (e.g. Claude Desktop's MCP server).

## Solution

Web Store installs (`installType: "normal"`) always auto-connect — no behavior change for real users. Development installs only create the offscreen doc if the user previously configured `bridgePort` in extension preferences.

Closes #663

## Test plan

- [x] 956 unit tests pass
- [x] 150 E2E tests pass
- [x] MCP bridge not disrupted during local E2E test runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)