### PR TITLE
feat: add lifecycle logging across MCP server and extension

### DIFF
--- a/packages/extension/src/background.ts
+++ b/packages/extension/src/background.ts
@@ -7,6 +7,20 @@ import type { PwReplSettings } from './panel/lib/settings';
 import { parseReplCommand } from './panel/lib/commands';
 import { detectMode } from './panel/lib/execute';
 
+// ─── Service worker lifecycle logging ────────────────────────────────────────
+
+chrome.runtime.onSuspend.addListener(() => {
+  console.debug('[pw-repl] onSuspend — service worker suspending');
+});
+
+chrome.runtime.onStartup.addListener(() => {
+  console.debug('[pw-repl] onStartup — browser cold start');
+});
+
+chrome.runtime.onInstalled.addListener((details) => {
+  console.debug(`[pw-repl] onInstalled — reason: ${details.reason}`);
+});
+
 // ─── Patch toMatchAriaSnapshot ──────────────────────────────────────────────
 // toMatchAriaSnapshot requires currentTestInfo() which only exists inside the
 // Playwright Test runner. We wrap expect() with a Proxy that intercepts this

--- a/packages/extension/src/offscreen/offscreen.ts
+++ b/packages/extension/src/offscreen/offscreen.ts
@@ -2,6 +2,17 @@
 // Maintains WebSocket connection to the bridge server + handles video capture.
 // This runs independently of the side panel — MCP works without the panel open.
 
+// ─── Lifecycle logging ──────────────────────────────────────────────────────
+
+if (typeof document !== 'undefined') {
+    document.addEventListener('visibilitychange', () => {
+        console.debug(`[pw-repl] offscreen visibility: ${document.visibilityState}`);
+    });
+    window.addEventListener('beforeunload', () => {
+        console.debug('[pw-repl] offscreen beforeunload — document being killed');
+    });
+}
+
 // ─── Video Capture (tabCapture + MediaRecorder) ─────────────────────────────
 
 let recorder: MediaRecorder | undefined;
@@ -123,6 +134,7 @@ function connect(port: number) {
         ws = new WebSocket(`ws://127.0.0.1:${port}`);
 
         ws.onopen = () => {
+            console.debug(`[pw-repl] bridge connected to port ${port}`);
             retryCount = 0;
             // Trigger auto-attach so the CLI knows which tab is connected
             chrome.runtime.sendMessage({ type: 'bridge-attach' }).then((result: any) => {
@@ -160,7 +172,8 @@ function connect(port: number) {
             }
         };
 
-        ws.onclose = () => {
+        ws.onclose = (e) => {
+            console.debug(`[pw-repl] bridge disconnected (code: ${e.code}, reason: ${e.reason || 'none'})`);
             ws = null;
             scheduleReconnect();
         };

--- a/packages/extension/test/offscreen.test.ts
+++ b/packages/extension/test/offscreen.test.ts
@@ -8,7 +8,7 @@ class MockWebSocket {
   static instances: MockWebSocket[] = [];
 
   onmessage: ((e: { data: string }) => void) | null = null;
-  onclose: (() => void) | null = null;
+  onclose: ((e?: { code?: number; reason?: string }) => void) | null = null;
   onerror: (() => void) | null = null;
   readyState = MockWebSocket.OPEN;
   sent: string[] = [];
@@ -20,7 +20,7 @@ class MockWebSocket {
   }
 
   send(data: string) { this.sent.push(data); }
-  close() { this.readyState = MockWebSocket.CLOSED; this.onclose?.(); }
+  close() { this.readyState = MockWebSocket.CLOSED; this.onclose?.({ code: 1000, reason: '' }); }
 }
 
 // ─── Tests ───────────────────────────────────────────────────────────────────
@@ -152,7 +152,7 @@ describe('offscreen bridge', () => {
 
   it('reconnects after WebSocket closes', async () => {
     const ws = MockWebSocket.instances[0];
-    ws.onclose!();
+    ws.onclose!({ code: 1000, reason: '' });
 
     expect(MockWebSocket.instances).toHaveLength(1); // no new WS yet
 
@@ -207,7 +207,7 @@ describe('offscreen bridge', () => {
     const ws = MockWebSocket.instances[0];
 
     // Trigger onclose to start a reconnect timer (to port 9876)
-    ws.onclose!();
+    ws.onclose!({ code: 1000, reason: '' });
 
     // Before the 3s timer fires, change port
     const countBefore = MockWebSocket.instances.length;

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -8,6 +8,31 @@ import { createBridgeRunner } from './bridge.js';
 import { createEvaluateRunner } from './evaluate.js';
 import { createStandaloneRunner } from './standalone.js';
 import { logStartup, logEvent, logToolCall, logToolResult, logError, LOG_FILE } from './logger.js';
+// ─── Process exit handlers — log why the process dies ───────────────────────
+
+process.on('uncaughtException', (err) => {
+    logError('uncaughtException', err);
+    process.exit(1);
+});
+
+process.on('unhandledRejection', (reason) => {
+    logError('unhandledRejection', reason);
+});
+
+process.on('SIGTERM', () => {
+    logEvent('Received SIGTERM — exiting');
+    process.exit(0);
+});
+
+process.on('SIGINT', () => {
+    logEvent('Received SIGINT — exiting');
+    process.exit(0);
+});
+
+process.on('exit', (code) => {
+    logEvent(`Process exiting (code: ${code})`);
+});
+
 const argv = process.argv.slice(2);
 const standalone = argv.includes('--standalone');
 const headed = argv.includes('--headed');

--- a/packages/mcp/src/logger.ts
+++ b/packages/mcp/src/logger.ts
@@ -62,13 +62,13 @@ export function logToolCall(tool: string, input: Record<string, unknown>): void 
             return `${k}=${truncate(s, 120)}`;
         })
         .join(' ');
-    write('info', `→ ${tool}(${args})`);
+    write('info', `-> ${tool}(${args})`);
 }
 
 export function logToolResult(tool: string, isError: boolean, text: string | undefined, durationMs: number): void {
     const status = isError ? 'ERROR' : 'OK';
     const summary = text ? truncate(text.replace(/\n/g, '\\n')) : '(empty)';
-    write('info', `← ${tool} [${status}] ${durationMs}ms ${summary}`);
+    write('info', `<- ${tool} [${status}] ${durationMs}ms ${summary}`);
 }
 
 export function logError(context: string, err: unknown): void {


### PR DESCRIPTION
## Summary

Add diagnostic logging to help diagnose why the MCP server process dies or the bridge WebSocket drops.

### MCP server (`packages/mcp`)
- `process.on('uncaughtException')` — log before crashing
- `process.on('unhandledRejection')` — log unhandled promise rejections
- `process.on('SIGTERM')` / `process.on('SIGINT')` — log signals
- `process.on('exit')` — log exit code
- Replace UTF-8 arrows (`→`/`←`) with ASCII (`->`/`<-`) for Windows terminal

### Service worker (`background.ts`)
- `chrome.runtime.onSuspend` — logged when Chrome suspends the SW
- `chrome.runtime.onStartup` — logged on browser cold start
- `chrome.runtime.onInstalled` — logged on install/update

### Offscreen document (`offscreen.ts`)
- `visibilitychange` — logged when Chrome hides/shows the document
- `beforeunload` — logged when Chrome is about to kill the document
- WebSocket `onopen` / `onclose` — logged with port and close codes

Closes #665

## Test plan

- [x] 956 unit tests pass
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)