### PR TITLE
test: add upstream mock test infrastructure for VS Code extension

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,6 +60,15 @@ jobs:
         run: pnpm exec playwright test
         working-directory: packages/extension
 
+      - name: Build VS Code extension for tests
+        run: node build-test.mjs
+        working-directory: packages/vscode
+
+      - name: Run VS Code extension mock tests
+        run: pnpm exec playwright test --config tests/playwright.config.ts --project default
+        working-directory: packages/vscode
+        timeout-minutes: 10
+
       # VS Code E2E tests disabled — flaky on CI, works locally
       # - name: Run VS Code extension E2E tests
       #   run: ${{ runner.os == 'Linux' && 'xvfb-run' || '' }} pnpm exec playwright test --config e2e/playwright.config.ts

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,6 +60,10 @@ jobs:
         run: pnpm exec playwright test
         working-directory: packages/extension
 
+      - name: Merge extension coverage
+        run: pnpm run coverage:merge
+        working-directory: packages/extension
+
       - name: Build VS Code extension for tests
         run: node build-test.mjs
         working-directory: packages/vscode
@@ -74,7 +78,3 @@ jobs:
       #   run: ${{ runner.os == 'Linux' && 'xvfb-run' || '' }} pnpm exec playwright test --config e2e/playwright.config.ts
       #   working-directory: packages/vscode
       #   timeout-minutes: 5
-
-      - name: Merge extension coverage
-        run: pnpm run coverage:merge
-        working-directory: packages/extension

--- a/packages/vscode/build-test.mjs
+++ b/packages/vscode/build-test.mjs
@@ -1,0 +1,44 @@
+/**
+ * Test-specific build that bundles @playwright-repl/* packages inline
+ * so the mock test infrastructure can require() the extension as CJS.
+ *
+ * The production build (build.mjs) externalizes these packages because
+ * VS Code handles ESM/CJS interop at runtime, but the mock tests run
+ * in plain Node.js where require(ESM) fails.
+ */
+import * as esbuild from 'esbuild';
+
+/** @type {esbuild.BuildOptions} */
+const options = {
+  entryPoints: ['src/extension.ts'],
+  bundle: true,
+  outdir: 'dist',
+  alias: {
+    // Stub the 'vscode' module — our recorder.ts/picker.ts import it
+    // at runtime, unlike upstream which only uses type imports.
+    'vscode': './tests/vscode-shim.ts',
+  },
+  external: [
+    // These are loaded dynamically by the extension at runtime
+    './babelBundle',
+    './debugTransform',
+    './oopReporter',
+    './playwrightFinder',
+    './*.script',
+    // Loaded at runtime via require() — nft traces their dependencies
+    '@playwright-repl/runner',
+  ],
+  format: 'cjs',
+  platform: 'node',
+  target: 'node18',
+  sourcemap: true,
+  minify: false,
+  // Polyfill import.meta.url for @playwright-repl/core (ESM) bundled into CJS
+  define: { 'import.meta.url': 'importMetaUrl' },
+  banner: {
+    js: 'var importMetaUrl = require("url").pathToFileURL(__filename).href;',
+  },
+};
+
+await esbuild.build(options);
+console.log('Test build complete.');

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -274,6 +274,8 @@
     "@vscode/vsce": "^3.7.1",
     "adm-zip": "^0.5.17",
     "esbuild": "^0.25.0",
+    "glob": "^8.1.0",
+    "minimatch": "^10.2.4",
     "stack-utils": "^2.0.6",
     "which": "^4.0.0",
     "ws": "^8.17.1",

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -342,7 +342,7 @@ export class Extension implements RunHooks {
         }
       }),
       vscode.workspace.onDidChangeConfiguration(event => {
-        if (event.affectsConfiguration('playwright.env'))
+        if (event.affectsConfiguration('playwright-repl.env'))
           this._scheduleRebuildModels();
       }),
       this._testTree,

--- a/packages/vscode/src/settingsModel.ts
+++ b/packages/vscode/src/settingsModel.ts
@@ -137,7 +137,7 @@ class PersistentSetting<T> extends SettingBase<T> {
   constructor(vscode: vscodeTypes.VSCode, settingName: string) {
     super(vscode, settingName);
 
-    const settingFQN = `playwright.${settingName}`;
+    const settingFQN = `playwright-repl.${settingName}`;
     this._disposables = [
       this._onChange,
       vscode.workspace.onDidChangeConfiguration(event => {

--- a/packages/vscode/tests/auto-close.spec.ts
+++ b/packages/vscode/tests/auto-close.spec.ts
@@ -1,0 +1,114 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { connectToSharedBrowser, expect, test, waitForPage } from './utils';
+
+test.skip(({ showBrowser }) => !showBrowser);
+
+test('should reuse browsers', async ({ activate }) => {
+  const { vscode, testController } = await activate({
+    'playwright.config.js': `module.exports = {}`,
+    'test.spec.ts': `
+      import { test } from '@playwright/test';
+      test('pass', async ({ page }) => {});
+    `
+  });
+
+  const reusedBrowser = await vscode.extensions[0].reusedBrowserForTest();
+  const events: number[] = [];
+  reusedBrowser.onPageCountChanged((count: number) => events.push(count));
+  await testController.run();
+  await expect.poll(() => events).toEqual([1]);
+  expect(reusedBrowser._backend).toBeTruthy();
+});
+
+test('should be closed with Close all Browsers button', async ({ activate }) => {
+  const { vscode, testController } = await activate({
+    'playwright.config.js': `module.exports = {}`,
+    'test.spec.ts': `
+      import { test } from '@playwright/test';
+      test('pass', async ({ page }) => {});
+    `
+  });
+
+  const webView = vscode.webViews.get('playwright-repl.settingsView')!;
+  const closeAllBrowsers = webView.getByRole('button', { name: 'Close all browsers' });
+  await expect(closeAllBrowsers).toBeDisabled();
+  const reusedBrowser = await vscode.extensions[0].reusedBrowserForTest();
+  await testController.run();
+  expect(reusedBrowser._backend).toBeTruthy();
+  await expect(closeAllBrowsers).toBeEnabled();
+  await closeAllBrowsers.click();
+  await expect.poll(() => reusedBrowser._backend).toBeFalsy();
+});
+
+test('should auto-close after test', async ({ activate }) => {
+  const { vscode, testController } = await activate({
+    'playwright.config.js': `module.exports = {}`,
+    'test.spec.ts': `
+      import { test } from '@playwright/test';
+      test('pass', async ({ page }) => { await page.close(); });
+    `
+  });
+
+  await testController.run();
+  const reusedBrowser = await vscode.extensions[0].reusedBrowserForTest();
+  await expect.poll(() => !!reusedBrowser._backend).toBeFalsy();
+});
+
+test('should auto-close after pick', async ({ activate }) => {
+  const { vscode } = await activate({
+    'playwright.config.js': `module.exports = {}`,
+  });
+
+  await vscode.commands.executeCommand('playwright-repl.command.inspect');
+
+  // It is important that we await for command above to have context for reuse set up.
+  const browser = await connectToSharedBrowser(vscode);
+  const page = await waitForPage(browser);
+  await page.close();
+
+  const reusedBrowser = await vscode.extensions[0].reusedBrowserForTest();
+  await expect.poll(() => !!reusedBrowser._backend).toBeFalsy();
+});
+
+test('should enact "Show Browser" setting change after test finishes', async ({ activate, createLatch }) => {
+  const latch = createLatch();
+
+  const { vscode, testController } = await activate({
+    'playwright.config.js': `module.exports = {}`,
+    'test.spec.ts': `
+      import { test } from '@playwright/test';
+      test('should pass', async ({ page }) => {
+        await page.setContent('foo');
+        ${latch.blockingCode}
+      });
+    `
+  });
+
+  const runPromise = testController.run();
+
+  const reusedBrowser = vscode.extensions[0].reusedBrowserForTest();
+  await expect.poll(() => !!reusedBrowser._backend, 'wait until test started').toBeTruthy();
+
+  const webView = vscode.webViews.get('playwright-repl.settingsView')!;
+  await webView.getByRole('checkbox', { name: 'Show Browser' }).uncheck();
+  await expect.poll(() => !!reusedBrowser._backend, 'contrary to setting change, browser stays open during test run').toBeTruthy();
+  latch.open();
+  await runPromise;
+
+  await expect.poll(() => !!reusedBrowser._backend, 'after test run, setting change is honored').toBeFalsy();
+});

--- a/packages/vscode/tests/codegen.spec.ts
+++ b/packages/vscode/tests/codegen.spec.ts
@@ -1,0 +1,159 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { connectToSharedBrowser, enableProjects, expect, test, waitForPage } from './utils';
+import fs from 'node:fs';
+
+// Our fork replaced upstream recording (Record new / Record at cursor) with
+// BrowserManager-based Recorder. These tests exercise the upstream codepath.
+// TODO: Phase 5 will add tests for our Recorder implementation.
+test.skip();
+
+test('should generate code', async ({ activate }) => {
+  test.slow();
+
+  const globalSetupFile = test.info().outputPath('globalSetup.txt');
+  const { vscode } = await activate({
+    'playwright.config.js': `module.exports = {
+      projects: [
+        {
+          name: 'default',
+        },
+        {
+          name: 'germany',
+          use: {
+            locale: 'de-DE',
+          },
+        },
+      ],
+      globalSetup: './globalSetup.js',
+    }`,
+    'globalSetup.js': `
+      import fs from 'fs';
+      module.exports = async () => {
+        fs.writeFileSync(${JSON.stringify(globalSetupFile)}, 'global setup was called');
+      }
+    `,
+  });
+
+  const webView = vscode.webViews.get('playwright-repl.settingsView')!;
+  await webView.getByRole('checkbox', { name: 'default' }).setChecked(false);
+  await webView.getByRole('checkbox', { name: 'germany' }).setChecked(true);
+  await webView.getByText('Record new').click();
+  await expect.poll(() => vscode.lastWithProgressData, { timeout: 0 }).toEqual({ message: 'recording\u2026' });
+
+  expect(fs.readFileSync(globalSetupFile, 'utf-8')).toBe('global setup was called');
+
+  const browser = await connectToSharedBrowser(vscode);
+  const page = await waitForPage(browser, { locale: 'de-DE' });
+  await page.locator('body').click();
+  expect(await page.evaluate(() => navigator.language)).toBe('de-DE');
+  await expect.poll(() => {
+    return vscode.window.visibleTextEditors[0]?.edits;
+  }).toEqual([{
+    from: `import { test, expect } from '@playwright/test';
+
+test('test', async ({ page }) => {
+  <selection>// Recording...</selection>
+});`,
+    range: '[3:2 - 3:17]',
+    to: `import { test, expect } from '@playwright/test';
+
+test('test', async ({ page }) => {
+  <selection>await page.locator('body').click();</selection>
+});`
+  }]);
+});
+
+test('running test should stop the recording', async ({ activate, showBrowser }) => {
+  test.skip(!showBrowser);
+
+  const { vscode, testController } = await activate({
+    'playwright.config.js': `module.exports = {}`,
+    'tests/test.spec.ts': `
+      import { test } from '@playwright/test';
+      test('one', () => {});
+    `,
+  });
+
+  const webView = vscode.webViews.get('playwright-repl.settingsView')!;
+  await webView.getByText('Record new').click();
+  await expect.poll(() => vscode.lastWithProgressData, { timeout: 0 }).toEqual({ message: 'recording\u2026' });
+
+  const testRun = await testController.run();
+  await expect(testRun).toHaveOutput('passed');
+
+  await expect.poll(() => vscode.lastWithProgressData, { timeout: 0 }).toEqual('finished');
+});
+
+test('Record at Cursor should respect custom testId', async ({ activate, showBrowser }) => {
+  test.skip(!showBrowser);
+
+  const { vscode, testController } = await activate({
+    'playwright.config.js': `module.exports = {
+      projects: [
+        { name: 'main', use: { testIdAttribute: 'data-testerid', testDir: 'tests' } },
+        { name: 'unused', use: { testIdAttribute: 'unused', testDir: 'nonExistant' } },
+      ]
+    };`,
+    'tests/test.spec.ts': `
+      import { test } from '@playwright/test';
+      test('should pass', async ({ page }) => {
+        await page.setContent('<button data-testerid="foo">click me</button>');
+
+      });
+    `,
+  });
+
+  await enableProjects(vscode, ['main']);
+
+  await testController.expandTestItems(/test.spec/);
+  await expect(await testController.run()).toHaveOutput('1 passed');
+
+  await vscode.openEditors('**/test.spec.ts');
+  const editor = vscode.window.activeTextEditor;
+  expect(editor.document.uri.path).toContain('test.spec.ts');
+  editor.selection = new vscode.Selection(4, 0, 4, 0);
+
+  const webView = vscode.webViews.get('playwright-repl.settingsView')!;
+  await webView.getByText('Record at cursor').click();
+  await expect.poll(() => vscode.lastWithProgressData, { timeout: 0 }).toEqual({ message: 'recording\u2026' });
+
+  const browser = await connectToSharedBrowser(vscode);
+  const page = await waitForPage(browser);
+  await page.getByRole('button', { name: 'click me' }).click();
+  await expect.poll(() => editor.edits).toEqual([
+    {
+      range: '[4:0 - 4:0]',
+      from: `
+      import { test } from '@playwright/test';
+      test('should pass', async ({ page }) => {
+        await page.setContent('<button data-testerid="foo">click me</button>');
+<selection></selection>
+      });
+    `,
+      to: `
+      import { test } from '@playwright/test';
+      test('should pass', async ({ page }) => {
+        await page.setContent('<button data-testerid="foo">click me</button>');
+<selection>await page.getByTestId('foo').click();</selection>
+      });
+    `,
+    }
+  ]);
+
+  vscode.lastWithProgressToken!.cancel();
+});

--- a/packages/vscode/tests/debug-tests.spec.ts
+++ b/packages/vscode/tests/debug-tests.spec.ts
@@ -1,0 +1,530 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { expect, test, escapedPathSep, enableProjects, connectToSharedBrowser, waitForPage } from './utils';
+import { TestRun, DebugSession, stripAnsi } from './mock/vscode';
+
+test('should debug multiple passing tests', async ({ activate }) => {
+  const { vscode } = await activate({
+    'playwright.config.js': `module.exports = { testDir: 'tests' }`,
+    'tests/test-1.spec.ts': `
+      import { test } from '@playwright/test';
+      test('should pass', async () => {});
+    `,
+    'tests/test-2.spec.ts': `
+      import { test, expect } from '@playwright/test';
+      test('should pass', async () => {});
+    `,
+  });
+
+  const testRun = await vscode.testControllers[0].debug();
+  expect(testRun.renderLog()).toBe(`
+    tests > test-1.spec.ts > should pass [2:0]
+      enqueued
+      started
+      passed
+    tests > test-2.spec.ts > should pass [2:0]
+      enqueued
+      started
+      passed
+  `);
+
+  await expect(vscode).toHaveConnectionLog([
+    { method: 'listFiles', params: {} },
+    { method: 'runGlobalSetup', params: {} },
+    {
+      method: 'runTests',
+      params: expect.objectContaining({
+        locations: [],
+        testIds: undefined
+      })
+    },
+  ]);
+});
+
+test('should debug one test and pause at end', async ({ activate }) => {
+  const { vscode, testController } = await activate({
+    'playwright.config.js': `module.exports = {
+      projects: [
+        { name: 'main', use: { testIdAttribute: 'data-testerid', testDir: 'tests' } },
+        { name: 'unused', use: { testIdAttribute: 'unused', testDir: 'nonExistant' } },
+      ]
+    };`,
+    'tests/test.spec.ts': `
+      import { test } from '@playwright/test';
+      test('should pass', async ({ page }) => {
+        await page.setContent('<button data-testerid="foo">click me</button>');
+        setInterval(() => console.log('time passed'), 500);
+
+      });
+    `,
+  });
+
+  await enableProjects(vscode, ['main']);
+
+  await testController.expandTestItems(/test.spec/);
+  const testItems = testController.findTestItems(/pass/);
+  const profile = testController.debugProfile();
+  const testRunPromise = new Promise<TestRun>(f => testController.onDidCreateTestRun(f));
+  const runPromise = profile.run(testItems);
+  const testRun = await testRunPromise;
+
+  await expect.poll(() => vscode.window.activeTextEditor?.renderDecorations('  '), { timeout: 10000 }).toContain(
+      `[6:6 - 6:6]: decorator pausedAtEnd`
+  );
+
+  // The test should keep running.
+  vscode.debug.output = '';
+  await expect.poll(() => vscode.debug.output, { timeout: 10000 }).toContain('time passed');
+
+  expect(testRun.renderLog()).toBe(`
+    tests > test.spec.ts > should pass [2:0]
+      enqueued
+      enqueued
+      started
+  `);
+
+  await expect(vscode).toHaveConnectionLog([
+    { method: 'listFiles', params: {} },
+    {
+      method: 'listTests',
+      params: expect.objectContaining({
+        locations: [expect.stringContaining(`tests${escapedPathSep}test\\.spec\\.ts`)]
+      })
+    },
+    { method: 'runGlobalSetup', params: {} },
+    {
+      method: 'runTests',
+      params: expect.objectContaining({
+        locations: [
+          expect.stringContaining(`tests${escapedPathSep}test\\.spec\\.ts`),
+        ],
+        testIds: [expect.any(String)]
+      })
+    },
+  ]);
+  vscode.connectionLog.length = 0;
+
+  // Recording during debug is tested separately in Phase 5
+  // (our fork uses BrowserManager-based Recorder, not upstream ReusedBrowser).
+
+  testRun.token.source.cancel();
+  await runPromise;
+
+  await expect(vscode).toHaveConnectionLog([
+    { method: 'stopTests', params: {} },
+  ]);
+
+  expect(testRun.renderLog()).toBe(`
+    tests > test.spec.ts > should pass [2:0]
+      enqueued
+      enqueued
+      started
+  `);
+});
+
+test('should debug one test and pause on error', async ({ activate }) => {
+  const { vscode, testController } = await activate({
+    'playwright.config.js': `module.exports = { testDir: 'tests' }`,
+    'tests/test.spec.ts': `
+      import { test, expect } from '@playwright/test';
+      test('should fail', async () => {
+        setInterval(() => console.log('time passed'), 500);
+        expect(1).toBe(2);
+      });
+    `,
+  });
+
+  await testController.expandTestItems(/test.spec/);
+  const testItems = testController.findTestItems(/should fail/);
+  const profile = testController.debugProfile();
+  const testRunPromise = new Promise<TestRun>(f => testController.onDidCreateTestRun(f));
+  const runPromise = profile.run(testItems);
+  const testRun = await testRunPromise;
+
+  await expect.poll(() => vscode.window.activeTextEditor?.renderDecorations('  '), { timeout: 10000 }).toBe(`
+    --------------------------------------------------------------
+    [4:18 - 4:18]: decorator pausedOnError
+  `);
+
+  // The test should keep running.
+  vscode.debug.output = '';
+  await expect.poll(() => vscode.debug.output, { timeout: 10000 }).toContain('time passed');
+
+  expect(testRun.renderLog()).toBe(`
+    tests > test.spec.ts > should fail [2:0]
+      enqueued
+      enqueued
+      started
+      failed
+  `);
+
+  await expect(vscode).toHaveConnectionLog([
+    { method: 'listFiles', params: {} },
+    {
+      method: 'listTests',
+      params: expect.objectContaining({
+        locations: [expect.stringContaining(`tests${escapedPathSep}test\\.spec\\.ts`)]
+      })
+    },
+    { method: 'runGlobalSetup', params: {} },
+    {
+      method: 'runTests',
+      params: expect.objectContaining({
+        locations: [
+          expect.stringContaining(`tests${escapedPathSep}test\\.spec\\.ts`),
+        ],
+        testIds: [expect.any(String)]
+      })
+    },
+  ]);
+  vscode.connectionLog.length = 0;
+
+  testRun.token.source.cancel();
+  await runPromise;
+
+  await expect(vscode).toHaveConnectionLog([
+    { method: 'stopTests', params: {} },
+  ]);
+});
+
+test('should debug error', async ({ activate }, testInfo) => {
+  const { vscode, testController } = await activate({
+    'playwright.config.js': `module.exports = { testDir: 'tests' }`,
+    'tests/test.spec.ts': `
+      import { test } from '@playwright/test';
+      test('should fail', async () => {
+        // Simulate breakpoint via stalling.
+        console.log('READY TO BREAK');
+        await new Promise(() => {});
+      });
+    `,
+  });
+
+  await testController.expandTestItems(/test.spec/);
+  const testItems = testController.findTestItems(/fail/);
+
+  const profile = testController.debugProfile();
+  const testRunPromise = new Promise<TestRun>(f => testController.onDidCreateTestRun(f));
+  void profile.run(testItems);
+  const testRun = await testRunPromise;
+
+  await expect.poll(() => vscode.debug.output, { timeout: 10000 }).toContain('READY TO BREAK');
+
+  vscode.debug.simulateStoppedOnError('Error on line 10', { file: testInfo.outputPath('tests/test.spec.ts'), line: 10 });
+
+  expect(testRun.renderLog({ messages: true }).replace(/\\/g, '/')).toBe(`
+    tests > test.spec.ts > should fail [2:0]
+      enqueued
+      enqueued
+      started
+      failed
+        test.spec.ts:[9:0 - 9:0]
+        Error on line 10
+        <br>
+         at tests/test.spec.ts:10:1 {matcherResult: ...}
+  `);
+
+  testRun.token.source.cancel();
+});
+
+test('should end test run when stopping the debugging', async ({ activate }, testInfo) => {
+  const { vscode, testController } = await activate({
+    'playwright.config.js': `module.exports = { testDir: 'tests' }`,
+    'tests/test.spec.ts': `
+      import { test } from '@playwright/test';
+      test('should stall', async () => {
+        // Simulate breakpoint via stalling.
+        console.log('READY TO BREAK');
+        await new Promise(() => {});
+      });
+    `,
+  });
+
+  await testController.expandTestItems(/test.spec/);
+  const testItems = testController.findTestItems(/should stall/);
+
+  const profile = testController.debugProfile();
+  const testRunPromise = new Promise<TestRun>(f => testController.onDidCreateTestRun(f));
+  void profile.run(testItems);
+  const testRun = await testRunPromise;
+  await expect.poll(() => vscode.debug.output, { timeout: 10000 }).toContain('READY TO BREAK');
+
+  const endPromise = new Promise(f => testRun.onDidEnd(f));
+  vscode.debug.stopDebugging();
+  await endPromise;
+
+  expect(testRun.renderLog({ messages: true })).toBe(`
+    tests > test.spec.ts > should stall [2:0]
+      enqueued
+      enqueued
+      started
+  `);
+
+  testRun.token.source.cancel();
+});
+
+test('should end test run when stopping the debugging during config parsing', async ({ activate }) => {
+  const { vscode, testController } = await activate({
+    'package.json': JSON.stringify({ type: 'module' }),
+    'playwright.config.js': `
+      // Simulate breakpoint via stalling.
+      async function stall() {
+        console.log('READY TO BREAK');
+        await new Promise(() => {});
+      }
+
+      process.env.STALL_CONFIG === '1' && await stall();
+      export default { testDir: 'tests' }
+    `,
+    'tests/test.spec.ts': `
+      import { test } from '@playwright/test';
+      test('should fail', async () => {});
+    `,
+  }, { env: { STALL_CONFIG: '0' } });
+
+  await testController.expandTestItems(/test.spec/);
+  const testItems = testController.findTestItems(/fail/);
+
+  const configuration = vscode.workspace.getConfiguration('playwright-repl');
+  configuration.update('env', { STALL_CONFIG: '1' });
+
+  const profile = testController.debugProfile();
+  const testRunPromise = new Promise<TestRun>(f => testController.onDidCreateTestRun(f));
+  void profile.run(testItems);
+  const testRun = await testRunPromise;
+  const endPromise = new Promise(f => testRun.onDidEnd(f));
+  await expect.poll(() => vscode.debug.output).toContain('READY TO BREAK');
+  vscode.debug.stopDebugging();
+  await endPromise;
+
+  expect(testRun.renderLog({ messages: true })).toBe(`
+    tests > test.spec.ts > should fail [2:0]
+      enqueued
+  `);
+
+  testRun.token.source.cancel();
+});
+
+test('should pass all args as string[] when debugging', async ({ activate }) => {
+  test.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/30829' });
+  const { vscode, testController } = await activate({
+    'playwright.config.js': `module.exports = { testDir: 'tests' }`,
+    'tests/test.spec.ts': `
+      import { test } from '@playwright/test';
+      test('pass', () => {});
+    `,
+  });
+
+  await testController.expandTestItems(/test.spec/);
+  const testItems = testController.findTestItems(/pass/);
+
+  const profile = testController.debugProfile();
+  const onDidStartDebugSession = new Promise<DebugSession>(resolve => vscode.debug.onDidStartDebugSession(resolve));
+  const onDidTerminateDebugSession = new Promise(resolve => vscode.debug.onDidTerminateDebugSession(resolve));
+  const testRunPromise = new Promise<TestRun>(f => testController.onDidCreateTestRun(f));
+  void profile.run(testItems);
+  const testRun = await testRunPromise;
+  const session = await onDidStartDebugSession;
+  expect(session.configuration.args.filter((arg: any) => typeof arg !== 'string')).toEqual([]);
+  testRun.token.source.cancel();
+  await onDidTerminateDebugSession;
+});
+
+test('should run global setup before debugging', async ({ activate }, testInfo) => {
+  const { vscode, testController } = await activate({
+    'playwright.config.js': `module.exports = {
+      testDir: 'tests',
+      globalSetup: 'globalSetup.ts',
+    }`,
+    'globalSetup.ts': `
+      async function globalSetup(config) {
+        console.log('RUN GLOBAL SETUP UNDER DEBUG: ' + !!process.env.VSCODE_MOCK_DEBUGGING);
+        process.env.MAGIC_NUMBER = '42';
+      }
+      export default globalSetup;
+    `,
+    'tests/test.spec.ts': `
+      import { test, expect } from '@playwright/test';
+      test('should pass', async () => {
+        console.log('TEST UNDER DEBUG: ' + !!process.env.VSCODE_MOCK_DEBUGGING);
+        console.log('MAGIC NUMBER: ' + process.env.MAGIC_NUMBER);
+        expect(process.env.MAGIC_NUMBER).toBe('42');
+      });
+    `
+  });
+
+  const testRunPromise1 = new Promise<TestRun>(f => testController.onDidCreateTestRun(f));
+  await testController.expandTestItems(/test.spec/);
+  const runFinishedPromise1 = testController.debugProfile().run(testController.findTestItems(/pass/));
+  const testRun1 = await testRunPromise1;
+  await expect(testRun1).toHaveOutput(`RUN GLOBAL SETUP UNDER DEBUG: false`);
+  await expect.poll(() => stripAnsi(vscode.debug.output)).toContain(`TEST UNDER DEBUG: true`);
+  await expect.poll(() => stripAnsi(vscode.debug.output)).toContain(`MAGIC NUMBER: 42`);
+  await expect.poll(() => testRun1.renderLog()).toBe(`
+    tests > test.spec.ts > should pass [2:0]
+      enqueued
+      enqueued
+      started
+  `);
+  testRun1.token.source.cancel();
+  await runFinishedPromise1;
+
+  // Second time it should reuse the global setup and not run it again.
+  const testRunPromise2 = new Promise<TestRun>(f => testController.onDidCreateTestRun(f));
+  await testController.expandTestItems(/test.spec/);
+  const runFinishedPromise2 = testController.debugProfile().run(testController.findTestItems(/pass/));
+  const testRun2 = await testRunPromise2;
+  await expect.poll(() => stripAnsi(vscode.debug.output)).toContain(`TEST UNDER DEBUG: true`);
+  await expect.poll(() => stripAnsi(vscode.debug.output)).toContain(`MAGIC NUMBER: 42`);
+  expect(testRun2.renderOutput()).not.toContain(`RUN GLOBAL SETUP`);
+  testRun2.token.source.cancel();
+  await runFinishedPromise2;
+});
+
+test('should debug global setup when toggle is enabled', async ({ activate }, testInfo) => {
+  const { vscode, testController } = await activate({
+    'playwright.config.js': `module.exports = {
+      testDir: 'tests',
+      globalSetup: 'globalSetup.ts',
+    }`,
+    'globalSetup.ts': `
+      async function globalSetup(config) {
+        console.log('RUN GLOBAL SETUP UNDER DEBUG: ' + !!process.env.VSCODE_MOCK_DEBUGGING);
+        process.env.MAGIC_NUMBER = '42';
+      }
+      export default globalSetup;
+    `,
+    'tests/test.spec.ts': `
+      import { test, expect } from '@playwright/test';
+      test('should pass', async () => {
+        console.log('TEST UNDER DEBUG: ' + !!process.env.VSCODE_MOCK_DEBUGGING);
+        console.log('MAGIC NUMBER: ' + process.env.MAGIC_NUMBER);
+        expect(process.env.MAGIC_NUMBER).toBe('42');
+      });
+    `
+  }, { runGlobalSetupOnEachRun: true });
+
+  const testRunPromise = new Promise<TestRun>(f => testController.onDidCreateTestRun(f));
+  await testController.expandTestItems(/test.spec/);
+  const runFinishedPromise = testController.debugProfile().run(testController.findTestItems(/pass/));
+  const testRun = await testRunPromise;
+  await expect.poll(() => stripAnsi(vscode.debug.output)).toContain(`RUN GLOBAL SETUP UNDER DEBUG: true`);
+  await expect.poll(() => stripAnsi(vscode.debug.output)).toContain(`TEST UNDER DEBUG: true`);
+  await expect.poll(() => stripAnsi(vscode.debug.output)).toContain(`MAGIC NUMBER: 42`);
+  testRun.token.source.cancel();
+  await runFinishedPromise;
+});
+
+test('should debug multiple tests and stop on first failure', async ({ activate }) => {
+  const { vscode, testController } = await activate({
+    'playwright.config.js': `module.exports = { testDir: 'tests' }`,
+    'tests/test-1.spec.ts': `
+      import { test } from '@playwright/test';
+      test('should pass', async () => {});
+    `,
+    'tests/test-2.spec.ts': `
+      import { test, expect } from '@playwright/test';
+      test('should fail', async () => { expect(1).toBe(2); });
+    `,
+  });
+
+  const profile = testController.debugProfile();
+  const testRunPromise = new Promise<TestRun>(f => testController.onDidCreateTestRun(f));
+  const runPromise = profile.run();
+  const testRun = await testRunPromise;
+
+  await expect.poll(() => vscode.window.activeTextEditor?.renderDecorations('  '), { timeout: 10000 }).toBe(`
+    --------------------------------------------------------------
+    [2:50 - 2:50]: decorator pausedOnError
+  `);
+
+  expect(testRun.renderLog()).toBe(`
+    tests > test-2.spec.ts > should fail [2:0]
+      enqueued
+      started
+      failed
+    tests > test-1.spec.ts > should pass [2:0]
+      enqueued
+      started
+      passed
+  `);
+
+  testRun.token.source.cancel();
+  await runPromise;
+
+  await expect(vscode).toHaveConnectionLog([
+    { method: 'listFiles', params: {} },
+    { method: 'runGlobalSetup', params: {} },
+    {
+      method: 'runTests',
+      params: expect.objectContaining({
+        locations: [],
+        testIds: undefined
+      })
+    },
+    { method: 'stopTests', params: {} },
+  ]);
+});
+
+test('should not pause at the end of a setup test', async ({ activate }) => {
+  const { vscode, testController } = await activate({
+    'playwright.config.js': `module.exports = {
+      testDir: 'tests',
+      projects: [
+        { name: 'setup', testMatch: /.*setup.ts/ },
+        { name: 'main' },
+      ]
+    }`,
+    'tests/auth.setup.ts': `
+      import { test } from '@playwright/test';
+      test('should setup', async () => {
+      });
+    `,
+    'tests/test.spec.ts': `
+      import { test } from '@playwright/test';
+      test('should pass', async () => {
+        setInterval(() => console.log('time passed'), 500);
+      });
+    `,
+  });
+  await enableProjects(vscode, ['setup', 'main']);
+
+  await testController.expandTestItems(/test.spec/);
+  const testItems = testController.findTestItems(/pass/);
+  const profile = testController.debugProfile();
+  const testRunPromise = new Promise<TestRun>(f => testController.onDidCreateTestRun(f));
+  const runPromise = profile.run(testItems);
+  const testRun = await testRunPromise;
+
+  // The "setup" project should not run when running a single test from "main" project.
+  await expect.poll(() => testRun.renderLog(), { timeout: 15000 }).toBe(`
+    tests > test.spec.ts > should pass [2:0]
+      enqueued
+      enqueued
+      started
+  `);
+
+  testRun.token.source.cancel();
+  await runPromise;
+
+  expect(testRun.renderLog()).toBe(`
+    tests > test.spec.ts > should pass [2:0]
+      enqueued
+      enqueued
+      started
+  `);
+});

--- a/packages/vscode/tests/decorations.spec.ts
+++ b/packages/vscode/tests/decorations.spec.ts
@@ -1,0 +1,106 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { escapedPathSep, expect, test } from './utils';
+
+test('should highlight steps while running', async ({ activate }) => {
+  const { vscode, testController } = await activate({
+    'playwright.config.js': `module.exports = { testDir: 'tests' }`,
+    'tests/test.spec.ts': `
+      import { test, expect } from '@playwright/test';
+      test('pass', async () => {
+        expect(1).toBe(1);
+        expect(2).toBe(2);
+        expect(3).toBe(3);
+      });
+    `,
+  });
+
+  await vscode.openEditors('**/test.spec.ts');
+  await new Promise(f => testController.onDidChangeTestItem(f));
+
+  await testController.run();
+  expect(vscode.window.activeTextEditor.renderDecorations('  ')).toBe(`
+    --------------------------------------------------------------
+
+    --------------------------------------------------------------
+    [3:18 - 3:18]: decorator activeStep
+    --------------------------------------------------------------
+
+    --------------------------------------------------------------
+    [3:18 - 3:18]: decorator completedStep {"after":{"contentText":" — Xms"}}
+    --------------------------------------------------------------
+    [3:18 - 3:18]: decorator completedStep {"after":{"contentText":" — Xms"}}
+    [4:18 - 4:18]: decorator activeStep
+    --------------------------------------------------------------
+    [3:18 - 3:18]: decorator completedStep {"after":{"contentText":" — Xms"}}
+    --------------------------------------------------------------
+    [3:18 - 3:18]: decorator completedStep {"after":{"contentText":" — Xms"}}
+    [4:18 - 4:18]: decorator completedStep {"after":{"contentText":" — Xms"}}
+    --------------------------------------------------------------
+    [3:18 - 3:18]: decorator completedStep {"after":{"contentText":" — Xms"}}
+    [4:18 - 4:18]: decorator completedStep {"after":{"contentText":" — Xms"}}
+    [5:18 - 5:18]: decorator activeStep
+    --------------------------------------------------------------
+    [3:18 - 3:18]: decorator completedStep {"after":{"contentText":" — Xms"}}
+    [4:18 - 4:18]: decorator completedStep {"after":{"contentText":" — Xms"}}
+    --------------------------------------------------------------
+    [3:18 - 3:18]: decorator completedStep {"after":{"contentText":" — Xms"}}
+    [4:18 - 4:18]: decorator completedStep {"after":{"contentText":" — Xms"}}
+    [5:18 - 5:18]: decorator completedStep {"after":{"contentText":" — Xms"}}
+  `);
+
+  await expect(vscode).toHaveConnectionLog([
+    { method: 'listFiles', params: {} },
+    {
+      method: 'listTests',
+      params: expect.objectContaining({
+        locations: [expect.stringContaining(`tests${escapedPathSep}test\\.spec\\.ts`)]
+      })
+    },
+    { method: 'runGlobalSetup', params: {} },
+    {
+      method: 'runTests',
+      params: expect.objectContaining({
+        locations: [],
+        testIds: undefined
+      })
+    },
+  ]);
+});
+
+test('should limit highlights', async ({ activate }) => {
+  const { vscode, testController } = await activate({
+    'playwright.config.js': `module.exports = { testDir: 'tests' }`,
+    'tests/test.spec.ts': `
+      import { test, expect } from '@playwright/test';
+      test('pass', async () => {  
+        for (let i = 0; i < 2000; i++) {
+          expect(i).toBe(i);
+        }
+      });
+    `,
+  });
+
+  await vscode.openEditors('**/test.spec.ts');
+  await new Promise(f => testController.onDidChangeTestItem(f));
+
+  await testController.run();
+
+  const decorationsLog = vscode.window.activeTextEditor.renderDecorations('  ');
+  const lastState = decorationsLog.substring(decorationsLog.lastIndexOf('------'));
+  expect(lastState).toContain(`[4:20 - 4:20]: decorator completedStep {"after":{"contentText":" — Xms (ran 2000×)"}}`);
+});

--- a/packages/vscode/tests/global-errors.spec.ts
+++ b/packages/vscode/tests/global-errors.spec.ts
@@ -1,0 +1,71 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { expect, test } from './utils';
+
+test('should report duplicate test title', async ({ activate }) => {
+  const { vscode, testController } = await activate({
+    'playwright.config.js': `module.exports = { testDir: 'tests' }`,
+    'tests/test.spec.ts': `
+      import { test } from '@playwright/test';
+      test('one', async () => {});
+      test('two', async () => {});
+      test('one', async () => {});
+    `,
+  });
+
+  await testController.expandTestItems(/test.spec.ts/);
+  await expect(testController).toHaveTestTree(`
+    -   tests
+      -   test.spec.ts
+  `);
+  await expect.poll(() => vscode.languages.getDiagnostics()).toEqual([
+    {
+      message: 'Error: duplicate test title \"one\", first declared in test.spec.ts:3',
+      range: { start: { line: 4, character: 10 }, end: { line: 5, character: 0 } },
+      severity: 'Error',
+      source: 'playwright',
+    }
+  ]);
+});
+
+test('should report error in global setup (explicit)', async ({ activate }) => {
+  const { vscode, testController } = await activate({
+    'playwright.config.js': `module.exports = {
+      testDir: 'tests',
+      globalSetup: 'globalSetup.ts',
+    }`,
+    'globalSetup.ts': `
+      import { expect } from '@playwright/test';
+      async function globalSetup(config) {
+        expect(true).toBe(false);
+      }
+      export default globalSetup;`,
+    'tests/test.spec.ts': `
+      import { test } from '@playwright/test';
+      test('should pass', async () => {});
+    `,
+  });
+
+  const testRun = await testController.run();
+  await expect(testRun).toHaveOutput(/Running global setup if any…/);
+  await expect(testRun).toHaveOutput(/Error: expect\(received\)\.toBe\(expected\)/);
+
+  await expect(vscode).toHaveConnectionLog([
+    { method: 'listFiles', params: {} },
+    { method: 'runGlobalSetup', params: {} },
+  ]);
+});

--- a/packages/vscode/tests/highlight-locators.spec.ts
+++ b/packages/vscode/tests/highlight-locators.spec.ts
@@ -1,0 +1,114 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { chromium } from '@playwright/test';
+import { expect, test } from './utils';
+
+test.beforeEach(({ showBrowser }) => {
+  // Locator highlighting is only relevant when the browser stays open.
+  test.skip(!showBrowser);
+});
+
+test('should work', async ({ activate }) => {
+  const cdpPort = 9234 + test.info().workerIndex * 2;
+  const { vscode, testController } = await activate({
+    'playwright.config.js': `module.exports = {
+      use: {
+        launchOptions: {
+          args: ['--remote-debugging-port=${cdpPort}']
+        }
+      }
+    }`,
+    'test.spec.ts': `
+      import { test } from '@playwright/test';
+      test('one', async ({ page }) => {
+        await page.goto('about:blank');
+        await page.setContent(\`
+          <button>one</button>
+          <button>two</button>
+        \`);
+        await page.getByRole('button', { name: 'one' }).click(); // line 8
+        await page.getByRole('button', { name: 'two' }).click(); // line 9
+        page.getByRole('button', { name: 'not there!' });        // line 10
+        await page
+          .getByRole(
+            'button',
+            { name: 'one' }
+          ).click();
+      });
+
+      class MyPom {
+        constructor(page) {
+          this.myElementOne1 = page.getByRole('button', { name: 'one' });       // line 20
+          this.myElementTwo1 = this._page.getByRole('button', { name: 'two' }); // line 21
+          this.myElementOne2 = this.page.getByRole('button', { name: 'one' });  // line 22
+        }
+
+        @step // decorators require a babel plugin
+        myMethod() {}
+      }
+
+      function step(target: Function, context: ClassMethodDecoratorContext) {
+        return function replacementMethod(...args: any) {
+          const name = this.constructor.name + '.' + (context.name as string);
+          return test.step(name, async () => {
+            return await target.call(this, ...args);
+          });
+        };
+      }
+    `,
+  });
+
+  const testItems = testController.findTestItems(/test.spec.ts/);
+  expect(testItems.length).toBe(1);
+  await vscode.openEditors('test.spec.ts');
+  await testController.run(testItems);
+  const browser = await chromium.connectOverCDP(`http://localhost:${cdpPort}`);
+  {
+    expect(browser.contexts()).toHaveLength(1);
+    expect(browser.contexts()[0].pages()).toHaveLength(1);
+  }
+  const page = browser.contexts()[0].pages()[0];
+  const boxOne = await page.getByRole('button', { name: 'one' }).boundingBox();
+  const boxTwo = await page.getByRole('button', { name: 'two' }).boundingBox();
+
+  for (const language of ['javascript', 'typescript']) {
+    for (const [[line, column], expectedBox] of [
+      [[9, 26], boxTwo],
+      [[8, 26], boxOne],
+      [[10, 26], null],
+      [[13, 15], boxOne],
+      [[20, 30], boxOne],
+      [[21, 30], boxTwo],
+      [[22, 30], boxOne],
+    ] as const) {
+      await test.step(`should highlight ${language} ${line}:${column}`, async () => {
+        // Clear highlight.
+        vscode.languages.emitHoverEvent(language, vscode.window.activeTextEditor.document, new vscode.Position(0, 0));
+        await expect(page.locator('x-pw-highlight')).toBeHidden();
+
+        vscode.languages.emitHoverEvent(language, vscode.window.activeTextEditor.document, new vscode.Position(line, column));
+        if (!expectedBox) {
+          await expect(page.locator('x-pw-highlight')).toBeHidden();
+        } else {
+          await expect(page.locator('x-pw-highlight')).toBeVisible();
+          expect(await page.locator('x-pw-highlight').boundingBox()).toEqual(expectedBox);
+        }
+      });
+    }
+  }
+  await browser.close();
+});

--- a/packages/vscode/tests/list-files.spec.ts
+++ b/packages/vscode/tests/list-files.spec.ts
@@ -1,0 +1,401 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { enableConfigs, enableProjects, expect, test } from './utils';
+import path from 'path';
+
+test('should list files', async ({ activate }) => {
+  const { vscode, testController } = await activate({
+    'playwright.config.js': `module.exports = { testDir: 'tests' }`,
+    'tests/test.spec.ts': `
+      import { test } from '@playwright/test';
+      test('one', async () => {});
+    `,
+  });
+
+  await expect(testController).toHaveTestTree(`
+    -   tests
+      -   test.spec.ts
+  `);
+  await expect(vscode).toHaveConnectionLog([
+    { method: 'listFiles', params: {} }
+  ]);
+});
+
+test('should list files top level if no testDir', async ({ activate }, testInfo) => {
+  const { vscode, testController } = await activate({
+    'playwright.config.js': `{}`,
+    'test.spec.ts': `
+      import { test } from '@playwright/test';
+      test('one', async () => {});
+    `,
+  }, { rootDir: testInfo.outputPath('myWorkspace') });
+
+  await expect(testController).toHaveTestTree(`
+    -   test.spec.ts
+  `);
+  await expect(vscode).toHaveConnectionLog([
+    { method: 'listFiles', params: {} }
+  ]);
+});
+
+test('should list only test files', async ({ activate }) => {
+  const { testController } = await activate({
+    'playwright.config.js': `module.exports = { testDir: 'tests' }`,
+    'model.ts': `
+      export const a = 1;
+    `,
+    'tests/test.spec.ts': `
+      import { test } from '@playwright/test';
+      test('one', async () => {});
+    `,
+  });
+
+  await expect(testController).toHaveTestTree(`
+    -   tests
+      -   test.spec.ts
+  `);
+});
+
+test('should list folders', async ({ activate }) => {
+  const { vscode, testController } = await activate({
+    'playwright.config.js': `module.exports = { testDir: 'tests' }`,
+    'tests/foo/test-a.spec.ts': ``,
+    'tests/foo/test-b.spec.ts': ``,
+    'tests/bar/test-a.spec.ts': ``,
+    'tests/a/b/c/d/test-c.spec.ts': ``,
+  });
+
+  await expect(testController).toHaveTestTree(`
+    -   tests
+      -   a
+        -   b
+          -   c
+            -   d
+              -   test-c.spec.ts
+      -   bar
+        -   test-a.spec.ts
+      -   foo
+        -   test-a.spec.ts
+        -   test-b.spec.ts
+  `);
+  await expect(vscode).toHaveConnectionLog([
+    { method: 'listFiles', params: {} }
+  ]);
+});
+
+test('should pick new files', async ({ activate }) => {
+  const { vscode, testController, workspaceFolder } = await activate({
+    'playwright.config.js': `module.exports = { testDir: 'tests' }`,
+    'tests/test-1.spec.ts': ``
+  });
+
+  await expect(testController).toHaveTestTree(`
+    -   tests
+      -   test-1.spec.ts
+  `);
+
+  await expect(vscode).toHaveConnectionLog([
+    { method: 'listFiles', params: {} }
+  ]);
+
+  await Promise.all([
+    new Promise(f => testController.onDidChangeTestItem(f)),
+    workspaceFolder.addFile('tests/test-2.spec.ts', '')
+  ]);
+
+  await expect(testController).toHaveTestTree(`
+    -   tests
+      -   test-1.spec.ts
+      -   test-2.spec.ts
+  `);
+
+  await expect(vscode).toHaveConnectionLog([
+    { method: 'listFiles', params: {} },
+    { method: 'listFiles', params: {} }
+  ]);
+});
+
+test('should not pick non-test files', async ({ activate }) => {
+  const { workspaceFolder, testController } = await activate({
+    'playwright.config.js': `module.exports = { testDir: 'tests' }`,
+    'tests/test-1.spec.ts': ``
+  });
+
+  await expect(testController).toHaveTestTree(`
+    -   tests
+      -   test-1.spec.ts
+  `);
+
+  await Promise.all([
+    new Promise(f => testController.onDidChangeTestItem(f)),
+    workspaceFolder.addFile('tests/model.ts', ''),
+    workspaceFolder.addFile('tests/test-2.spec.ts', ''),
+  ]);
+
+  await expect(testController).toHaveTestTree(`
+    -   tests
+      -   test-1.spec.ts
+      -   test-2.spec.ts
+  `);
+});
+
+test('should tolerate missing testDir', async ({ activate }) => {
+  const { workspaceFolder, testController } = await activate({
+    'playwright.config.js': `module.exports = { testDir: 'tests' }`,
+  });
+
+  await expect(testController).toHaveTestTree(`
+  `);
+
+  await Promise.all([
+    new Promise(f => testController.onDidChangeTestItem(f)),
+    workspaceFolder.addFile('tests/test.spec.ts', '')
+  ]);
+
+  await expect(testController).toHaveTestTree(`
+    -   tests
+      -   test.spec.ts
+  `);
+});
+
+test('should remove deleted files', async ({ activate }) => {
+  const { vscode, testController, workspaceFolder } = await activate({
+    'playwright.config.js': `module.exports = { testDir: 'tests' }`,
+    'tests/test-1.spec.ts': ``,
+    'tests/test-2.spec.ts': ``,
+    'tests/test-3.spec.ts': ``,
+  });
+
+  await expect(testController).toHaveTestTree(`
+    -   tests
+      -   test-1.spec.ts
+      -   test-2.spec.ts
+      -   test-3.spec.ts
+  `);
+
+  await expect(vscode).toHaveConnectionLog([
+    { method: 'listFiles', params: {} }
+  ]);
+
+  await Promise.all([
+    new Promise(f => testController.onDidChangeTestItem(f)),
+    workspaceFolder.removeFile('tests/test-2.spec.ts')
+  ]);
+
+  await expect(testController).toHaveTestTree(`
+    -   tests
+      -   test-1.spec.ts
+      -   test-3.spec.ts
+  `);
+
+  await expect(vscode).toHaveConnectionLog([
+    { method: 'listFiles', params: {} },
+    { method: 'listFiles', params: {} }
+  ]);
+});
+
+test('should do nothing for not loaded changed file', async ({ activate }) => {
+  const { workspaceFolder, testController } = await activate({
+    'playwright.config.js': `module.exports = { testDir: 'tests' }`,
+    'tests/test-1.spec.ts': ``,
+    'tests/test-2.spec.ts': ``,
+    'tests/test-3.spec.ts': ``,
+  });
+
+  await expect(testController).toHaveTestTree(`
+    -   tests
+      -   test-1.spec.ts
+      -   test-2.spec.ts
+      -   test-3.spec.ts
+  `);
+
+  let changed = false;
+  testController.onDidChangeTestItem(() => changed = true);
+  await workspaceFolder.changeFile('tests/test-2.spec.ts', '// new content');
+  await new Promise(f => setTimeout(f, 2000));
+  expect(changed).toBeFalsy();
+});
+
+test('should support multiple projects', async ({ activate }) => {
+  const { vscode, testController } = await activate({
+    'playwright.config.js': `module.exports = {
+      testDir: './tests',
+      projects: [
+        { name: 'project 1' },
+        { name: 'project 2' },
+      ]
+    }`,
+    'tests/test1.spec.ts': `
+      import { test } from '@playwright/test';
+      test('one', async () => {});
+    `,
+    'tests/test2.spec.ts': `
+      import { test } from '@playwright/test';
+      test('two', async () => {});
+    `,
+  });
+  await expect(testController).toHaveTestTree(`
+    -   tests
+      -   test1.spec.ts
+      -   test2.spec.ts
+  `);
+
+  await expect(vscode).toHaveConnectionLog([
+    { method: 'listFiles', params: {} }
+  ]);
+});
+
+test('should switch between multiple projects with filter', async ({ activate }) => {
+  const { vscode, testController } = await activate({
+    'playwright.config.js': `module.exports = {
+      testDir: './tests',
+      projects: [
+        { name: 'project 1', testMatch: /test1.spec/ },
+        { name: 'project 2', testMatch: /test2.spec/ },
+      ]
+    }`,
+    'tests/test1.spec.ts': `
+      import { test } from '@playwright/test';
+      test('one', async () => {});
+    `,
+    'tests/test2.spec.ts': `
+      import { test } from '@playwright/test';
+      test('two', async () => {});
+    `,
+    'tests/test3.spec.ts': `
+      import { test } from '@playwright/test';
+      test('three', async () => {});
+    `,
+  });
+  await enableProjects(vscode, ['project 1']);
+  await expect(testController).toHaveTestTree(`
+    -   tests
+      -   test1.spec.ts
+    -    [playwright.config.js [project 2] — disabled]
+  `);
+
+  await expect(vscode).toHaveConnectionLog([
+    { method: 'listFiles', params: {} }
+  ]);
+
+  await expect(vscode).toHaveProjectTree(`
+    config: playwright.config.js
+    [x] project 1
+    [ ] project 2
+  `);
+
+  await enableProjects(vscode, ['project 2']);
+
+  await expect(testController).toHaveTestTree(`
+    -   tests
+      -   test2.spec.ts
+    -    [playwright.config.js [project 1] — disabled]
+  `);
+
+  await expect(vscode).toHaveProjectTree(`
+    config: playwright.config.js
+    [ ] project 1
+    [x] project 2
+  `);
+
+  await expect(vscode).toHaveConnectionLog([
+    { method: 'listFiles', params: {} }
+  ]);
+});
+
+test('should list files in relative folder', async ({ activate }) => {
+  const { vscode, testController } = await activate({
+    'foo/bar/playwright.config.js': `module.exports = { testDir: '../../tests' }`,
+    'tests/test.spec.ts': `
+      import { test } from '@playwright/test';
+      test('one', async () => {});
+    `,
+  });
+  await expect(testController).toHaveTestTree(`
+    -   tests
+      -   test.spec.ts
+  `);
+  await expect(vscode).toHaveConnectionLog([
+    { method: 'listFiles', params: {} }
+  ]);
+});
+
+test('should list files in multi-folder workspace with project switching', async ({ activate }, testInfo) => {
+  const { vscode, testController } = await activate({}, {
+    workspaceFolders: [
+      [testInfo.outputPath('folder1'), {
+        'playwright.config.js': `module.exports = { testDir: './' }`,
+        'test.spec.ts': `
+          import { test } from '@playwright/test';
+          test('one', async () => {});
+        `,
+      }],
+      [testInfo.outputPath('folder2'), {
+        'playwright.config.js': `module.exports = { testDir: './' }`,
+        'test.spec.ts': `
+          import { test } from '@playwright/test';
+          test('two', async () => {});
+        `,
+      }],
+    ]
+  });
+
+  await expect(testController).toHaveTestTree(`
+    -   folder1
+      -   test.spec.ts
+  `);
+
+  await enableConfigs(vscode, [`folder2${path.sep}playwright.config.js`]);
+
+  await expect(testController).toHaveTestTree(`
+    -   folder2
+      -   test.spec.ts
+  `);
+});
+
+test('should ignore errors when listing files', async ({ activate }) => {
+  const { vscode, testController } = await activate({
+    'playwright.config.js': `module.exports = { testDir: 'tests' }`,
+    'playwright.config.ts': `throw new Error('oh my')`,
+    'tests/test.spec.ts': `
+      import { test } from '@playwright/test';
+      test('one', async () => {});
+    `,
+  });
+
+  await enableConfigs(vscode, ['playwright.config.ts', 'playwright.config.js']);
+
+  await expect(testController).toHaveTestTree(`
+    -   tests
+      -   test.spec.ts
+  `);
+
+  await expect(vscode).toHaveConnectionLog([
+    { method: 'listFiles', params: {} },
+    { method: 'listFiles', params: {} }
+  ]);
+
+  await new Promise(f => setTimeout(f, 2000));
+  await expect.poll(() => vscode.languages.getDiagnostics()).toEqual([
+    {
+      message: 'Error: oh my',
+      range: { start: { line: 0, character: 6 }, end: { line: 1, character: 0 } },
+      severity: 'Error',
+      source: 'playwright',
+    }
+  ]);
+});

--- a/packages/vscode/tests/list-tests.spec.ts
+++ b/packages/vscode/tests/list-tests.spec.ts
@@ -1,0 +1,837 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { enableConfigs, enableProjects, escapedPathSep, expect, test } from './utils';
+import fs from 'fs';
+import path from 'path';
+
+test('should list tests on expand', async ({ activate }) => {
+  const { vscode, testController } = await activate({
+    'playwright.config.js': `module.exports = { testDir: 'tests' }`,
+    'tests/test.spec.ts': `
+      import { test } from '@playwright/test';
+      test('one', async () => {});
+    `,
+  });
+
+  await testController.expandTestItems(/test.spec.ts/);
+  await expect(testController).toHaveTestTree(`
+    -   tests
+      -   test.spec.ts
+        -   one [2:0]
+  `);
+
+  await expect(vscode).toHaveConnectionLog([
+    { method: 'listFiles', params: {} },
+    {
+      method: 'listTests',
+      params: {
+        locations: [expect.stringContaining(`tests${escapedPathSep}test\\.spec\\.ts`)]
+      }
+    },
+  ]);
+});
+
+test('should list tests for visible editors', async ({ activate }) => {
+  const { vscode, testController } = await activate({
+    'playwright.config.js': `module.exports = { testDir: 'tests' }`,
+    'tests/test1.spec.ts': `
+      import { test } from '@playwright/test';
+      test('one', async () => {});
+    `,
+    'tests/test2.spec.ts': `
+      import { test } from '@playwright/test';
+      test('two', async () => {});
+    `,
+  });
+
+  await vscode.openEditors('**/test*.spec.ts');
+  await new Promise(f => testController.onDidChangeTestItem(f));
+
+  await expect(testController).toHaveTestTree(`
+    -   tests
+      -   test1.spec.ts
+        -   one [2:0]
+      -   test2.spec.ts
+        -   two [2:0]
+  `);
+
+  await expect(vscode).toHaveConnectionLog([
+    { method: 'listFiles', params: {} },
+    {
+      method: 'listTests',
+      params: {
+        locations: [
+          expect.stringContaining(`tests${escapedPathSep}test1\\.spec\\.ts`),
+          expect.stringContaining(`tests${escapedPathSep}test2\\.spec\\.ts`),
+        ]
+      }
+    },
+  ]);
+});
+
+test('should list suits', async ({ activate }) => {
+  const { testController } = await activate({
+    'playwright.config.js': `module.exports = { testDir: 'tests' }`,
+    'tests/test.spec.ts': `
+      import { test } from '@playwright/test';
+      test('one', async () => {});
+      test('two', async () => {});
+      test.describe('group 1', () => {
+        test('one', async () => {});
+        test('two', async () => {});
+      });
+      test.describe('group 2', () => {
+        test.describe('group 2.1', () => {
+          test('one', async () => {});
+          test('two', async () => {});
+        });
+        test('one', async () => {});
+        test('two', async () => {});
+      });
+    `,
+  });
+
+  await testController.expandTestItems(/test.spec.ts/);
+  await expect(testController).toHaveTestTree(`
+    -   tests
+      -   test.spec.ts
+        -   one [2:0]
+        -   two [3:0]
+        -   group 1 [4:0]
+          -   one [5:0]
+          -   two [6:0]
+        -   group 2 [8:0]
+          -   group 2.1 [9:0]
+            -   one [10:0]
+            -   two [11:0]
+          -   one [13:0]
+          -   two [14:0]
+  `);
+});
+
+test('should discover new tests', async ({ activate }) => {
+  const { vscode, testController, workspaceFolder } = await activate({
+    'playwright.config.js': `module.exports = { testDir: 'tests' }`,
+    'tests/test.spec.ts': `
+      import { test } from '@playwright/test';
+      test('one', async () => {});
+    `,
+  });
+
+  await testController.expandTestItems(/test.spec.ts/);
+
+  await expect(vscode).toHaveConnectionLog([
+    { method: 'listFiles', params: {} },
+    {
+      method: 'listTests',
+      params: {
+        locations: [expect.stringContaining(`tests${escapedPathSep}test\\.spec\\.ts`)]
+      }
+    },
+  ]);
+
+  await Promise.all([
+    new Promise(f => testController.onDidChangeTestItem(f)),
+    workspaceFolder.changeFile('tests/test.spec.ts', `
+      import { test } from '@playwright/test';
+      test('one', async () => {});
+      test('two', async () => {});
+    `)
+  ]);
+
+  await expect(testController).toHaveTestTree(`
+    -   tests
+      -   test.spec.ts
+        -   one [2:0]
+        -   two [3:0]
+  `);
+
+  await expect(vscode).toHaveConnectionLog([
+    { method: 'listFiles', params: {} },
+    {
+      method: 'listTests',
+      params: {
+        locations: [expect.stringContaining(`tests${escapedPathSep}test\\.spec\\.ts`)]
+      }
+    },
+    {
+      method: 'listTests',
+      params: {
+        locations: [expect.stringContaining(`tests${escapedPathSep}test\\.spec\\.ts`)]
+      }
+    },
+  ]);
+});
+
+test('should discover new tests with active editor', async ({ activate }) => {
+  const { vscode, testController, workspaceFolder } = await activate({
+    'playwright.config.js': `module.exports = { testDir: 'tests' }`,
+    'tests/test1.spec.ts': `
+      import { test } from '@playwright/test';
+      test('one', async () => {});
+    `,
+  });
+
+
+  await expect(vscode).toHaveConnectionLog([
+    { method: 'listFiles', params: {} },
+  ]);
+  await workspaceFolder.addFile('tests/test2.spec.ts', `
+    import { test } from '@playwright/test';
+    test('two', async () => {});
+  `);
+
+
+  await expect(vscode).toHaveConnectionLog([
+    { method: 'listFiles', params: {} },
+    { method: 'listFiles', params: {} },
+  ]);
+  await Promise.all([
+    new Promise<void>(f => {
+      testController.onDidChangeTestItem(ti => {
+        if (ti.label.includes('test2.spec'))
+          f();
+      });
+    }),
+    vscode.openEditors('**/test2.spec.ts'),
+  ]);
+
+  await expect(testController).toHaveTestTree(`
+    -   tests
+      -   test1.spec.ts
+      -   test2.spec.ts
+        -   two [2:0]
+  `);
+
+
+  await expect(vscode).toHaveConnectionLog([
+    { method: 'listFiles', params: {} },
+    { method: 'listFiles', params: {} },
+    {
+      method: 'listTests',
+      params: {
+        locations: [expect.stringContaining(`tests${escapedPathSep}test2\\.spec\\.ts`)]
+      }
+    },
+  ]);
+});
+
+test('should discover tests on add + change', async ({ activate }) => {
+  const { vscode, testController, workspaceFolder } = await activate({
+    'playwright.config.js': `module.exports = { testDir: './' }`,
+  });
+
+  await Promise.all([
+    new Promise(f => testController.onDidChangeTestItem(f)),
+    workspaceFolder.addFile('test.spec.ts', ``)
+  ]);
+
+  await expect(testController).toHaveTestTree(`
+    -   test.spec.ts
+  `);
+
+  await testController.expandTestItems(/test.spec.ts/);
+
+  await Promise.all([
+    new Promise(f => testController.onDidChangeTestItem(f)),
+    workspaceFolder.changeFile('test.spec.ts', `
+      import { test } from '@playwright/test';
+      test('one', async () => {});
+    `)
+  ]);
+
+  await expect(testController).toHaveTestTree(`
+    -   test.spec.ts
+      -   one [2:0]
+  `);
+
+
+  await expect(vscode).toHaveConnectionLog([
+    { method: 'listFiles', params: {} },
+    { method: 'listFiles', params: {} },
+    {
+      method: 'listTests',
+      params: {
+        locations: [expect.stringContaining(`test\\.spec\\.ts`)]
+      }
+    },
+    {
+      method: 'listTests',
+      params: {
+        locations: [expect.stringContaining(`test\\.spec\\.ts`)]
+      }
+    },
+  ]);
+});
+
+test('should discover new test at existing location', async ({ activate }) => {
+  const { vscode, testController, workspaceFolder } = await activate({
+    'playwright.config.js': `module.exports = { testDir: 'tests' }`,
+    'tests/test.spec.ts': `
+      import { test } from '@playwright/test';
+      test('one', async () => {});
+    `,
+  });
+
+  await testController.expandTestItems(/test.spec.ts/);
+
+  await expect(vscode).toHaveConnectionLog([
+    { method: 'listFiles', params: {} },
+    {
+      method: 'listTests',
+      params: {
+        locations: [expect.stringContaining(`tests${escapedPathSep}test\\.spec\\.ts`)]
+      }
+    },
+  ]);
+
+  await Promise.all([
+    new Promise(f => testController.onDidChangeTestItem(f)),
+    workspaceFolder.changeFile('tests/test.spec.ts', `
+      import { test } from '@playwright/test';
+      test('two', async () => {});
+    `)
+  ]);
+
+  await expect(testController).toHaveTestTree(`
+    -   tests
+      -   test.spec.ts
+        -   two [2:0]
+  `);
+
+  await expect(vscode).toHaveConnectionLog([
+    { method: 'listFiles', params: {} },
+    {
+      method: 'listTests',
+      params: {
+        locations: [expect.stringContaining(`tests${escapedPathSep}test\\.spec\\.ts`)]
+      }
+    },
+    {
+      method: 'listTests',
+      params: {
+        locations: [expect.stringContaining(`tests${escapedPathSep}test\\.spec\\.ts`)]
+      }
+    },
+  ]);
+});
+
+test('should remove deleted tests', async ({ activate }) => {
+  const { vscode, testController, workspaceFolder } = await activate({
+    'playwright.config.js': `module.exports = { testDir: 'tests' }`,
+    'tests/test.spec.ts': `
+      import { test } from '@playwright/test';
+      test('one', async () => {});
+      test('two', async () => {});
+    `,
+  });
+
+  await testController.expandTestItems(/test.spec.ts/);
+
+  await expect(vscode).toHaveConnectionLog([
+    { method: 'listFiles', params: {} },
+    {
+      method: 'listTests',
+      params: {
+        locations: [expect.stringContaining(`tests${escapedPathSep}test\\.spec\\.ts`)]
+      }
+    },
+  ]);
+
+  await expect(testController).toHaveTestTree(`
+    -   tests
+      -   test.spec.ts
+        -   one [2:0]
+        -   two [3:0]
+  `);
+
+  await Promise.all([
+    new Promise(f => testController.onDidChangeTestItem(f)),
+    workspaceFolder.changeFile('tests/test.spec.ts', `
+      import { test } from '@playwright/test';
+      test('one', async () => {});
+    `)
+  ]);
+
+  await expect(testController).toHaveTestTree(`
+    -   tests
+      -   test.spec.ts
+        -   one [2:0]
+  `);
+
+  await expect(vscode).toHaveConnectionLog([
+    { method: 'listFiles', params: {} },
+    {
+      method: 'listTests',
+      params: {
+        locations: [expect.stringContaining(`tests${escapedPathSep}test\\.spec\\.ts`)]
+      }
+    },
+    {
+      method: 'listTests',
+      params: {
+        locations: [expect.stringContaining(`tests${escapedPathSep}test\\.spec\\.ts`)]
+      }
+    },
+  ]);
+});
+
+test('should forget tests after error before first test', async ({ activate }) => {
+  const { testController, workspaceFolder } = await activate({
+    'playwright.config.js': `module.exports = { testDir: 'tests' }`,
+    'tests/test.spec.ts': `
+      import { test } from '@playwright/test';
+      test('one', async () => {});
+      test('two', async () => {});
+    `,
+  });
+
+  await testController.expandTestItems(/test.spec.ts/);
+
+  await expect(testController).toHaveTestTree(`
+    -   tests
+      -   test.spec.ts
+        -   one [2:0]
+        -   two [3:0]
+  `);
+
+  await Promise.all([
+    new Promise(f => testController.onDidChangeTestItem(f)),
+    workspaceFolder.changeFile('tests/test.spec.ts', `
+      import { test } from '@playwright/test';
+      test('one', async () => {});
+      throw new Error('Uncaught');
+      test('two', async () => {});
+    `)
+  ]);
+
+  await expect(testController).toHaveTestTree(`
+    -   tests
+      -   test.spec.ts
+  `);
+});
+
+test('should regain tests after error is fixed', async ({ activate }) => {
+  const { vscode, testController, workspaceFolder } = await activate({
+    'playwright.config.js': `module.exports = { testDir: 'tests' }`,
+    'tests/test.spec.ts': `
+      import { test } from '@playwright/test';
+      throw new Error('Uncaught');
+      test('one', async () => {});
+      test('two', async () => {});
+    `,
+  });
+
+  await testController.expandTestItems(/test.spec.ts/);
+
+  await expect(vscode).toHaveConnectionLog([
+    { method: 'listFiles', params: {} },
+    {
+      method: 'listTests',
+      params: {
+        locations: [expect.stringContaining(`tests${escapedPathSep}test\\.spec\\.ts`)]
+      }
+    },
+  ]);
+
+  await expect(testController).toHaveTestTree(`
+    -   tests
+      -   test.spec.ts
+  `);
+
+  await Promise.all([
+    new Promise(f => testController.onDidChangeTestItem(f)),
+    workspaceFolder.changeFile('tests/test.spec.ts', `
+      import { test } from '@playwright/test';
+      test('one', async () => {});
+      test('two', async () => {});
+    `)
+  ]);
+
+  await expect(testController).toHaveTestTree(`
+    -   tests
+      -   test.spec.ts
+        -   one [2:0]
+        -   two [3:0]
+  `);
+
+  await expect(vscode).toHaveConnectionLog([
+    { method: 'listFiles', params: {} },
+    {
+      method: 'listTests',
+      params: {
+        locations: [expect.stringContaining(`tests${escapedPathSep}test\\.spec\\.ts`)]
+      }
+    },
+    {
+      method: 'listTests',
+      params: {
+        locations: [expect.stringContaining(`tests${escapedPathSep}test\\.spec\\.ts`)]
+      }
+    },
+  ]);
+});
+
+test('should support multiple configs', async ({ activate }) => {
+  const { vscode, testController } = await activate({
+    'tests1/playwright.config.js': `module.exports = { testDir: '.' }`,
+    'tests2/playwright.config.js': `module.exports = { testDir: '.' }`,
+    'tests1/test.spec.ts': `
+      import { test } from '@playwright/test';
+      test('one', async () => {});
+    `,
+    'tests2/test.spec.ts': `
+      import { test } from '@playwright/test';
+      test('two', async () => {});
+    `,
+  });
+
+  await enableConfigs(vscode, [`tests1${path.sep}playwright.config.js`, `tests2${path.sep}playwright.config.js`]);
+
+  await expect(testController).toHaveTestTree(`
+    -   tests1
+      -   test.spec.ts
+    -   tests2
+      -   test.spec.ts
+  `);
+
+  await testController.expandTestItems(/test.spec/);
+
+  await expect(testController).toHaveTestTree(`
+    -   tests1
+      -   test.spec.ts
+        -   one [2:0]
+    -   tests2
+      -   test.spec.ts
+        -   two [2:0]
+  `);
+
+  await expect(vscode).toHaveConnectionLog([
+    { method: 'listFiles', params: {} },
+    { method: 'listFiles', params: {} },
+    {
+      method: 'listTests',
+      params: {
+        locations: [expect.stringContaining(`tests1${escapedPathSep}test\\.spec\\.ts`)]
+      }
+    },
+    {
+      method: 'listTests',
+      params: {
+        locations: [expect.stringContaining(`tests2${escapedPathSep}test\\.spec\\.ts`)]
+      }
+    },
+  ]);
+});
+
+test('should support multiple projects', async ({ activate }) => {
+  const { vscode, testController } = await activate({
+    'playwright.config.js': `module.exports = {
+      testDir: './tests',
+      projects: [
+        { name: 'project 1', testMatch: /test1.spec/ },
+        { name: 'project 2', testMatch: /test2.spec/ },
+      ]
+    }`,
+    'tests/test1.spec.ts': `
+      import { test } from '@playwright/test';
+      test('one', async () => {});
+    `,
+    'tests/test2.spec.ts': `
+      import { test } from '@playwright/test';
+      test('two', async () => {});
+    `,
+  });
+
+  await enableProjects(vscode, ['project 1', 'project 2']);
+
+  await expect(testController).toHaveTestTree(`
+    -   tests
+      -   test1.spec.ts
+      -   test2.spec.ts
+  `);
+
+  await testController.expandTestItems(/test1.spec/);
+
+  await expect(testController).toHaveTestTree(`
+    -   tests
+      -   test1.spec.ts
+        -   one [2:0]
+      -   test2.spec.ts
+  `);
+
+  await expect(vscode).toHaveConnectionLog([
+    { method: 'listFiles', params: {} },
+    {
+      method: 'listTests',
+      params: {
+        locations: [expect.stringContaining(`tests${escapedPathSep}test1\\.spec\\.ts`)]
+      }
+    },
+  ]);
+});
+
+test('should list parametrized tests', async ({ activate }) => {
+  const { testController } = await activate({
+    'playwright.config.js': `module.exports = { testDir: 'tests' }`,
+    'tests/test.spec.ts': `
+      import { test } from '@playwright/test';
+      for (const name of ['one', 'two', 'three'])
+        test(name, async () => {});
+    `,
+  });
+
+  await testController.expandTestItems(/test.spec.ts/);
+  await expect(testController).toHaveTestTree(`
+    -   tests
+      -   test.spec.ts
+        -   one [3:0]
+        -   three [3:0]
+        -   two [3:0]
+  `);
+});
+
+test('should list tests in parametrized groups', async ({ activate }) => {
+  const { testController } = await activate({
+    'playwright.config.js': `module.exports = { testDir: 'tests' }`,
+    'tests/test.spec.ts': `
+      import { test } from '@playwright/test';
+      for (const foo of [1, 2]) {
+        test.describe('level ' + foo, () => {
+          test('should work', async () => {});
+        });
+      }
+    `,
+  });
+
+  await testController.expandTestItems(/test.spec.ts/);
+  await expect(testController).toHaveTestTree(`
+    -   tests
+      -   test.spec.ts
+        -   level 1 [3:0]
+          -   should work [4:0]
+        -   level 2 [3:0]
+          -   should work [4:0]
+  `);
+});
+
+test('should not run config reporters', async ({ activate }, testInfo) => {
+  const { testController } = await activate({
+    'playwright.config.js': `module.exports = {
+      testDir: 'tests',
+      reporter: 'html',
+    }`,
+    'tests/test.spec.ts': `
+      import { test } from '@playwright/test';
+      test('one', async () => {});
+    `,
+  });
+
+  await testController.expandTestItems(/test.spec.ts/);
+  await expect(testController).toHaveTestTree(`
+    -   tests
+      -   test.spec.ts
+        -   one [2:0]
+  `);
+
+  expect(fs.existsSync(testInfo.outputPath('playwright-report'))).toBeFalsy();
+});
+
+test('should list tests in multi-folder workspace', async ({ activate }, testInfo) => {
+  const { vscode, testController } = await activate({}, {
+    workspaceFolders: [
+      [testInfo.outputPath('folder1'), {
+        'playwright.config.js': `module.exports = { testDir: './' }`,
+        'test.spec.ts': `
+          import { test } from '@playwright/test';
+          test('one', async () => {});
+        `,
+      }],
+      [testInfo.outputPath('folder2'), {
+        'playwright.config.js': `module.exports = { testDir: './' }`,
+        'test.spec.ts': `
+          import { test } from '@playwright/test';
+          test('two', async () => {});
+        `,
+      }]
+    ]
+  });
+
+  await enableConfigs(vscode, [`folder1${path.sep}playwright.config.js`, `folder2${path.sep}playwright.config.js`]);
+
+  await expect(testController).toHaveTestTree(`
+    -   folder1
+      -   test.spec.ts
+    -   folder2
+      -   test.spec.ts
+  `);
+
+  await testController.expandTestItems(/test.spec.ts/);
+  await expect(testController).toHaveTestTree(`
+    -   folder1
+      -   test.spec.ts
+        -   one [2:0]
+    -   folder2
+      -   test.spec.ts
+        -   two [2:0]
+  `);
+});
+
+test('should not keep empty workspace-folders in a workspace', async ({ activate }, testInfo) => {
+  const { testController } = await activate({}, {
+    workspaceFolders: [
+      [testInfo.outputPath('folder1'), {}],
+      [testInfo.outputPath('folder2'), {
+        'playwright.config.js': `module.exports = { testDir: './' }`,
+        'test.spec.ts': `
+          import { test } from '@playwright/test';
+          test('two', async () => {});
+        `,
+      }]
+    ]
+  });
+
+  // Make sure folder1 is not listed.
+  await expect(testController).toHaveTestTree(`
+    -   folder2
+      -   test.spec.ts
+  `);
+
+  await testController.expandTestItems(/test.spec.ts/);
+  // Make sure folder1 is not listed.
+  await expect(testController).toHaveTestTree(`
+    -   folder2
+      -   test.spec.ts
+        -   two [2:0]
+  `);
+});
+
+test('should merge items from different projects', async ({ activate }, testInfo) => {
+  const { vscode, testController } = await activate({
+    'playwright.config.ts': `module.exports = {
+      projects: [
+        { name: 'desktop', grepInvert: /mobile|tablet/ },
+        { name: 'mobile', grep: /@mobile/ },
+        { name: 'tablet', grep: /@tablet/ },
+      ]
+    }`,
+    'test.spec.ts': `
+      import { test } from '@playwright/test';
+      test.describe('group', () => {
+        test('test 1', async () => {});
+        test('test 2 [@mobile]', async () => {});
+        test('test 3 [@mobile]', async () => {});
+        test('test 4', async () => {});
+      });`,
+  });
+
+  await enableProjects(vscode, ['desktop', 'mobile', 'tablet']);
+
+  await testController.expandTestItems(/test.spec.ts/);
+  await testController.expandTestItems(/group/);
+  await expect(testController).toHaveTestTree(`
+    -   test.spec.ts
+      -   group [2:0]
+        -   test 1 [3:0]
+        -   test 2 [@mobile] [4:0]
+        -   test 3 [@mobile] [5:0]
+        -   test 4 [6:0]
+  `);
+});
+
+test('should show project-specific tests', async ({ activate }, testInfo) => {
+  const { vscode, testController } = await activate({
+    'playwright.config.ts': `module.exports = {
+      projects: [
+        { name: 'chromium' },
+        { name: 'firefox' },
+        { name: 'webkit' },
+      ]
+    }`,
+    'test.spec.ts': `
+      import { test } from '@playwright/test';
+      test('test', async () => {});
+    `
+  });
+
+  await expect(testController).toHaveTestTree(`
+    -   test.spec.ts
+    -    [playwright.config.ts [firefox] — disabled]
+    -    [playwright.config.ts [webkit] — disabled]
+  `);
+
+  await testController.expandTestItems(/test.spec.ts/);
+  await expect(testController).toHaveTestTree(`
+    -   test.spec.ts
+      -   test [2:0]
+    -    [playwright.config.ts [firefox] — disabled]
+    -    [playwright.config.ts [webkit] — disabled]
+  `);
+
+  await enableProjects(vscode, ['chromium', 'firefox', 'webkit']);
+  await expect(testController).toHaveTestTree(`
+    -   test.spec.ts
+      -   test [2:0]
+        -   chromium [2:0]
+        -   firefox [2:0]
+        -   webkit [2:0]
+  `);
+
+  await enableProjects(vscode, ['webkit']);
+  await expect(testController).toHaveTestTree(`
+    -   test.spec.ts
+      -   test [2:0]
+    -    [playwright.config.ts [chromium] — disabled]
+    -    [playwright.config.ts [firefox] — disabled]
+  `);
+});
+
+test('should remove top-level items after disabling config', async ({ activate }) => {
+  const { vscode, testController } = await activate({
+    'tests1/playwright.config.js': `module.exports = { testDir: '.' }`,
+    'tests2/playwright.config.js': `module.exports = { testDir: '.' }`,
+    'tests1/test.spec.ts': `
+      import { test } from '@playwright/test';
+      test('one', async () => {});
+    `,
+    'tests2/test.spec.ts': `
+      import { test } from '@playwright/test';
+      test('two', async () => {});
+    `,
+  });
+
+  await enableConfigs(vscode, [`tests1${path.sep}playwright.config.js`, `tests2${path.sep}playwright.config.js`]);
+
+  await expect(testController).toHaveTestTree(`
+    -   tests1
+      -   test.spec.ts
+    -   tests2
+      -   test.spec.ts
+  `);
+
+  await enableConfigs(vscode, [`tests1${path.sep}playwright.config.js`]);
+
+  await expect(testController).toHaveTestTree(`
+    -   tests1
+      -   test.spec.ts
+  `);
+
+  await expect(vscode).toHaveConnectionLog([
+    { method: 'listFiles', params: {} },
+    { method: 'listFiles', params: {} },
+  ]);
+});

--- a/packages/vscode/tests/mock/vscode.ts
+++ b/packages/vscode/tests/mock/vscode.ts
@@ -1,0 +1,1380 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import fs from 'fs';
+import glob from 'glob';
+import path from 'path';
+import { Disposable, EventEmitter, Event } from '../../src/upstream/events';
+import { minimatch } from 'minimatch';
+import { ChildProcessWithoutNullStreams, spawn } from 'child_process';
+import which from 'which';
+import { Browser, Page } from '@playwright/test';
+import { CancellationToken } from '../../src/vscodeTypes';
+
+/* eslint-disable no-restricted-properties */
+
+export class Uri {
+  scheme = 'file';
+  authority = '';
+  path = '';
+  query = '';
+  fragment = '';
+  fsPath = '';
+
+  static file(fsPath: string): Uri {
+    const uri = new Uri();
+    // VSCode lowercases drive letters on Windows.
+    if (process.platform === 'win32' && fsPath && fsPath[0] !== '\\' && fsPath[0] !== '/')
+      fsPath = fsPath[0].toLowerCase() + fsPath.substring(1);
+    uri.fsPath = fsPath;
+    uri.path = fsPath;
+    return uri;
+  }
+
+  static joinPath(base: Uri, ...args: string[]): Uri {
+    return Uri.file(path.join(base.fsPath, ...args));
+  }
+
+  static parse(value: string): Uri {
+    const { protocol, host, pathname, search, hash } = new URL(value);
+    const uri = new Uri();
+    uri.scheme = protocol.replace(/:$/, '');
+    uri.authority = host;
+    uri.path = pathname;
+    uri.query = search;
+    uri.fragment = hash;
+    return uri;
+  }
+
+  toString() {
+    const url = new URL(`${this.scheme}://${this.authority}${this.path}`);
+    if (this.query) url.search = this.query;
+    if (this.fragment) url.hash = this.fragment;
+    return url.toString();
+  }
+}
+
+export enum ColorThemeKind {
+  Light = 1,
+  Dark = 2,
+  HighContrast = 3,
+  HighContrastLight = 4
+}
+
+class Position {
+  constructor(readonly line: number, readonly character: number) {}
+
+  toString() {
+    return `${this.line}:${this.character}`;
+  }
+}
+
+export enum DiagnosticSeverity {
+  Error = 'Error',
+  Warning = 'Warning',
+  Information = 'Information',
+  Hint = 'Hint'
+}
+
+type Diagnostic = {
+  message: string;
+  location: Location;
+  severity: DiagnosticSeverity;
+};
+
+class Location {
+  range: Range;
+  constructor(readonly uri: Uri, rangeOrPosition: Range | Position) {
+    if ('line' in rangeOrPosition)
+      this.range = new Range(rangeOrPosition.line, rangeOrPosition.character, rangeOrPosition.line, rangeOrPosition.character);
+    else
+      this.range = rangeOrPosition;
+  }
+}
+
+class Range {
+  start: Position;
+  end: Position;
+  constructor(startLine: number | Position, startCharacter: number | Position, endLine?: number, endCharacter?: number) {
+    if (startLine instanceof Position) {
+      this.start = startLine;
+      this.end = startCharacter as Position;
+    } else {
+      this.start = new Position(startLine as number, startCharacter as number);
+      this.end = new Position(endLine as number, endCharacter as number);
+    }
+  }
+
+  clone(): Range {
+    return new Range(this.start.line, this.start.character, this.end.line, this.end.character);
+  }
+
+  toString() {
+    return `[${this.start.toString()} - ${this.end.toString()}]`;
+  }
+}
+
+class Selection extends Range {
+}
+
+class CancellationTokenSource implements Disposable {
+  token: CancellationToken & { source: CancellationTokenSource };
+  readonly didCancel = new EventEmitter<void>();
+
+  constructor() {
+    this.token = {
+      isCancellationRequested: false,
+      onCancellationRequested: this.didCancel.event,
+      source: this,
+    };
+  }
+
+  cancel() {
+    this.token.isCancellationRequested = true;
+    this.didCancel.fire();
+  }
+
+  dispose() {
+    this.cancel();
+  }
+}
+
+export class WorkspaceFolder {
+  name: string;
+  uri: Uri;
+
+  constructor(readonly vscode: VSCode, name: string, uri: Uri) {
+    this.name = name;
+    this.uri = uri;
+  }
+
+  async addFile(file: string, content: string, isNewWorkspace?: boolean) {
+    const fsPath = path.join(this.uri.fsPath, file);
+    await fs.promises.mkdir(path.dirname(fsPath), { recursive: true });
+    await fs.promises.writeFile(fsPath, content);
+    if (!isNewWorkspace) {
+      for (const watcher of this.vscode.fsWatchers) {
+        if (minimatch(fsPath, watcher.glob))
+          watcher.didCreate.fire(Uri.file(fsPath));
+      }
+    }
+  }
+
+  async removeFile(file: string) {
+    const fsPath = path.join(this.uri.fsPath, file);
+    await fs.promises.unlink(fsPath);
+    for (const watcher of this.vscode.fsWatchers) {
+      if (minimatch(fsPath, watcher.glob))
+        watcher.didDelete.fire(Uri.file(fsPath));
+    }
+  }
+
+  async changeFile(file: string, content: string) {
+    // TODO: investigate why watch immediately followed by changeFile doesn't emit the event.
+    await new Promise(f => setTimeout(f, 1000));
+    const fsPath = path.join(this.uri.fsPath, file);
+    await fs.promises.writeFile(fsPath, content);
+    for (const watcher of this.vscode.fsWatchers) {
+      if (minimatch(fsPath, watcher.glob))
+        watcher.didChange.fire(Uri.file(fsPath));
+    }
+  }
+}
+
+export class TestItem {
+  readonly children = this;
+  readonly map = new Map<string, TestItem>();
+  range: Range | undefined;
+  parent: TestItem | undefined;
+  tags: readonly TestTag[] = [];
+  canResolveChildren = false;
+  status: 'none' | 'enqueued' | 'started' | 'skipped' | 'failed' | 'passed' = 'none';
+  description: string | undefined;
+  sortText: string | undefined;
+  error: string | undefined;
+
+  constructor(
+      readonly testController: TestController,
+      readonly id: string,
+      readonly label: string,
+      readonly uri?: Uri) {
+  }
+
+  get size() {
+    return this.map.size;
+  }
+
+  [Symbol.iterator](): Iterator<[string, TestItem]> {
+    return this.map[Symbol.iterator]();
+  }
+
+  async expand() {
+    if (this.canResolveChildren)
+      await this.testController.resolveHandler!(this);
+  }
+
+  add(item: TestItem) {
+    this._innerAdd(item);
+    this.testController.didChangeTestItem.fire(this);
+  }
+
+  private _innerAdd(item: TestItem) {
+    this.map.set(item.id, item);
+    item.parent = this;
+    this.testController.allTestItems.set(item.id, item);
+  }
+
+  delete(id: string) {
+    this._innerDelete(id);
+    this.testController.didChangeTestItem.fire(this);
+  }
+
+  private _innerDelete(id: string) {
+    const item = this.map.get(id);
+    this.map.delete(id);
+    item?.forEach(child => this.testController.allTestItems.delete(child.id));
+    this.testController.allTestItems.delete(id);
+  }
+
+  replace(items: TestItem[]) {
+    for (const itemId of this.map.keys())
+      this._innerDelete(itemId);
+    for (const item of items)
+      this._innerAdd(item);
+    this.testController.didChangeTestItem.fire(this);
+  }
+
+  forEach(visitor: (item: TestItem) => void) {
+    this.map.forEach(visitor);
+  }
+
+  toString(): string {
+    const result: string[] = [];
+    this.innerToString('', result);
+    return result.join('\n');
+  }
+
+  innerToString(indent: string, result: string[]) {
+    result.push(`${indent}- ${this.statusIcon()} ${this.treeTitle()}`);
+    if (this.error)
+      result.push(`${indent}  ${this.error}`);
+    const items = [...this.children.map.values()];
+    items.sort((i1, i2) => itemOrder(i1).localeCompare(itemOrder(i2)));
+    for (const item of items)
+      item.innerToString(indent + '  ', result);
+  }
+
+  statusIcon() {
+    if (this.status === 'enqueued')
+      return '🕦';
+    if (this.status === 'started')
+      return '↻';
+    if (this.status === 'skipped')
+      return '◯';
+    if (this.status === 'failed')
+      return '❌';
+    if (this.status === 'passed')
+      return '✅';
+    return ' ';
+  }
+
+  treeTitle(): string {
+    let location = '';
+    if (this.range)
+      location = ` [${this.range.start.toString()}]`;
+    let description = '';
+    if (this.description)
+      description = ` [${this.description}]`;
+    return `${this.label}${description}${location}`;
+  }
+
+  flatTitle(): string {
+    let location = '';
+    if (this.range)
+      location = ` [${this.range.start.toString()}]`;
+    const titlePath: string[] = [];
+    let item: TestItem | undefined = this;
+    while (item && item.parent) {
+      titlePath.unshift(item.label);
+      item = item.parent;
+    }
+    return `${titlePath.join(' > ')}${location}`;
+  }
+}
+
+function itemOrder(item: TestItem) {
+  let result = '';
+  if (item.range)
+    result += item.range.start.line.toString().padStart(5, '0');
+  result += item.sortText || item.label;
+  return result;
+}
+
+class TestRunProfile {
+  private _isDefault = true;
+  readonly didChangeDefault = new EventEmitter<boolean>();
+  readonly onDidChangeDefault: Event<boolean> | undefined;
+
+  constructor(
+    private testController: TestController,
+    readonly label: string,
+    readonly kind: TestRunProfileKind,
+    readonly runHandler: (request: TestRunRequest, token: CancellationToken) => Promise<void>,
+    isDefault: boolean,
+    private runProfiles: TestRunProfile[]) {
+    runProfiles.push(this);
+    this.onDidChangeDefault = this.didChangeDefault.event;
+    this._isDefault = isDefault;
+  }
+
+  get isDefault(): boolean {
+    return this._isDefault;
+  }
+
+  set isDefault(value: boolean) {
+    this._isDefault = value;
+    this.didChangeDefault.fire(value);
+  }
+
+  async run(include?: TestItem[], exclude?: TestItem[]): Promise<TestRun> {
+    const request = new TestRunRequest(include, exclude, this);
+    const [testRun] = await Promise.all([
+      new Promise<TestRun>(f => this.testController.onDidCreateTestRun(testRun => {
+        testRun.onDidEnd(() => f(testRun));
+      })),
+      this.runHandler(request, request.token),
+    ]);
+    return testRun;
+  }
+
+  async watch(include?: TestItem[], exclude?: TestItem[]): Promise<TestRunRequest> {
+    const request = new TestRunRequest(include, exclude, this, true);
+    await this.runHandler(request, request.token);
+    return request;
+  }
+
+  dispose() {
+    this.runProfiles.splice(this.runProfiles.indexOf(this), 1);
+    this.didChangeDefault.dispose();
+  }
+}
+
+export class TestRunRequest {
+  readonly token = new CancellationTokenSource().token;
+
+  include: TestItem[] | undefined;
+  exclude: TestItem[] | undefined;
+  profile: TestRunProfile | undefined;
+  continuous?: boolean;
+
+  constructor(include?: TestItem[], exclude?: TestItem[], profile?: TestRunProfile, continuous?: boolean) {
+    this.include = include;
+    this.exclude = exclude;
+    this.profile = profile;
+    this.continuous = continuous;
+  }
+}
+
+export class TestMessage {
+  constructor(
+    readonly message: MarkdownString,
+    readonly expectedOutput?: string,
+    readonly actualOutput?: string,
+    readonly location?: Location,
+    readonly stackTrace?: TestMessageStackFrame[]) {}
+
+  render(indent: string, result: string[]) {
+    if (this.location)
+      result.push(`${indent}${path.basename(this.location.uri.fsPath)}:${this.location.range.toString()}`);
+    const message = this.message.render();
+    for (let line of message.split('\n')) {
+      line = line.replace(/at .*\/test-results.*[/\\]tests(.*)\)/, 'at tests$1');
+      if (this.location && line.includes('    at'))
+        line = line.replace(/\\/g, '/');
+      if (this.location && line.includes('&nbsp;&nbsp;&nbsp;&nbsp;at'))
+        line = line.replace(/\\/g, '/');
+      result.push(indent + line);
+    }
+    if (this.stackTrace?.length) {
+      result.push(indent + 'Stack trace:');
+      for (const frame of this.stackTrace)
+        result.push(`${indent}  ${frame.label} (${path.basename(frame.uri.fsPath)}:${frame.position.line + 1})`);
+    }
+  }
+}
+
+export class TestMessageStackFrame {
+  constructor(
+    readonly label: string,
+    readonly uri: Uri,
+    readonly position: Position) {}
+}
+
+type LogEntry = { status: string, duration?: number, messages?: TestMessage | TestMessage[] };
+
+const disposable = { dispose: () => {} };
+
+export class TestRun {
+  private _didChange = new EventEmitter<void>();
+  readonly onDidChange = this._didChange.event;
+  readonly _didEnd = new EventEmitter<void>();
+  readonly onDidEnd = this._didEnd.event;
+  readonly _didOutput = new EventEmitter<string>();
+  readonly onDidOutput = this._didOutput.event;
+  readonly entries = new Map<TestItem, LogEntry[]>();
+  readonly token = new CancellationTokenSource().token;
+  readonly output: { output: string, location?: Location, test?: TestItem }[] = [];
+
+  constructor(
+    readonly request: TestRunRequest,
+    readonly name?: string,
+    readonly persist?: boolean) {
+  }
+
+  enqueued(test: TestItem) {
+    test.status = 'enqueued';
+    this._log(test, { status: 'enqueued' });
+  }
+
+  started(test: TestItem) {
+    test.status = 'started';
+    this._log(test, { status: 'started' });
+  }
+
+  skipped(test: TestItem) {
+    test.status = 'skipped';
+    this._log(test, { status: 'skipped' });
+  }
+
+  failed(test: TestItem, messages: TestMessage[], duration?: number) {
+    test.status = 'failed';
+    this._log(test, { status: 'failed', duration, messages });
+  }
+
+  passed(test: TestItem, duration?: number) {
+    test.status = 'passed';
+    this._log(test, { status: 'passed', duration });
+  }
+
+  private _log(test: TestItem, entry: LogEntry) {
+    let entries = this.entries.get(test);
+    if (!entries) {
+      entries = [];
+      this.entries.set(test, entries);
+    }
+    entries.push(entry);
+    this._didChange.fire();
+  }
+
+  appendOutput(output: string, location?: Location, test?: TestItem) {
+    this.output.push({ output, location, test });
+    this._didOutput.fire(output);
+  }
+
+  end() {
+    this._didEnd.fire();
+  }
+
+  renderLog(options: { messages?: boolean, output?: boolean } = {}): string {
+    const indent = '  ';
+    const result: string[] = [''];
+    const tests = [...this.entries.keys()];
+    tests.sort((i1, i2) => itemOrder(i1).localeCompare(itemOrder(i2)));
+    for (const test of tests) {
+      const entries = this.entries.get(test)!;
+      result.push(`  ${test.flatTitle()}`);
+      for (const entry of entries) {
+        result.push(`    ${entry.status}`);
+        if (options.messages && entry.messages) {
+          const messages = Array.isArray(entry.messages) ? entry.messages : [entry.messages];
+          for (const message of messages)
+            message.render('      ', result);
+        }
+      }
+    }
+    if (options.output) {
+      result.push('  Output:');
+      result.push(...this._renderOutput());
+    }
+    let log = trimLog(result.join(`\n${indent}`)) + `\n${indent}`;
+    // Strip Playwright's "Context for AI" details block as it contains absolute paths.
+    log = log.replace(/\n?\s*<br><br><details><summary>Context for AI<\/summary>[\s\S]*?<\/details>/g, '');
+    return log;
+  }
+
+  renderOutput(): string {
+    return this._renderOutput().join('\n');
+  }
+
+  private _renderOutput(): string[] {
+    const output = this.output.map(o => o.output).join('');
+    const lines = output.split('\n');
+    return lines.map(l => '  ' + stripAnsi(l).replace(/\d+(\.\d+)?(ms|s)/, 'XXms'));
+  }
+}
+
+export class TestController {
+  readonly items: TestItem;
+  readonly runProfiles: TestRunProfile[] = [];
+  readonly allTestItems = new Map<string, TestItem>();
+
+  readonly didChangeTestItem = new EventEmitter<TestItem>();
+  readonly onDidChangeTestItem = this.didChangeTestItem.event;
+
+  private _didCreateTestRun = new EventEmitter<TestRun>();
+  readonly onDidCreateTestRun = this._didCreateTestRun.event;
+
+  refreshHandler?: (item: TestItem | null) => Promise<void>;
+  resolveHandler?: (item: TestItem | null) => Promise<void>;
+
+  constructor(readonly vscode: VSCode, id: string, label: string) {
+    this.items = new TestItem(this, id, label);
+  }
+
+  runProfile(): TestRunProfile {
+    return this.runProfiles.filter(p => p.kind === TestRunProfileKind.Run)[0];
+  }
+
+  debugProfile(): TestRunProfile {
+    return this.runProfiles.filter(p => p.kind === TestRunProfileKind.Debug)[0];
+  }
+
+  createTestItem(id: string, label: string, uri?: Uri): TestItem {
+    return new TestItem(this, id, label, uri);
+  }
+
+  createRunProfile(label: string, kind: TestRunProfileKind, runHandler: (request: TestRunRequest, token: CancellationToken) => Promise<void>, isDefault?: boolean): TestRunProfile {
+    return new TestRunProfile(this, label, kind, runHandler, !!isDefault, this.runProfiles);
+  }
+
+  createTestRun(request: TestRunRequest, name?: string, persist?: boolean): TestRun {
+    const testRun = new TestRun(request, name, persist);
+    this._didCreateTestRun.fire(testRun);
+    return testRun;
+  }
+
+  renderTestTree() {
+    const result: string[] = [''];
+    const items = [...this.items.map.values()];
+    items.sort((i1, i2) => itemOrder(i1).localeCompare(itemOrder(i2)));
+    for (const item of items)
+      item.innerToString('    ', result);
+    result.push('  ');
+    return result.join('\n');
+  }
+
+  async expandTestItems(label: RegExp) {
+    await Promise.all(this.findTestItems(label).map(t => t.expand()));
+  }
+
+  findTestItems(label: RegExp): TestItem[] {
+    return [...this.allTestItems.values()].filter(t => label.exec(t.label));
+  }
+
+  async run(include?: TestItem[], exclude?: TestItem[]): Promise<TestRun> {
+    const profile = this.runProfiles.find(p => p.kind === this.vscode.TestRunProfileKind.Run)!;
+    return profile.run(include, exclude);
+  }
+
+  async watch(include?: TestItem[], exclude?: TestItem[]): Promise<TestRunRequest> {
+    const profile = this.runProfiles.find(p => p.kind === this.vscode.TestRunProfileKind.Run)!;
+    return profile.watch(include, exclude);
+  }
+
+  async debug(include?: TestItem[], exclude?: TestItem[]): Promise<TestRun> {
+    const profile = this.runProfiles.find(p => p.kind === this.vscode.TestRunProfileKind.Debug)!;
+    return profile.run(include, exclude);
+  }
+
+  dispose() {
+    this.didChangeTestItem.dispose();
+    this._didCreateTestRun.dispose();
+  }
+}
+
+type Decoration = { type?: number, range: Range, renderOptions?: any };
+
+class TextDocument {
+  uri: Uri;
+  lines: string[] = [];
+
+  constructor(uri: Uri) {
+    this.uri = uri;
+  }
+
+  get text() {
+    return this.lines.join('\n');
+  }
+
+  getText(selection?: Range) {
+    if (!selection)
+      return this.text;
+    const start = selection.start;
+    const end = selection.end;
+    if (start.line === end.line)
+      return this.lines[start.line].substring(start.character, end.character);
+    const result = [];
+    result.push(this.lines[start.line].substring(start.character));
+    for (let i = start.line + 1; i < end.line; ++i)
+      result.push(this.lines[i]);
+    result.push(this.lines[end.line].substring(0, end.character));
+    return result.join('\n');
+  }
+
+  async _load() {
+    const text = await fs.promises.readFile(this.uri.fsPath, 'utf-8');
+    this.lines = text.split('\n');
+  }
+
+  lineAt(i: number) {
+    const line = this.lines[i];
+    return {
+      text: line,
+      isEmptyOrWhitespace: !line.replace(/\s/g, '').trim(),
+      firstNonWhitespaceCharacterIndex: line.match(/^\s*/g)![0].length
+    };
+  }
+}
+
+class TextEditor {
+  readonly document: TextDocument;
+  private _log: string[] = [];
+  private _state = new Map<number, Decoration[]>();
+  readonly edits: { range: string, from: string, to: string }[] = [];
+  selection = new Selection(0, 0, 0, 0);
+
+  constructor(document: TextDocument) {
+    this.document = document;
+  }
+
+  setDecorations(type: number, decorations: Decoration[]) {
+    this._state.set(type, decorations);
+
+    const lines: string[] = [];
+    for (const [type, decorations] of this._state) {
+      for (const decoration of decorations) {
+        let options = decoration.renderOptions ? ' ' + JSON.stringify(decoration.renderOptions) : '';
+        options = options.replace(/\d+ms/g, 'Xms');
+        const name = [
+          'activeStep',
+          'completedStep',
+          'pausedAtEnd',
+          'pausedOnError'
+        ][type - 1];
+        lines.push(`${decoration.range.toString()}: decorator ${name}${options}`);
+      }
+    }
+    const state = lines.sort().join('\n');
+    if (this._log[this._log.length - 1] !== state)
+      this._log.push(state);
+  }
+
+  renderDecorations(indent: string): string {
+    const result = [''];
+    for (const state of this._log) {
+      result.push('  --------------------------------------------------------------');
+      result.push(...state.split('\n').map(s => '  ' + s));
+    }
+    return trimLog(result.join(`\n${indent}`)) + `\n${indent}`;
+  }
+
+  renderWithSelection() {
+    // render with selection wrapped with <selection> tag
+    const prefix = this.document.getText(new Range(0, 0, this.selection.start.line, this.selection.start.character));
+    const selection = this.document.getText(this.selection);
+    const suffix = this.document.getText(new Range(this.selection.end.line, this.selection.end.character, this.document.lines.length - 1, this.document.lines[this.document.lines.length - 1].length));
+    return `${prefix}<selection>${selection}</selection>${suffix}`;
+  }
+
+  edit(editCallback: any) {
+    editCallback({
+      replace: (range: Range, text: string) => {
+        const from = this.renderWithSelection();
+        const lines = this.document.text.split('\n');
+        const editLines = text.split('\n');
+        const newLines = lines.slice(0, range.start.line);
+        if (editLines.length === 1) {
+          newLines.push(lines[range.start.line].substring(0, range.start.character) + text + lines[range.end.line].substring(range.end.character));
+        } else {
+          newLines.push(lines[range.start.line].substring(0, range.start.character) + editLines[0]);
+          newLines.push(...editLines.slice(1, -1));
+          newLines.push(editLines[editLines.length - 1] + lines[range.end.line].substring(range.end.character));
+        }
+        newLines.push(...lines.slice(range.end.line + 1));
+        this.document.lines = newLines;
+
+        this.selection = range.clone();
+        const lastLine = editLines[editLines.length - 1];
+        const endOfLastLine = new Position(range.start.line + (editLines.length - 1), editLines.length > 1 ? lastLine.length : range.start.character + lastLine.length);
+        this.selection.end = endOfLastLine;
+
+        this.edits.push({ range: range.toString(), from, to: this.renderWithSelection() });
+      }
+    });
+  }
+}
+
+class FileSystemWatcher {
+  readonly didCreate = new EventEmitter<Uri>();
+  readonly didChange = new EventEmitter<Uri>();
+  readonly didDelete = new EventEmitter<Uri>();
+  readonly onDidCreate = this.didCreate.event;
+  readonly onDidChange = this.didChange.event;
+  readonly onDidDelete = this.didDelete.event;
+  constructor(readonly vscode: VSCode, readonly glob: string) { }
+
+  dispose() {
+    this.vscode.fsWatchers.delete(this);
+    this.didCreate.dispose();
+    this.didChange.dispose();
+    this.didDelete.dispose();
+  }
+}
+
+type DebugConfiguration  = {
+  type: string;
+  name: string;
+  request: string;
+  [key: string]: any;
+};
+
+class Debug {
+  private _didStartDebugSession = new EventEmitter<DebugSession>();
+  private _didTerminateDebugSession = new EventEmitter<DebugSession>();
+  readonly onDidStartDebugSession = this._didStartDebugSession.event;
+  readonly onDidTerminateDebugSession = this._didTerminateDebugSession.event;
+  output = '';
+  dapFactories: any[] = [];
+  private _dapSniffer: any;
+  private _debuggerProcess?: ChildProcessWithoutNullStreams;
+
+  constructor() {
+  }
+
+  registerDebugAdapterTrackerFactory(type: string, factory: any) {
+    this.dapFactories.push(factory);
+  }
+
+  async startDebugging(folder: WorkspaceFolder | undefined, configuration: DebugConfiguration, parentSession?: DebugSession): Promise<boolean> {
+    const session = new DebugSession('<extension-id>', configuration.type, configuration.name, folder, configuration, parentSession);
+    for (const factory of this.dapFactories)
+      this._dapSniffer = factory.createDebugAdapterTracker(session);
+    this._didStartDebugSession.fire(session);
+    const node = await which('node');
+    this._debuggerProcess = spawn(node, [configuration.program, ...configuration.args], {
+      cwd: configuration.cwd,
+      stdio: 'pipe',
+      env: { ...configuration.env, VSCODE_MOCK_DEBUGGING: '1' },
+    });
+
+    this._debuggerProcess.stdout.on('data', data => {
+      this.output += data.toString();
+      this._dapSniffer.onDidSendMessage({
+        type: 'event',
+        event: 'output',
+        body: {
+          category: 'stdout',
+          output: data.toString(),
+        }
+      });
+    });
+    this._debuggerProcess.stderr.on('data', data => this.output += data.toString());
+    this._debuggerProcess.on('exit', () => this._didTerminateDebugSession.fire(session));
+    return true;
+  }
+
+  stopDebugging() {
+    this._debuggerProcess?.kill();
+  }
+
+  simulateStoppedOnError(error: string, location: { file: string; line: number; }) {
+    const errorText = `${error.replace(/\n/g, '\\n')}\n at ${location.file}:${location.line}:1 {matcherResult: ...}`;
+    this._dapSniffer.onDidSendMessage({
+      success: true,
+      type: 'response',
+      command: 'scopes',
+      body: {
+        scopes: [
+          {
+            name: 'Catch Block',
+            source: {
+              path: location.file,
+            },
+            line: location.line,
+            column: 0,
+          },
+        ],
+      }
+    });
+
+    this._dapSniffer.onDidSendMessage({
+      success: true,
+      type: 'response',
+      command: 'variables',
+      body: {
+        variables: [
+          {
+            type: 'ExpectError',
+            name: '__playwright_error__',
+            value: errorText,
+          },
+        ],
+      }
+    });
+  }
+
+  dispose() {
+    this._didStartDebugSession.dispose();
+    this._didTerminateDebugSession.dispose();
+  }
+}
+
+export class DebugSession {
+  constructor(
+    readonly id: string,
+    readonly type: string,
+    readonly name: string,
+    readonly workspaceFolder: WorkspaceFolder | undefined,
+    readonly configuration: DebugConfiguration,
+    readonly parentSession?: DebugSession,
+  ) {}
+
+  async customRequest(command: string, args?: any) {}
+
+  async getDebugProtocolBreakpoint() {}
+}
+
+export enum TestRunProfileKind {
+  Run = 1,
+  Debug = 2,
+  Coverage = 3,
+}
+
+class MarkdownString {
+  readonly md: string[] = [];
+
+  appendMarkdown(md: string) {
+    this.md.push(md);
+  }
+
+  render(): string {
+    return this.md.join('\n').replace(/&nbsp;/g, ' ');
+  }
+}
+
+class TestTag {
+  name: string;
+  constructor(name: string) {
+    this.name = name.replace(/.*playwright.config.[tj]s:/, '');
+  }
+}
+
+class DiagnosticsCollection {
+  readonly _entries = new Map<string, Diagnostic[]>();
+
+  set(uri: Uri, diagnostics: Diagnostic[]) {
+    this._entries.set(uri.toString(), diagnostics);
+  }
+
+  get(uri: Uri) {
+    return this._entries.get(uri.toString()) || [];
+  }
+
+  delete(uri: Uri) {
+    this._entries.delete(uri.toString());
+  }
+
+  clear() {
+    this._entries.clear();
+  }
+}
+
+class L10n {
+  readonly accessedMessages = new Set<string>();
+
+  t(message: string, ...args: Array<string | number | boolean>): string {
+    this.accessedMessages.add(message);
+    return message.replace(/{(\d+)}/g, function(match: string, idx) {
+      return (args[parseInt(idx, 10)] ?? match) as string;
+    });
+  }
+}
+
+enum UIKind {
+  Desktop = 1,
+  Web = 2
+}
+
+type HoverProvider = {
+  provideHover?(document: TextDocument, position: Position, token: CancellationToken): void
+};
+
+class LogOutputChannel {
+  debug() {}
+  info() {}
+  warn() {}
+  error() {}
+  trace() {}
+}
+
+export class VSCode {
+  isUnderTest = true;
+  CancellationTokenSource = CancellationTokenSource;
+  ColorThemeKind = ColorThemeKind;
+  DiagnosticSeverity = DiagnosticSeverity;
+  EventEmitter = EventEmitter;
+  Location = Location;
+  MarkdownString = MarkdownString;
+  Position = Position;
+  Range = Range;
+  Selection = Selection;
+  TestTag = TestTag;
+  TestMessage = TestMessage;
+  TestMessageStackFrame = TestMessageStackFrame;
+  TestRunProfileKind = TestRunProfileKind;
+  TestRunRequest = TestRunRequest;
+  Uri = Uri;
+  UIKind = UIKind;
+  commands: any = {};
+  debug: Debug;
+  languages: any = {};
+  tests: any = {};
+  window: any = {};
+  workspace: any = {};
+  env: any = {
+    uiKind: UIKind.Desktop,
+    remoteName: undefined,
+    openExternal: (url: any) => {
+      if (url) this.openExternalUrls.push(url.toString());
+    },
+    asExternalUri: (uri: Uri) => Promise.resolve(uri),
+  };
+  ProgressLocation = { Notification: 1 };
+  ViewColumn = { Active: -1 };
+
+  private _didChangeActiveTextEditor = new EventEmitter();
+  private _didChangeVisibleTextEditors = new EventEmitter();
+  private _didChangeTextEditorSelection = new EventEmitter();
+  private _didChangeWorkspaceFolders = new EventEmitter();
+  private _didChangeTextDocument = new EventEmitter();
+  private _didChangeConfiguration = new EventEmitter();
+  private _didShowInputBox = new EventEmitter<any>();
+
+  readonly onDidChangeActiveTextEditor = this._didChangeActiveTextEditor.event;
+  readonly onDidChangeTextEditorSelection = this._didChangeTextEditorSelection.event;
+  readonly onDidChangeVisibleTextEditors = this._didChangeVisibleTextEditors.event;
+  readonly onDidChangeWorkspaceFolders = this._didChangeWorkspaceFolders.event;
+  readonly onDidChangeTextDocument = this._didChangeTextDocument.event;
+  readonly onDidChangeConfiguration = this._didChangeConfiguration.event;
+  readonly onDidShowInputBox = this._didShowInputBox.event;
+
+  readonly testControllers: TestController[] = [];
+  readonly fsWatchers = new Set<FileSystemWatcher>();
+  readonly warnings: string[] = [];
+  readonly errors: string[] = [];
+  readonly context: { subscriptions: any[]; extensionUri: Uri; workspaceState: any };
+  readonly extensions: any[] = [];
+  private _webviewProviders = new Map<string, any>();
+  private _browser: Browser;
+  private _webViewsByPanelType = new Map<string, Set<Page>>();
+  readonly webViews = new Map<string, Page>();
+  readonly commandLog: string[] = [];
+  readonly l10n = new L10n();
+  lastWithProgressData: any;
+  lastWithProgressToken?: CancellationTokenSource;
+  private _hoverProviders: Map<string, HoverProvider> = new Map();
+  readonly version: string;
+  readonly connectionLog: any[] = [];
+  readonly openExternalUrls: string[] = [];
+  readonly diagnosticsCollections: DiagnosticsCollection[] = [];
+  private _clipboardText = '';
+
+  constructor(readonly versionNumber: number, baseDir: string, browser: Browser) {
+    this.version = String(versionNumber);
+    const workspaceStateStorage = new Map();
+    const workspaceState = {
+      get: (key: string) => workspaceStateStorage.get(key),
+      update: (key: string, value: any) => workspaceStateStorage.set(key, value)
+    };
+    this.context = { subscriptions: [], extensionUri: Uri.file(baseDir), workspaceState };
+    this._browser = browser;
+    (globalThis as any).__logForTest = (message: any) => this.connectionLog.push(message);
+    const commands = new Map<string, () => Promise<void>>();
+    this.commands.registerCommand = (name: string, callback: () => Promise<void>) => {
+      commands.set(name, callback);
+      return disposable;
+    };
+    this.commands.executeCommand = async (name: string) => {
+      await commands.get(name)?.();
+      this.commandLog.push(name);
+    };
+    this.debug = new Debug();
+    this.context.subscriptions.push(
+        this.debug,
+        this._didChangeActiveTextEditor,
+        this._didChangeVisibleTextEditors,
+        this._didChangeTextEditorSelection,
+        this._didChangeWorkspaceFolders,
+        this._didChangeTextDocument,
+        this._didChangeConfiguration,
+        this._didShowInputBox,
+    );
+
+    this.languages.registerHoverProvider = (language: string, provider: HoverProvider) => {
+      this._hoverProviders.set(language, provider);
+      return disposable;
+    };
+    this.languages.emitHoverEvent = (language: string, document: TextDocument, position: Position, token: CancellationToken) => {
+      const provider = this._hoverProviders.get(language);
+      if (!provider)
+        return;
+      provider.provideHover?.(document, position, token);
+    };
+    this.languages.getDiagnostics = () => {
+      const result: Diagnostic[] = [];
+      for (const collection of this.diagnosticsCollections) {
+        for (const diagnostics of collection._entries.values())
+          result.push(...diagnostics);
+      }
+      return result;
+    };
+    this.languages.createDiagnosticCollection = () => {
+      const diagnosticsCollection = new DiagnosticsCollection();
+      this.diagnosticsCollections.push(diagnosticsCollection);
+      return diagnosticsCollection;
+    };
+    this.tests.createTestController = this._createTestController.bind(this);
+
+    let lastDecorationTypeId = 0;
+    this.window.onDidChangeActiveTextEditor = this.onDidChangeActiveTextEditor;
+    this.window.onDidChangeTextEditorSelection = this.onDidChangeTextEditorSelection;
+    this.window.didChangeTextEditorSelection = (textEditor: TextEditor, selection: Selection) => {
+      this._didChangeTextEditorSelection.fire({ textEditor, selections: [selection] });
+    };
+    this.window.onDidChangeVisibleTextEditors = this.onDidChangeVisibleTextEditors;
+    this.window.onDidChangeActiveColorTheme = () => disposable;
+    this.window.createTextEditorDecorationType = () => ++lastDecorationTypeId;
+    this.window.showWarningMessage = (message: string) => this.warnings.push(message);
+    this.window.showErrorMessage = (message: string) => this.errors.push(message);
+    this.window.visibleTextEditors = [];
+    this.window.registerTreeDataProvider = () => disposable;
+    this.window.registerWebviewViewProvider = (name: string, provider: any) => {
+      this._webviewProviders.set(name, provider);
+      return disposable;
+    };
+    this.window.createWebviewPanel = (viewType: string) => {
+      const { webview, pagePromise } = this._createWebviewAndPage();
+      const didDispose = new EventEmitter<void>();
+      const didChangeViewState = new EventEmitter<{ webviewPanel: any }>();
+      const panel: any = {};
+      panel.onDidDispose = didDispose.event;
+      panel.onDidChangeViewState = didChangeViewState.event;
+      panel.webview = webview;
+      panel.visible = true;
+      webview.onDidChangeVisibility((visibilityState: string) => {
+        panel.visible = visibilityState === 'visible';
+        didChangeViewState.fire({ webviewPanel: panel });
+      });
+      void pagePromise.then(webview => {
+        if (!webview) {
+          // test ended.
+          return;
+        }
+        webview.on('close', () => {
+          panel.dispose();
+          webviews.delete(webview);
+        });
+        const webviews = this._webViewsByPanelType.get(viewType) ?? new Set();
+        webviews.add(webview);
+        this._webViewsByPanelType.set(viewType, webviews);
+      });
+      panel.dispose = () => {
+        void pagePromise.then(page => page?.close());
+        didDispose.fire();
+      };
+      return panel;
+    };
+    this.window.createInputBox = () => {
+      const didAccept = new EventEmitter<void>();
+      const didChange = new EventEmitter<string>();
+      const didHide = new EventEmitter<void>();
+      const didAssignValue = new EventEmitter<string>();
+      let value = '';
+      const inputBox = {
+        onDidAccept: didAccept.event,
+        onDidChangeValue: didChange.event,
+        onDidHide: didHide.event,
+        onDidAssignValue: didAssignValue.event,
+        set value(val: string) {
+          value = val;
+          didAssignValue.fire(val);
+        },
+        get value() {
+          return value;
+        },
+        dispose: () => {},
+        accept: () => didAccept.fire(),
+        hide: () => didHide.fire(),
+        show: () => this._didShowInputBox.fire(inputBox),
+      };
+      return inputBox;
+    };
+    this.window.withProgress = async (opts: any, callback: any) => {
+      const progress = {
+        report: (data: any) => this.lastWithProgressData = data,
+      };
+      this.lastWithProgressToken = new CancellationTokenSource();
+      await callback(progress, this.lastWithProgressToken.token);
+      this.lastWithProgressData = 'finished';
+    };
+    this.window.showTextDocument = (document: TextDocument) => {
+      const editor = new TextEditor(document);
+      this.window.visibleTextEditors.push(editor);
+      this.window.activeTextEditor = editor;
+      this._didChangeVisibleTextEditors.fire(this.window.visibleTextEditors);
+      this._didChangeActiveTextEditor.fire(this.window.activeTextEditor);
+      return editor;
+    };
+    this.window.showQuickPick = async (options: any) => {
+      return this.window.mockQuickPick(options);
+    };
+    this.window.registerTerminalLinkProvider = () => disposable;
+    Object.defineProperty(this.window, 'activeColorTheme', {
+      get: () => {
+        const theme: string = this.workspace.getConfiguration('workbench').get('colorTheme', 'Dark Modern');
+        const kind = /Dark/i.test(theme) ? 2 : 1;
+        return { kind };
+      },
+    });
+    this.window.createOutputChannel = () => new LogOutputChannel();
+
+    this.workspace.onDidChangeWorkspaceFolders = this.onDidChangeWorkspaceFolders;
+    this.workspace.onDidChangeTextDocument = this.onDidChangeTextDocument;
+    this.workspace.onDidChangeConfiguration = this.onDidChangeConfiguration;
+    this.workspace.createFileSystemWatcher = (glob: string) => {
+      const watcher = new FileSystemWatcher(this, glob);
+      this.fsWatchers.add(watcher);
+      return watcher;
+    };
+    this.workspace.workspaceFolders = [];
+    this.workspace.openTextDocument = async (file: string) => {
+      const document = new TextDocument(Uri.file(file));
+      await document._load();
+      return document;
+    };
+
+    this.workspace.findFiles = async (pattern: string) => {
+      const uris: Uri[] = [];
+      for (const workspaceFolder of this.workspace.workspaceFolders) {
+        await new Promise<void>(f => {
+          const cwd = workspaceFolder.uri.fsPath;
+          glob(pattern, { cwd }, (err, files) => {
+            uris.push(...files.map(f => Uri.file(path.join(cwd, f))));
+            f();
+          });
+        });
+      }
+      return uris;
+    };
+
+    this.workspace.getWorkspaceFolder = (uri: Uri): WorkspaceFolder | undefined => {
+      for (const workspaceFolder of this.workspace.workspaceFolders) {
+        if (uri.fsPath.startsWith(workspaceFolder.uri.fsPath))
+          return workspaceFolder;
+      }
+    };
+    const settings: Record<string, any> = {
+      'workbench.colorTheme': 'Dark Modern',
+    };
+    const { properties } = require('../../package.json').contributes.configuration;
+    for (const [key, value] of Object.entries(properties))
+      settings[key] = (value as any).default;
+
+    this.workspace.getConfiguration = (scope: string) => {
+      return {
+        get: (key: string) => settings[scope + '.' + key],
+        update: (key: string, value: any, notifyListeners?: boolean) => {
+          settings[scope + '.' + key] = value;
+          if (notifyListeners) {
+            this._didChangeConfiguration.fire({
+              affectsConfiguration: (prefix: string) => (scope + '.' + key).startsWith(prefix)
+            });
+          }
+        },
+        inspect: (key: string) => {
+          return { defaultValue: false, globalValue: settings[scope + '.' + key] };
+        },
+      };
+    };
+
+    this.env.clipboard = {
+      writeText: async (text: string) => this._clipboardText = text,
+      readText: async () => this._clipboardText,
+    };
+  }
+
+  async activate() {
+    for (const extension of this.extensions)
+      await extension.activate();
+
+    for (const [name, provider] of this._webviewProviders) {
+      const { webview, pagePromise } = this._createWebviewAndPage();
+      provider?.resolveWebviewView({ webview, onDidChangeVisibility: () => disposable });
+      const page = await pagePromise;
+      if (page)
+        this.webViews.set(name, page);
+    }
+  }
+
+  dispose() {
+    for (const d of this.context.subscriptions)
+      d.dispose();
+  }
+
+  webViewsByPanelType(viewType: string) {
+    const webviews = this._webViewsByPanelType.get(viewType);
+    return webviews ? [...webviews] : [];
+  }
+
+  async changeVisibility(webview: Page, state: 'visible' | 'hidden') {
+    if (state === 'visible')
+      await webview.goto('http://localhost');
+    else
+      await webview.goto('http://localhost/hidden');
+  }
+
+  private _createWebviewAndPage() {
+    let initializedPage: Page | undefined = undefined;
+    const webview: any = {};
+    webview.asWebviewUri = (uri: Uri) => path.relative(this.context.extensionUri.fsPath, uri.fsPath).replace(/\\/g, '/');
+    const didReceiveMessage = new EventEmitter<any>();
+    const didChangeVisibility = new EventEmitter<'visible' | 'hidden'>();
+    webview.onDidReceiveMessage = didReceiveMessage.event;
+    webview.onDidChangeVisibility = didChangeVisibility.event;
+    webview.cspSource = 'http://localhost/';
+    const pendingMessages: any[] = [];
+    webview.postMessage = (data: any) => {
+      if (!initializedPage) {
+        pendingMessages.push(data);
+        return;
+      }
+      initializedPage.evaluate((data: any) => {
+        const event = new globalThis.Event('message');
+        (event as any).data = data;
+        (globalThis as any).dispatchEvent(event);
+      }, data).catch(() => {});
+    };
+    const createPage = async () => {
+      const context = await this._browser.newContext();
+      const page = await context.newPage();
+      await page.route('**/*', async route => {
+        const url = route.request().url();
+        if (!url.startsWith('http://localhost/')) {
+          await route.continue();
+        } else if (url === 'http://localhost/') {
+          await route.fulfill({ body: webview.html });
+        } else if (url === 'http://localhost/hidden') {
+          await route.fulfill({ body: 'hidden webview' });
+        } else {
+          const suffix = url.substring('http://localhost/'.length);
+          const buffer = fs.readFileSync(path.join(this.context.extensionUri.fsPath, suffix));
+          await route.fulfill({ body: buffer });
+        }
+      });
+      page.on('load', () => {
+        const url = page.url();
+        if (url === 'http://localhost/')
+          didChangeVisibility.fire('visible');
+        else if (url === 'http://localhost/hidden')
+          didChangeVisibility.fire('hidden');
+      });
+      await page.addInitScript(() => {
+        (globalThis as any).acquireVsCodeApi = () => globalThis;
+      });
+      await page.goto('http://localhost');
+      await page.exposeFunction('postMessage', (data: any) => didReceiveMessage.fire(data));
+      this.context.subscriptions.push({
+        dispose: () => {
+          context.close().catch(() => {});
+        }
+      });
+      initializedPage = page;
+      for (const m of pendingMessages)
+        webview.postMessage(m);
+      return page;
+    };
+    const pagePromise = createPage().catch(() => null);
+    return { webview, pagePromise };
+  }
+
+  private _createTestController(id: string, label: string): TestController {
+    const testController = new TestController(this, id, label);
+    this.testControllers.push(testController);
+    return testController;
+  }
+
+  async addWorkspaceFolder(rootFolder: string, files?: { [key: string]: string }): Promise<WorkspaceFolder> {
+    const workspaceFolder = new WorkspaceFolder(this, path.basename(rootFolder), Uri.file(rootFolder));
+    this.workspace.workspaceFolders.push(workspaceFolder);
+    await fs.promises.mkdir(rootFolder, { recursive: true });
+    await workspaceFolder.addFile('package.json', '{}', true);
+    if (files) {
+      for (const [fsPath, content] of Object.entries(files))
+        await workspaceFolder.addFile(fsPath, content, true);
+    }
+    this._didChangeWorkspaceFolders.fire(undefined);
+    return workspaceFolder;
+  }
+
+  async openEditors(glob: string) {
+    const uris = await this.workspace.findFiles(glob);
+    this.window.activeTextEditor = undefined;
+    this.window.visibleTextEditors = [];
+    for (const uri of uris) {
+      const editor = new TextEditor(new TextDocument(uri));
+      await editor.document._load();
+      if (!this.window.activeTextEditor)
+        this.window.activeTextEditor = editor;
+      this.window.visibleTextEditors.push(editor);
+    }
+    this._didChangeVisibleTextEditors.fire(this.window.visibleTextEditors);
+    this._didChangeActiveTextEditor.fire(this.window.activeTextEditor);
+    return this.window.visibleTextEditors;
+  }
+
+  async renderProjectTree(): Promise<string> {
+    const result: string[] = [''];
+    const webView = this.webViews.get('playwright-repl.settingsView')!;
+    const selectedConfig = await webView.getByTestId('models').evaluate((e: HTMLSelectElement) => e.selectedOptions[0].textContent);
+    result.push(`    config: ${selectedConfig}`);
+    const projectLocators = await webView.getByTestId('projects').locator('div').locator('label').filter({ visible: true }).all();
+    for (const projectLocator of projectLocators) {
+      const checked = await projectLocator.locator('input').isChecked();
+      const name = await projectLocator.textContent();
+      result.push(`    ${checked ? '[x]' : '[ ]'} ${name}`);
+    }
+    return result.join('\n');
+  }
+}
+
+function trimLog(log: string) {
+  return log.split('\n').map(line => line.trimEnd()).join('\n');
+}
+
+const ansiRegex = new RegExp('[\\u001B\\u009B][[\\]()#;?]*(?:(?:(?:[a-zA-Z\\d]*(?:;[-a-zA-Z\\d\\/#&.:=?%@~_]*)*)?\\u0007)|(?:(?:\\d{1,4}(?:;\\d{0,4})*)?[\\dA-PR-TZcf-ntqry=><~]))', 'g');
+export function stripAnsi(str: string): string {
+  return str.replace(ansiRegex, '');
+}

--- a/packages/vscode/tests/pick-selector.spec.ts
+++ b/packages/vscode/tests/pick-selector.spec.ts
@@ -1,0 +1,153 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { selectors } from '@playwright/test';
+import { connectToSharedBrowser, expect, test, waitForPage, waitForRecorderMode } from './utils';
+
+// Our fork replaced the upstream ReusedBrowser picker with BrowserManager-based Picker.
+// These tests exercise the upstream codepath (ReusedBrowser.inspect) which no longer applies.
+// TODO: Phase 5 will add tests for our Picker implementation.
+test.skip();
+
+test('should pick locator and dismiss the toolbar', async ({ activate }) => {
+  const { vscode } = await activate({
+    'playwright.config.js': `module.exports = {}`,
+  });
+
+  const settingsView = vscode.webViews.get('playwright-repl.settingsView')!;
+  await settingsView.getByText('Pick locator').click();
+  await waitForRecorderMode(vscode, 'inspecting');
+
+  const browser = await connectToSharedBrowser(vscode);
+  const page = await waitForPage(browser);
+  await page.setContent(`
+    <h1>Hello</h1>
+    <h1>World</h1>
+  `);
+  await page.locator('h1').first().click();
+
+  const locatorsView = vscode.webViews.get('playwright-repl.locatorsView')!;
+  await expect(locatorsView.locator('body')).toMatchAriaSnapshot(`
+    - text: Locator
+    - textbox "Locator": "getByRole('heading', { name: 'Hello' })"
+  `);
+
+  await expect(locatorsView.locator('body')).toMatchAriaSnapshot(`
+    - text: Locator
+    - textbox "Locator": "getByRole('heading', { name: 'Hello' })"
+    - text: Aria
+    - textbox "Aria": "- heading \\"Hello\\" [level=1]"
+  `);
+
+  await page.click('x-pw-tool-item.pick-locator');
+  await expect(page.locator('x-pw-tool-item.pick-locator')).toBeHidden();
+  await waitForRecorderMode(vscode, 'none');
+});
+
+test('should highlight locator on edit', async ({ activate }) => {
+  const { vscode } = await activate({
+    'playwright.config.js': `module.exports = {}`,
+  });
+
+  const settingsView = vscode.webViews.get('playwright-repl.settingsView')!;
+  await settingsView.getByText('Pick locator').click();
+  await waitForRecorderMode(vscode, 'inspecting');
+
+  const browser = await connectToSharedBrowser(vscode);
+  const page = await waitForPage(browser);
+  await page.setContent(`
+    <h1>Hello</h1>
+    <button>World</button>
+  `);
+  const box = await page.getByRole('heading', { name: 'Hello' }).boundingBox();
+
+  const locatorsView = vscode.webViews.get('playwright-repl.locatorsView')!;
+  await locatorsView.getByRole('textbox', { name: 'Locator' }).fill('h1');
+
+  await expect(page.locator('x-pw-highlight')).toBeVisible();
+  expect(await page.locator('x-pw-highlight').boundingBox()).toEqual(box);
+});
+
+test('should copy locator to clipboard', async ({ activate }) => {
+  const { vscode } = await activate({
+    'playwright.config.js': `module.exports = {}`,
+  });
+
+  const locatorsView = vscode.webViews.get('playwright-repl.locatorsView')!;
+  await locatorsView.getByRole('checkbox', { name: 'Copy on pick' }).check();
+  await locatorsView.getByRole('button', { name: 'Pick locator' }).first().click();
+  await waitForRecorderMode(vscode, 'inspecting');
+
+  const browser = await connectToSharedBrowser(vscode);
+  const page = await waitForPage(browser);
+  await page.setContent(`
+    <h1>Hello</h1>
+    <h1>World</h1>
+  `);
+  await page.locator('h1').first().click();
+
+  await expect.poll(() => vscode.env.clipboard.readText()).toBe(`getByRole('heading', { name: 'Hello' })`);
+});
+
+test('should pick locator and use the testIdAttribute from the config', async ({ activate }) => {
+  const { vscode } = await activate({
+    'playwright.config.js': `module.exports = { use: { testIdAttribute: 'data-testerid' } }`,
+  });
+
+  const settingsView = vscode.webViews.get('playwright-repl.settingsView')!;
+  await settingsView.getByText('Pick locator').click();
+  await waitForRecorderMode(vscode, 'inspecting');
+
+  const browser = await connectToSharedBrowser(vscode);
+  // TODO: Get rid of 'selectors.setTestIdAttribute' once launchServer multiclient is stable and migrate to it.
+  // This is a workaround for waitForPage which internally uses Browser._newContextForReuse
+  // which ends up overriding the testIdAttribute back to 'data-testid'.
+  selectors.setTestIdAttribute('data-testerid');
+  const page = await waitForPage(browser);
+  await page.setContent(`
+    <div data-testerid="hello">Hello</div>
+  `);
+  await page.locator('div').click();
+
+  const locatorsView = vscode.webViews.get('playwright-repl.locatorsView')!;
+  await expect(locatorsView.locator('body')).toMatchAriaSnapshot(`
+    - text: Locator
+    - textbox "Locator": "getByTestId('hello')"
+  `);
+  // TODO: remove as per TODO above.
+  selectors.setTestIdAttribute('data-testid');
+});
+
+test('running test should dismiss the toolbar', async ({ activate, showBrowser }) => {
+  test.skip(!showBrowser);
+
+  const { vscode, testController } = await activate({
+    'playwright.config.js': `module.exports = {}`,
+    'tests/test.spec.ts': `
+      import { test } from '@playwright/test';
+      test('one', () => {});
+    `,
+  });
+
+  const settingsView = vscode.webViews.get('playwright-repl.settingsView')!;
+  await settingsView.getByRole('button', { name: 'Pick locator' }).click();
+  await waitForRecorderMode(vscode, 'inspecting');
+
+  const testRun = await testController.run();
+  await expect(testRun).toHaveOutput('passed');
+
+  await waitForRecorderMode(vscode, 'none');
+});

--- a/packages/vscode/tests/playwright.config.ts
+++ b/packages/vscode/tests/playwright.config.ts
@@ -22,7 +22,7 @@ export default defineConfig<WorkerOptions>({
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 2,
-  workers: process.env.CI ? 1 : 4,
+  workers: process.env.CI ? 2 : 4,
   reporter: process.env.CI ? [
     ['line'],
     ['blob'],

--- a/packages/vscode/tests/playwright.config.ts
+++ b/packages/vscode/tests/playwright.config.ts
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { defineConfig } from '@playwright/test';
+import { WorkerOptions } from './utils';
+
+export default defineConfig<WorkerOptions>({
+  testDir: '.',
+  outputDir: './test-results/inner',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 2,
+  workers: process.env.CI ? 1 : 4,
+  reporter: process.env.CI ? [
+    ['line'],
+    ['blob'],
+  ] : [
+    ['line']
+  ],
+  tag: process.env.PW_TAG,  // Set when running vscode extension tests in playwright repo CI.
+  projects: [
+    {
+      name: 'default',
+    },
+    {
+      name: 'default-reuse',
+      use: {
+        showBrowser: true,
+      }
+    },
+    {
+      name: 'default-trace',
+      use: {
+        showTrace: true,
+      }
+    },
+  ]
+});

--- a/packages/vscode/tests/pnp.spec.ts
+++ b/packages/vscode/tests/pnp.spec.ts
@@ -1,0 +1,80 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { enableConfigs, expect, test } from './utils';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+// --experimental-loader is deprecated in Node 22+; the ESM loader portion fails.
+test.skip('should pick up .pnp.cjs file closest to config', async ({ activate }, testInfo) => {
+  const pnpCjsOutfile = testInfo.outputPath('pnp-cjs.txt');
+  const esmLoaderInfile = testInfo.outputPath('esm-loader-in.txt');
+  const esmLoaderOutfile = testInfo.outputPath('esm-loader-out.txt');
+  await fs.writeFile(esmLoaderInfile, 'untouched');
+
+  const { vscode, testController, workspaceFolder } = await activate({
+    '.pnp.cjs': `
+      const fs = require("node:fs");
+      fs.writeFileSync(${JSON.stringify(pnpCjsOutfile)}, "root");
+    `,
+    '.pnp.loader.mjs': `
+      import fs from 'node:fs';
+      fs.copyFileSync(${JSON.stringify(esmLoaderInfile)}, ${JSON.stringify(esmLoaderOutfile)});
+    `,
+    'apps/tests/tests/root.spec.ts': `
+      import { test } from '@playwright/test';
+      test('should pass', async () => {});
+    `,
+
+    'foo/playwright.config.js': `module.exports = { testDir: 'tests' }`,
+    'foo/.pnp.cjs': `
+      const fs = require("node:fs");
+      fs.writeFileSync(${JSON.stringify(pnpCjsOutfile)}, "foo");
+    `,
+    'foo/tests/foo.spec.ts': `
+      import { test } from '@playwright/test';
+      test('should pass', async () => {});
+    `,
+  });
+
+  await expect(testController).toHaveTestTree(`
+    -   foo
+      -   tests
+        -   foo.spec.ts
+  `);
+
+  let testRun = await testController.run();
+  expect(testRun.renderLog()).toContain('passed');
+  expect(await fs.readFile(pnpCjsOutfile, 'utf-8')).toBe('foo');
+
+  await workspaceFolder.addFile('apps/tests/playwright.config.js', `module.exports = { testDir: 'tests' }`);
+  await enableConfigs(vscode, [`apps${path.sep}tests${path.sep}playwright.config.js`, `foo${path.sep}playwright.config.js`]);
+  await expect(testController).toHaveTestTree(`
+    -   apps
+      -   tests
+        -   tests
+          -   root.spec.ts
+    -   foo
+      -   tests
+        -   foo.spec.ts
+  `);
+
+  await fs.writeFile(esmLoaderInfile, 'root');
+  testRun = await testController.run(testController.findTestItems(/root/));
+  expect(testRun.renderLog()).toContain('passed');
+  expect(await fs.readFile(pnpCjsOutfile, 'utf-8')).toBe('root');
+  expect(await fs.readFile(esmLoaderOutfile, 'utf-8')).toBe('root');
+});

--- a/packages/vscode/tests/problems.spec.ts
+++ b/packages/vscode/tests/problems.spec.ts
@@ -1,0 +1,92 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { expect, test } from './utils';
+
+test('should list tests on expand', async ({ activate }) => {
+  const { vscode, testController } = await activate({
+    'playwright.config.js': `module.exports = { testDir: 'tests' }`,
+    'tests/test.spec.ts': `
+      import { test } from '@playwright/test';
+      test('one', async ({ page }) => {
+        const
+        await page.goto('http://example.com');
+      });
+    `,
+  });
+
+  await testController.expandTestItems(/test.spec.ts/);
+  await expect(testController).toHaveTestTree(`
+    -   tests
+      -   test.spec.ts
+  `);
+  expect(vscode.diagnosticsCollections.length).toBe(1);
+  expect([...vscode.diagnosticsCollections[0]._entries]).toEqual([
+    [
+      expect.stringContaining('test.spec.ts'),
+      [
+        {
+          message: expect.stringMatching(/^SyntaxError: tests[/\\]test.spec.ts: Unexpected reserved word 'await'. \(5:8\)$/),
+          range: {
+            end: { character: 0, line: 5 },
+            start: { character: 7, line: 4 }
+          },
+          severity: 'Error',
+          source: 'playwright'
+        }
+      ]
+    ]
+  ]);
+});
+
+test('should update diagnostics on file change', async ({ activate }) => {
+  const { vscode, testController, workspaceFolder } = await activate({
+    'playwright.config.js': `module.exports = { testDir: 'tests' }`,
+    'tests/test.spec.ts': `
+      import { test } from '@playwright/test';
+      test('one', async ({ page }) => {
+        const
+        await page.goto('http://example.com');
+      });
+    `,
+  });
+
+  await testController.expandTestItems(/test.spec.ts/);
+  await expect(testController).toHaveTestTree(`
+    -   tests
+      -   test.spec.ts
+  `);
+  expect(vscode.diagnosticsCollections.length).toBe(1);
+  expect([...vscode.diagnosticsCollections[0]._entries]).toEqual([
+    [
+      expect.stringContaining('test.spec.ts'),
+      [
+        expect.objectContaining({
+          message: expect.stringContaining('SyntaxError'),
+          source: 'playwright',
+        })
+      ]
+    ]
+  ]);
+
+  await workspaceFolder.changeFile('tests/test.spec.ts', `
+    import { test } from '@playwright/test';
+    test('one', async ({ page }) => {
+      await page.goto('http://example.com');
+    });
+  `);
+  await expect.poll(() => vscode.diagnosticsCollections[0]._entries.size).toBe(0);
+});

--- a/packages/vscode/tests/project-setup.spec.ts
+++ b/packages/vscode/tests/project-setup.spec.ts
@@ -1,0 +1,148 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { enableProjects, expect, test } from './utils';
+
+const testsWithSetup = {
+  'playwright.config.ts': `
+    import { defineConfig } from '@playwright/test';
+    export default defineConfig({
+      projects: [
+        { name: 'setup', teardown: 'teardown', testMatch: 'setup.ts' },
+        { name: 'test', testMatch: 'test.ts', dependencies: ['setup'] },
+        { name: 'teardown', testMatch: 'teardown.ts' },
+      ]
+    });
+  `,
+  'setup.ts': `
+    import { test, expect } from '@playwright/test';
+    test('setup', async ({}) => {
+      console.log('from-setup');
+    });
+  `,
+  'test.ts': `
+    import { test, expect } from '@playwright/test';
+    test('test', async ({}) => {
+      console.log('from-test');
+    });
+  `,
+  'teardown.ts': `
+    import { test, expect } from '@playwright/test';
+    test('teardown', async ({}) => {
+      console.log('from-teardown');
+    });
+  `,
+};
+
+test('should run setup and teardown projects (1)', async ({ activate }) => {
+  const { vscode, testController } = await activate(testsWithSetup);
+  await enableProjects(vscode, ['setup', 'teardown', 'test']);
+  const testRun = await testController.run();
+
+  await expect(testController).toHaveTestTree(`
+    -   setup.ts
+      - ✅ setup [2:0]
+    -   teardown.ts
+      - ✅ teardown [2:0]
+    -   test.ts
+      - ✅ test [2:0]
+  `);
+
+  const output = testRun.renderLog({ output: true });
+  expect(output).toContain('from-setup');
+  expect(output).toContain('from-test');
+  expect(output).toContain('from-teardown');
+
+  // Ensure the rendered order of the projects is correct.
+  const webView = vscode.webViews.get('playwright-repl.settingsView')!;
+  await expect(webView.getByTestId('projects').locator('div').locator('label')).toHaveText([
+    'setup',
+    'test',
+    'teardown',
+  ]);
+});
+
+test('should run setup and teardown projects (2)', async ({ activate }) => {
+  const { vscode, testController } = await activate(testsWithSetup);
+  await enableProjects(vscode, ['teardown', 'test']);
+  const testRun = await testController.run();
+
+  await expect(testController).toHaveTestTree(`
+    -   teardown.ts
+      - ✅ teardown [2:0]
+    -   test.ts
+      - ✅ test [2:0]
+    -    [playwright.config.ts [setup] — disabled]
+  `);
+
+  const output = testRun.renderLog({ output: true });
+  expect(output).not.toContain('from-setup');
+  expect(output).toContain('from-test');
+  expect(output).toContain('from-teardown');
+});
+
+test('should run setup and teardown projects (3)', async ({ activate }) => {
+  const { vscode, testController } = await activate(testsWithSetup);
+  await enableProjects(vscode, ['test']);
+  const testRun = await testController.run();
+
+  await expect(testController).toHaveTestTree(`
+    -   test.ts
+      - ✅ test [2:0]
+    -    [playwright.config.ts [setup] — disabled]
+    -    [playwright.config.ts [teardown] — disabled]
+  `);
+
+  const output = testRun.renderLog({ output: true });
+  expect(output).not.toContain('from-setup');
+  expect(output).toContain('from-test');
+  expect(output).not.toContain('from-teardown');
+});
+
+test('should run part of the setup only', async ({ activate }) => {
+  const { vscode, testController } = await activate(testsWithSetup);
+  await enableProjects(vscode, ['setup', 'teardown', 'test']);
+
+  await testController.expandTestItems(/setup.ts/);
+  const testItems = testController.findTestItems(/setup/);
+  await testController.run(testItems);
+
+  await expect(testController).toHaveTestTree(`
+    -   setup.ts
+      - ✅ setup [2:0]
+    -   teardown.ts
+      - ✅ teardown [2:0]
+    -   test.ts
+  `);
+});
+
+test('should run setup and teardown for test', async ({ activate }) => {
+  const { vscode, testController } = await activate(testsWithSetup);
+  await enableProjects(vscode, ['setup', 'teardown', 'test']);
+
+  await testController.expandTestItems(/test.ts/);
+  const testItems = testController.findTestItems(/test/);
+  await testController.run(testItems);
+
+  await expect(testController).toHaveTestTree(`
+    -   setup.ts
+      - ✅ setup [2:0]
+    -   teardown.ts
+      - ✅ teardown [2:0]
+    -   test.ts
+      - ✅ test [2:0]
+  `);
+});

--- a/packages/vscode/tests/project-tree.spec.ts
+++ b/packages/vscode/tests/project-tree.spec.ts
@@ -1,0 +1,213 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { enableConfigs, enableProjects, expect, test } from './utils';
+import path from 'path';
+
+test('should switch between configs', async ({ activate }) => {
+  const { vscode, testController } = await activate({
+    'tests1/playwright.config.js': `module.exports = { testDir: '.', projects: [{ name: 'projectOne' }, { name: 'projectTwo' }] }`,
+    'tests2/playwright.config.js': `module.exports = { testDir: '.', projects: [{ name: 'projectThree' }, { name: 'projectFour' }] }`,
+    'tests1/test.spec.ts': `
+      import { test } from '@playwright/test';
+      test('one', async () => {});
+    `,
+    'tests2/test.spec.ts': `
+      import { test } from '@playwright/test';
+      test('one', async () => {});
+    `,
+  });
+  await expect(testController).toHaveTestTree(`
+    -   tests1
+      -   test.spec.ts
+  `);
+  await expect(vscode).toHaveProjectTree(`
+    config: tests1/playwright.config.js
+    [x] projectOne
+    [x] projectTwo
+  `);
+
+  await expect(vscode).toHaveConnectionLog([
+    { method: 'listFiles', params: {} },
+  ]);
+
+  await enableConfigs(vscode, [`tests2${path.sep}playwright.config.js`]);
+
+  await expect(vscode).toHaveProjectTree(`
+    config: tests2/playwright.config.js
+    [x] projectThree
+    [x] projectFour
+  `);
+
+  await expect(testController).toHaveTestTree(`
+    -   tests2
+      -   test.spec.ts
+  `);
+  await expect(vscode).toHaveConnectionLog([
+    { method: 'listFiles', params: {} },
+    { method: 'listFiles', params: {} },
+  ]);
+});
+
+test('should switch between projects', async ({ activate }) => {
+  const { vscode, testController } = await activate({
+    'playwright.config.js': `module.exports = {
+      projects: [
+        { name: 'projectOne', testDir: 'tests1', },
+        { name: 'projectTwo', testDir: 'tests2', },
+      ]
+    }`,
+    'tests1/test.spec.ts': `
+      import { test } from '@playwright/test';
+      test('one', async () => {});
+    `,
+    'tests2/test.spec.ts': `
+      import { test } from '@playwright/test';
+      test('two', async () => {});
+    `,
+  });
+
+  await enableProjects(vscode, ['projectOne']);
+
+  await expect(testController).toHaveTestTree(`
+    -   tests1
+      -   test.spec.ts
+    -    [playwright.config.js [projectTwo] — disabled]
+  `);
+
+  await expect(vscode).toHaveProjectTree(`
+    config: playwright.config.js
+    [x] projectOne
+    [ ] projectTwo
+  `);
+
+  await enableProjects(vscode, ['projectOne', 'projectTwo']);
+
+  await expect(vscode).toHaveProjectTree(`
+    config: playwright.config.js
+    [x] projectOne
+    [x] projectTwo
+  `);
+
+  await expect(testController).toHaveTestTree(`
+    -   tests1
+      -   test.spec.ts
+    -   tests2
+      -   test.spec.ts
+  `);
+
+  await enableProjects(vscode, ['projectTwo']);
+
+  await expect(vscode).toHaveProjectTree(`
+    config: playwright.config.js
+    [ ] projectOne
+    [x] projectTwo
+  `);
+});
+
+test('should hide unchecked projects', async ({ activate }) => {
+  const { vscode, testController } = await activate({
+    'playwright.config.js': `module.exports = {
+      projects: [
+        { name: 'projectOne', testDir: 'tests1', },
+        { name: 'projectTwo', testDir: 'tests2', },
+      ]
+    }`,
+    'tests1/test.spec.ts': `
+      import { test } from '@playwright/test';
+      test('one', async () => {});
+    `,
+    'tests2/test.spec.ts': `
+      import { test } from '@playwright/test';
+      test('two', async () => {});
+    `,
+  });
+
+  await enableProjects(vscode, ['projectOne']);
+
+  await expect(testController).toHaveTestTree(`
+    -   tests1
+      -   test.spec.ts
+    -    [playwright.config.js [projectTwo] — disabled]
+  `);
+
+  await expect(vscode).toHaveProjectTree(`
+    config: playwright.config.js
+    [x] projectOne
+    [ ] projectTwo
+  `);
+
+  await enableProjects(vscode, []);
+
+  await expect(vscode).toHaveProjectTree(`
+    config: playwright.config.js
+    [ ] projectOne
+    [ ] projectTwo
+  `);
+
+  await expect(testController).toHaveTestTree(`
+    -    [playwright.config.js [projectOne] — disabled]
+    -    [playwright.config.js [projectTwo] — disabled]
+  `);
+});
+
+test('should hide project section when there is just one', async ({ activate }) => {
+  const { vscode } = await activate({
+    'playwright.config.js': `module.exports = {
+      projects: [
+        { name: 'projectOne', testDir: 'tests1', },
+      ]
+    }`
+  });
+
+  const webView = vscode.webViews.get('playwright-repl.settingsView')!;
+  await expect(webView.getByRole('heading', { name: 'PROJECTS' })).not.toBeVisible();
+});
+
+test('should treat project as enabled when UI for it is hidden', async ({ activate }) => {
+  const { vscode, workspaceFolder, testController } = await activate({
+    'playwright.config.js': `module.exports = {
+      projects: [
+        { name: 'projectOne', testDir: 'tests1', },
+        { name: 'projectTwo', testDir: 'tests2', },
+      ]
+    }`,
+    'tests1/test.spec.ts': `
+      import { test } from '@playwright/test';
+      test('one', async () => {});
+    `,
+  });
+
+  const webView = vscode.webViews.get('playwright-repl.settingsView')!;
+
+  await enableProjects(vscode, ['projectTwo']);
+  await expect(vscode).toHaveProjectTree(`
+    config: playwright.config.js
+    [ ] projectOne
+    [x] projectTwo
+  `);
+
+  await workspaceFolder.changeFile('playwright.config.js', `module.exports = {
+    projects: [
+      { name: 'projectOne', testDir: 'tests1', },
+    ]
+  }`);
+  await expect(webView.getByRole('heading', { name: 'PROJECTS' })).not.toBeVisible();
+  await expect(testController).toHaveTestTree(`
+    -   tests1
+      -   test.spec.ts
+  `);
+});

--- a/packages/vscode/tests/run-annotations.spec.ts
+++ b/packages/vscode/tests/run-annotations.spec.ts
@@ -1,0 +1,69 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { expect, test } from './utils';
+
+test('should mark test as skipped', async ({ activate }) => {
+  const { vscode, testController } = await activate({
+    'playwright.config.js': `module.exports = { testDir: 'tests' }`,
+    'tests/test.spec.ts': `
+      import { test } from '@playwright/test';
+      test('pass', async () => {});
+      test('skipped', async () => {
+        test.skip(true, 'Test skipped');
+      });
+      test('fixme', async () => {
+        test.fixme(true, 'Test to be fixed');
+      });
+      test('fails', async () => {
+        test.fail(true, 'Test should fail');
+        expect(1).toBe(2);
+      });
+    `,
+  });
+
+  const testRun = await testController.run();
+  expect(testRun.renderLog()).toBe(`
+    tests > test.spec.ts > pass [2:0]
+      enqueued
+      started
+      passed
+    tests > test.spec.ts > skipped [3:0]
+      enqueued
+      started
+      skipped
+    tests > test.spec.ts > fixme [6:0]
+      enqueued
+      started
+      skipped
+    tests > test.spec.ts > fails [9:0]
+      enqueued
+      started
+      passed
+  `);
+
+  await expect(vscode).toHaveConnectionLog([
+    { method: 'listFiles', params: {} },
+    { method: 'runGlobalSetup', params: {} },
+    {
+      method: 'runTests',
+      params: expect.objectContaining({
+        locations: [],
+        testIds: undefined
+      })
+    },
+  ]);
+});

--- a/packages/vscode/tests/run-tests.spec.ts
+++ b/packages/vscode/tests/run-tests.spec.ts
@@ -1,0 +1,1389 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { enableConfigs, enableProjects, escapedPathSep, expect, test } from './utils';
+import { TestRun } from './mock/vscode';
+import fs from 'fs';
+import path from 'path';
+
+test('should run all tests', async ({ activate }) => {
+  const { vscode, testController } = await activate({
+    'playwright.config.js': `module.exports = { testDir: 'tests' }`,
+    'tests/test-1.spec.ts': `
+      import { test } from '@playwright/test';
+      test('should pass', async () => {});
+    `,
+    'tests/test-2.spec.ts': `
+      import { test, expect } from '@playwright/test';
+      test('should fail', async () => { expect(1).toBe(2); });
+    `,
+  });
+
+  const testRun = await testController.run();
+
+  await expect(testController).toHaveTestTree(`
+    -   tests
+      -   test-1.spec.ts
+        - ✅ should pass [2:0]
+      -   test-2.spec.ts
+        - ❌ should fail [2:0]
+  `);
+
+  expect(testRun.renderLog()).toBe(`
+    tests > test-2.spec.ts > should fail [2:0]
+      enqueued
+      started
+      failed
+    tests > test-1.spec.ts > should pass [2:0]
+      enqueued
+      started
+      passed
+  `);
+
+  await expect(vscode).toHaveConnectionLog([
+    { method: 'listFiles', params: {} },
+    { method: 'runGlobalSetup', params: {} },
+    { method: 'runTests', params: expect.objectContaining({
+      locations: [],
+      testIds: undefined,
+    }) },
+  ]);
+});
+
+test('should run one test', async ({ activate }) => {
+  const { vscode, testController } = await activate({
+    'playwright.config.js': `module.exports = { testDir: 'tests' }`,
+    'tests/test.spec.ts': `
+      import { test } from '@playwright/test';
+      test('should pass', async () => {});
+    `,
+  });
+
+  await testController.expandTestItems(/test.spec/);
+  const testItems = testController.findTestItems(/pass/);
+  const testRun = await testController.run(testItems);
+
+  await expect(testController).toHaveTestTree(`
+    -   tests
+      -   test.spec.ts
+        - ✅ should pass [2:0]
+  `);
+
+  expect(testRun.renderLog()).toBe(`
+    tests > test.spec.ts > should pass [2:0]
+      enqueued
+      enqueued
+      started
+      passed
+  `);
+
+  await expect(vscode).toHaveConnectionLog([
+    { method: 'listFiles', params: {} },
+    {
+      method: 'listTests',
+      params: {
+        locations: [expect.stringContaining(`tests${escapedPathSep}test\\.spec\\.ts`)]
+      }
+    },
+    { method: 'runGlobalSetup', params: {} },
+    {
+      method: 'runTests',
+      params: expect.objectContaining({
+        locations: [expect.stringContaining(`tests${escapedPathSep}test\\.spec\\.ts`)],
+        testIds: [expect.any(String)]
+      })
+    },
+  ]);
+});
+
+test('should run describe', async ({ activate }) => {
+  const { testController } = await activate({
+    'playwright.config.js': `module.exports = { testDir: 'tests' }`,
+    'tests/test.spec.ts': `
+      import { test } from '@playwright/test';
+      test.describe('describe', () => {
+        test('one', async () => {});
+        test('two', async () => {});
+      });
+    `,
+  });
+
+  await testController.expandTestItems(/test.spec.ts/);
+  const testItems = testController.findTestItems(/describe/);
+  expect(testItems.length).toBe(1);
+  const testRun = await testController.run(testItems);
+
+  expect(testRun.renderLog()).toBe(`
+    tests > test.spec.ts > describe > one [3:0]
+      enqueued
+      enqueued
+      started
+      passed
+    tests > test.spec.ts > describe > two [4:0]
+      enqueued
+      enqueued
+      started
+      passed
+  `);
+});
+
+test('should run file', async ({ activate }) => {
+  const { vscode, testController } = await activate({
+    'playwright.config.js': `module.exports = { testDir: 'tests' }`,
+    'tests/test.spec.ts': `
+      import { test } from '@playwright/test';
+      test('one', async () => {});
+      test('two', async () => {});
+    `,
+  });
+
+  const testItems = testController.findTestItems(/test.spec.ts/);
+  expect(testItems.length).toBe(1);
+  const testRun = await testController.run(testItems);
+
+  expect(testRun.renderLog()).toBe(`
+    tests > test.spec.ts > one [2:0]
+      enqueued
+      started
+      passed
+    tests > test.spec.ts > two [3:0]
+      enqueued
+      started
+      passed
+  `);
+
+  await expect(vscode).toHaveConnectionLog([
+    { method: 'listFiles', params: {} },
+    { method: 'runGlobalSetup', params: {} },
+    {
+      method: 'runTests',
+      params: expect.objectContaining({
+        locations: [expect.stringContaining(`tests${escapedPathSep}test\\.spec\\.ts`)],
+        testIds: undefined
+      })
+    },
+  ]);
+});
+
+test('should run folder', async ({ activate }) => {
+  const { vscode, testController } = await activate({
+    'playwright.config.js': `module.exports = { testDir: 'tests' }`,
+    'tests/folder/test1.spec.ts': `
+      import { test } from '@playwright/test';
+      test('one', async () => {});
+    `,
+    'tests/folder/test2.spec.ts': `
+      import { test } from '@playwright/test';
+      test('two', async () => {});
+    `,
+    'tests/folderwithsuffix/test2.spec.ts': `
+      import { test } from '@playwright/test';
+      test('two', async () => {});
+    `,
+  });
+
+  const testItems = testController.findTestItems(/folder$/);
+  expect(testItems.length).toBe(1);
+  const testRun = await testController.run(testItems);
+
+  expect(testRun.renderLog()).toBe(`
+    tests > folder > test1.spec.ts > one [2:0]
+      enqueued
+      started
+      passed
+    tests > folder > test2.spec.ts > two [2:0]
+      enqueued
+      started
+      passed
+  `);
+
+  await expect(vscode).toHaveConnectionLog([
+    { method: 'listFiles', params: {} },
+    { method: 'runGlobalSetup', params: {} },
+    {
+      method: 'runTests',
+      params: expect.objectContaining({
+        locations: [expect.stringContaining(`tests${escapedPathSep}folder${escapedPathSep}`)],
+        testIds: undefined
+      })
+    },
+  ]);
+});
+
+test('should show error message', async ({ activate }) => {
+  const { testController } = await activate({
+    'playwright.config.js': `module.exports = { testDir: 'tests' }`,
+    'tests/test.spec.ts': `
+      import { test, expect } from '@playwright/test';
+      test('should fail', async () => {
+        expect(1).toBe(2);
+      });
+    `,
+  });
+
+  await testController.expandTestItems(/test.spec/);
+  const testItems = testController.findTestItems(/fail/);
+  const testRun = await testController.run(testItems);
+
+  expect(testRun.renderLog({ messages: true })).toBe(`
+    tests > test.spec.ts > should fail [2:0]
+      enqueued
+      enqueued
+      started
+      failed
+        test.spec.ts:[3:18 - 3:18]
+        Error: <span style='color:#888;'>expect(</span><span style='color:#f14c4c;'>received</span><span style='color:#888;'>).</span>toBe<span style='color:#888;'>(</span><span style='color:#73c991;'>expected</span><span style='color:#888;'>) // Object.is equality</span>
+        <br>
+
+        <br>
+        Expected: <span style='color:#73c991;'>2</span>
+        <br>
+        Received: <span style='color:#f14c4c;'>1</span>
+        <br>
+            at tests/test.spec.ts:4:19
+  `);
+});
+
+test('should escape error log', async ({ activate }) => {
+  const { testController } = await activate({
+    'playwright.config.js': `module.exports = { testDir: 'tests' }`,
+    'tests/test.spec.ts': `
+      import { test, expect } from '@playwright/test';
+      test('should fail', async () => {
+        throw new Error('\\n========== log ==========\\n<div class="foo bar baz"></div>\\n===============\\n');
+      });
+    `,
+  });
+  await testController.expandTestItems(/test.spec/);
+  const testItems = testController.findTestItems(/fail/);
+  const testRun = await testController.run(testItems);
+
+  expect(testRun.renderLog({ messages: true })).toContain(
+      `&lt;div class=&quot;foo bar baz&quot;&gt;&lt;/div&gt;`);
+});
+
+test('should show soft error messages', async ({ activate }) => {
+  const { testController } = await activate({
+    'playwright.config.js': `module.exports = { testDir: 'tests' }`,
+    'tests/test.spec.ts': `
+      import { test, expect } from '@playwright/test';
+      test('should fail', async () => {
+        expect.soft(1).toBe(2);
+        expect.soft(2).toBe(3);
+      });
+    `,
+  });
+
+  await testController.expandTestItems(/test.spec/);
+  const testItems = testController.findTestItems(/fail/);
+  const testRun = await testController.run(testItems);
+
+  expect(testRun.renderLog({ messages: true })).toBe(`
+    tests > test.spec.ts > should fail [2:0]
+      enqueued
+      enqueued
+      started
+      failed
+        test.spec.ts:[3:23 - 3:23]
+        Error: <span style='color:#888;'>expect(</span><span style='color:#f14c4c;'>received</span><span style='color:#888;'>).</span>toBe<span style='color:#888;'>(</span><span style='color:#73c991;'>expected</span><span style='color:#888;'>) // Object.is equality</span>
+        <br>
+
+        <br>
+        Expected: <span style='color:#73c991;'>2</span>
+        <br>
+        Received: <span style='color:#f14c4c;'>1</span>
+        <br>
+            at tests/test.spec.ts:4:24
+        test.spec.ts:[4:23 - 4:23]
+        Error: <span style='color:#888;'>expect(</span><span style='color:#f14c4c;'>received</span><span style='color:#888;'>).</span>toBe<span style='color:#888;'>(</span><span style='color:#73c991;'>expected</span><span style='color:#888;'>) // Object.is equality</span>
+        <br>
+
+        <br>
+        Expected: <span style='color:#73c991;'>3</span>
+        <br>
+        Received: <span style='color:#f14c4c;'>2</span>
+        <br>
+            at tests/test.spec.ts:5:24
+  `);
+});
+
+test('should only create test run if file belongs to context', async ({ activate }) => {
+  const { vscode, testController } = await activate({
+    'tests1/playwright.config.js': `module.exports = { testDir: '.' }`,
+    'tests2/playwright.config.js': `module.exports = { testDir: '.' }`,
+    'tests1/test1.spec.ts': `
+      import { test } from '@playwright/test';
+      test('one', async () => {});
+    `,
+    'tests2/test2.spec.ts': `
+      import { test } from '@playwright/test';
+      test('two', async () => {});
+    `,
+  });
+
+  const profile = testController.runProfile();
+  await enableConfigs(vscode, [`tests1${path.sep}playwright.config.js`, `tests2${path.sep}playwright.config.js`]);
+
+  let testRuns: TestRun[] = [];
+  testController.onDidCreateTestRun(run => testRuns.push(run));
+
+  {
+    testRuns = [];
+    const items = testController.findTestItems(/test1.spec/);
+    await profile.run(items);
+    expect(testRuns).toHaveLength(1);
+  }
+
+  await expect(vscode).toHaveConnectionLog(expect.arrayContaining([
+    { method: 'listFiles', params: {} },
+    { method: 'runGlobalSetup', params: {} },
+    {
+      method: 'runTests',
+      params: expect.objectContaining({
+        locations: [expect.stringContaining(`tests1${escapedPathSep}test1\\.spec\\.ts`)],
+        testIds: undefined
+      })
+    },
+  ]));
+  vscode.connectionLog.length = 0;
+
+  {
+    testRuns = [];
+    const items = testController.findTestItems(/test2.spec/);
+    await profile.run(items);
+    expect(testRuns).toHaveLength(1);
+  }
+
+  await expect(vscode).toHaveConnectionLog([
+    { method: 'runGlobalSetup', params: {} },
+    {
+      method: 'runTests',
+      params: expect.objectContaining({
+        locations: [expect.stringContaining(`tests2${escapedPathSep}test2\\.spec\\.ts`)],
+        testIds: undefined
+      })
+    },
+  ]);
+
+});
+
+test('should only create test run if folder belongs to context', async ({ activate }) => {
+  const { vscode, testController } = await activate({
+    'tests1/playwright.config.js': `module.exports = { testDir: '.' }`,
+    'tests2/playwright.config.js': `module.exports = { testDir: '.' }`,
+    'tests1/foo1/bar1/test1.spec.ts': `
+      import { test } from '@playwright/test';
+      test('one', async () => {});
+    `,
+    'tests2/foo2/bar2/test2.spec.ts': `
+      import { test } from '@playwright/test';
+      test('two', async () => {});
+    `,
+  });
+
+  await enableConfigs(vscode, [`tests1${path.sep}playwright.config.js`, `tests2${path.sep}playwright.config.js`]);
+
+  await expect(testController).toHaveTestTree(`
+    -   tests1
+      -   foo1
+        -   bar1
+          -   test1.spec.ts
+    -   tests2
+      -   foo2
+        -   bar2
+          -   test2.spec.ts
+  `);
+
+  const profile = testController.runProfile();
+  const items = testController.findTestItems(/foo1/);
+  await profile.run(items);
+
+  await expect(vscode).toHaveConnectionLog([
+    { method: 'listFiles', params: {} },
+    { method: 'listFiles', params: {} },
+    { method: 'runGlobalSetup', params: {} },
+    {
+      method: 'runTests',
+      params: expect.objectContaining({
+        locations: [expect.stringContaining(`tests1${escapedPathSep}foo1`)],
+        testIds: undefined
+      })
+    },
+  ]);
+});
+
+test('should run all projects at once', async ({ activate }) => {
+  const { vscode, testController } = await activate({
+    'playwright.config.js': `module.exports = {
+      testDir: './tests',
+      projects: [
+        { name: 'projectOne' },
+        { name: 'projectTwo' },
+      ]
+    }`,
+    'tests/test.spec.ts': `
+      import { test } from '@playwright/test';
+      test('one', async () => {});
+    `,
+  });
+
+  await enableProjects(vscode, ['projectOne', 'projectTwo']);
+  const profile = testController.runProfile();
+  await profile.run();
+
+  await expect(vscode).toHaveConnectionLog([
+    { method: 'listFiles', params: {} },
+    { method: 'runGlobalSetup', params: {} },
+    {
+      method: 'runTests',
+      params: expect.objectContaining({
+        locations: [],
+        projects: [],
+        testIds: undefined
+      })
+    },
+  ]);
+});
+
+test('should stop', async ({ activate, showBrowser }) => {
+  test.fixme(showBrowser, 'Times out');
+  const { testController } = await activate({
+    'playwright.config.js': `module.exports = { testDir: 'tests' }`,
+    'tests/test.spec.ts': `
+      import { test } from '@playwright/test';
+      test('one', async () => {
+        await new Promise(f => process.stdout.write('RUNNING TEST', f));
+        await new Promise(() => {});
+      });
+    `,
+  });
+
+  const profile = testController.runProfile();
+  const testRunPromise = new Promise<TestRun>(f => testController.onDidCreateTestRun(f));
+  const runPromise = profile.run();
+  const testRun = await testRunPromise;
+  let output = testRun.renderLog({ output: true });
+  while (!output.includes('RUNNING TEST')) {
+    output = testRun.renderLog({ output: true });
+    await new Promise(f => setTimeout(f, 100));
+  }
+  testRun.token.source.cancel();
+  await runPromise;
+});
+
+test('should not remove other tests when running focused test', async ({ activate }) => {
+  const { testController } = await activate({
+    'playwright.config.js': `module.exports = { testDir: 'tests' }`,
+    'tests/test.spec.ts': `
+      import { test } from '@playwright/test';
+      test('one', async () => {});
+      test('two', async () => {});
+      test('three', async () => {});
+    `,
+  });
+
+  await testController.expandTestItems(/test.spec/);
+  const testItems = testController.findTestItems(/two/);
+  await testController.run(testItems);
+
+  await expect(testController).toHaveTestTree(`
+    -   tests
+      -   test.spec.ts
+        -   one [2:0]
+        - ✅ two [3:0]
+        -   three [4:0]
+  `);
+});
+
+test('should run all parametrized tests', async ({ activate }) => {
+  const { vscode, testController } = await activate({
+    'playwright.config.js': `module.exports = { testDir: 'tests' }`,
+    'tests/test.spec.ts': `
+      import { test } from '@playwright/test';
+      for (const name of ['test-one', 'test-two', 'test-three'])
+        test(name, async () => {});
+    `,
+  });
+
+  await testController.expandTestItems(/test.spec/);
+  const testItems = testController.findTestItems(/test-/);
+  expect(testItems.length).toBe(3);
+  const testRun = await testController.run(testItems);
+
+  expect(testRun.renderLog()).toBe(`
+    tests > test.spec.ts > test-one [3:0]
+      enqueued
+      enqueued
+      started
+      passed
+    tests > test.spec.ts > test-three [3:0]
+      enqueued
+      enqueued
+      started
+      passed
+    tests > test.spec.ts > test-two [3:0]
+      enqueued
+      enqueued
+      started
+      passed
+  `);
+
+  await expect(vscode).toHaveConnectionLog([
+    { method: 'listFiles', params: {} },
+    {
+      method: 'listTests',
+      params: expect.objectContaining({
+        locations: [expect.stringContaining(`tests${escapedPathSep}test\\.spec\\.ts`)],
+      })
+    },
+    { method: 'runGlobalSetup', params: {} },
+    {
+      method: 'runTests',
+      params: expect.objectContaining({
+        locations: [
+          expect.stringContaining(`tests${escapedPathSep}test\\.spec\\.ts`),
+        ],
+        testIds: [
+          expect.any(String),
+          expect.any(String),
+          expect.any(String),
+        ]
+      })
+    },
+  ]);
+});
+
+test('should run one parametrized test', async ({ activate }) => {
+  const { vscode, testController } = await activate({
+    'playwright.config.js': `module.exports = { testDir: 'tests' }`,
+    'tests/test.spec.ts': `
+      import { test } from '@playwright/test';
+      for (const name of ['test one', 'test two', 'test three'])
+        test(name, async () => {});
+    `,
+  });
+
+  await testController.expandTestItems(/test.spec/);
+  const testItems = testController.findTestItems(/test two/);
+  expect(testItems.length).toBe(1);
+  const testRun = await testController.run(testItems);
+
+  expect(testRun.renderLog()).toBe(`
+    tests > test.spec.ts > test two [3:0]
+      enqueued
+      enqueued
+      started
+      passed
+  `);
+
+  await expect(vscode).toHaveConnectionLog([
+    { method: 'listFiles', params: {} },
+    { method: 'listTests', params: {
+      locations: [expect.stringContaining(`tests${escapedPathSep}test\\.spec\\.ts`)]
+    } },
+    { method: 'runGlobalSetup', params: {} },
+    {
+      method: 'runTests',
+      params: expect.objectContaining({
+        locations: [
+          expect.stringContaining(`tests${escapedPathSep}test\\.spec\\.ts`),
+        ],
+        testIds: [expect.any(String)]
+      })
+    },
+  ]);
+});
+
+test('should run one parametrized groups', async ({ activate }) => {
+  const { vscode, testController } = await activate({
+    'playwright.config.js': `module.exports = { testDir: 'tests' }`,
+    'tests/test.spec.ts': `
+      import { test } from '@playwright/test';
+      for (const name of ['group one', 'group two', 'group three'])
+        test.describe(name, () => {
+          test('test one in ' + name, async () => {});
+          test('test two in ' + name, async () => {});
+        });
+    `,
+  });
+
+  await testController.expandTestItems(/test.spec/);
+  const testItems = testController.findTestItems(/^group three$/);
+  expect(testItems.length).toBe(1);
+  const testRun = await testController.run(testItems);
+
+  expect(testRun.renderLog()).toBe(`
+    tests > test.spec.ts > group three > test one in group three [4:0]
+      enqueued
+      enqueued
+      started
+      passed
+    tests > test.spec.ts > group three > test two in group three [5:0]
+      enqueued
+      enqueued
+      started
+      passed
+  `);
+
+  await expect(vscode).toHaveConnectionLog([
+    { method: 'listFiles', params: {} },
+    {
+      method: 'listTests',
+      params: expect.objectContaining({
+        locations: [expect.stringContaining(`tests${escapedPathSep}test\\.spec\\.ts`)],
+      })
+    },
+    { method: 'runGlobalSetup', params: {} },
+    {
+      method: 'runTests',
+      params: expect.objectContaining({
+        locations: [
+          expect.stringContaining(`tests${escapedPathSep}test\\.spec\\.ts`),
+        ],
+        testIds: [
+          expect.any(String),
+          expect.any(String),
+        ]
+      })
+    },
+  ]);
+});
+
+test('should run tests in parametrized groups', async ({ activate }) => {
+  const { vscode, testController } = await activate({
+    'playwright.config.js': `module.exports = { testDir: 'tests' }`,
+    'tests/test.spec.ts': `
+      import { test, expect } from '@playwright/test';
+      for (const foo of [1, 2]) {
+        test.describe('level ' + foo, () => {
+          test('should work', async () => {
+            expect(1).toBe(1);
+          });
+        });
+      }
+    `,
+  });
+
+  await testController.expandTestItems(/test.spec/);
+  const testItems1 = testController.findTestItems(/level 1/);
+  expect(testItems1.length).toBe(1);
+  const testRun = await testController.run(testItems1);
+  expect(testRun.renderLog()).toBe(`
+    tests > test.spec.ts > level 1 > should work [4:0]
+      enqueued
+      enqueued
+      started
+      passed
+  `);
+
+  await expect(vscode).toHaveConnectionLog([
+    { method: 'listFiles', params: {} },
+    {
+      method: 'listTests',
+      params: expect.objectContaining({
+        locations: [expect.stringContaining(`tests${escapedPathSep}test\\.spec\\.ts`)],
+      })
+    },
+    { method: 'runGlobalSetup', params: {} },
+    {
+      method: 'runTests',
+      params: expect.objectContaining({
+        locations: [
+          expect.stringContaining(`tests${escapedPathSep}test\\.spec\\.ts`),
+        ],
+        testIds: [
+          expect.any(String),
+        ]
+      })
+    },
+  ]);
+  vscode.connectionLog.length = 0;
+
+  const testItems2 = testController.findTestItems(/level 2/);
+  expect(testItems2.length).toBe(1);
+  const testRun2 = await testController.run(testItems2);
+  expect(testRun2.renderLog()).toBe(`
+    tests > test.spec.ts > level 2 > should work [4:0]
+      enqueued
+      enqueued
+      started
+      passed
+  `);
+
+  await expect(vscode).toHaveConnectionLog([
+    {
+      method: 'runTests',
+      params: expect.objectContaining({
+        locations: [
+          expect.stringContaining(`tests${escapedPathSep}test\\.spec\\.ts`),
+        ],
+        testIds: [
+          expect.any(String),
+        ]
+      })
+    },
+  ]);
+});
+
+test('should list tests in relative folder', async ({ activate }) => {
+  const { vscode, testController } = await activate({
+    'foo/bar/playwright.config.js': `module.exports = { testDir: '../../tests' }`,
+    'tests/test.spec.ts': `
+      import { test } from '@playwright/test';
+      test('one', async () => {});
+    `,
+  });
+
+  await testController.expandTestItems(/test.spec/);
+
+  await expect(vscode).toHaveConnectionLog([
+    { method: 'listFiles', params: {} },
+    {
+      method: 'listTests',
+      params: expect.objectContaining({
+        locations: [expect.stringContaining(`tests${escapedPathSep}test\\.spec\\.ts`)],
+      })
+    },
+  ]);
+
+  await expect(testController).toHaveTestTree(`
+    -   tests
+      -   test.spec.ts
+        -   one [2:0]
+  `);
+});
+
+test('should filter selected project', async ({ activate }) => {
+  const { vscode, testController } = await activate({
+    'playwright.config.js': `module.exports = {
+      projects: [
+        { testDir: './tests1', name: 'project 1' },
+        { testDir: './tests2', name: 'project 2' },
+      ]
+    }`,
+    'tests1/test.spec.ts': `
+      import { test } from '@playwright/test';
+      test('one', async () => {});
+    `,
+    'tests2/test.spec.ts': `
+      import { test } from '@playwright/test';
+      test('two', async () => {});
+    `,
+  });
+
+
+  await enableProjects(vscode, ['project 1']);
+  await expect(testController).toHaveTestTree(`
+    -   tests1
+      -   test.spec.ts
+    -    [playwright.config.js [project 2] — disabled]
+  `);
+
+  const testItems = testController.findTestItems(/test.spec/);
+  expect(testItems).toHaveLength(1);
+  const testRun = await testController.run(testItems);
+  expect(testRun.renderLog()).toBe(`
+    tests1 > test.spec.ts > one [2:0]
+      enqueued
+      started
+      passed
+  `);
+
+  await expect(vscode).toHaveConnectionLog([
+    { method: 'listFiles', params: {} },
+    { method: 'runGlobalSetup', params: {} },
+    {
+      method: 'runTests',
+      params: expect.objectContaining({
+        projects: ['project 1'],
+        locations: [expect.stringContaining(`tests1${escapedPathSep}test\\.spec\\.ts`)],
+      })
+    },
+  ]);
+});
+
+test('should report project-specific failures', async ({ activate }) => {
+  const { vscode, testController } = await activate({
+    'playwright.config.js': `module.exports = {
+      testDir: 'tests',
+      workers: 1,
+      projects: [
+        { 'name': 'projectA' },
+        { 'name': 'projectB' },
+        { 'name': 'projectC' },
+      ]
+    }`,
+    'tests/test.spec.ts': `
+      import { test } from '@playwright/test';
+      test('should pass', async ({}, testInfo) => {
+        throw new Error(testInfo.project.name);
+      });
+    `,
+  });
+
+  await enableProjects(vscode, ['projectA', 'projectB', 'projectC']);
+  const profile = testController.runProfile();
+  const testRuns: TestRun[] = [];
+  testController.onDidCreateTestRun(run => testRuns.push(run));
+  await profile.run();
+
+  expect(testRuns[0].renderLog({ messages: true })).toBe(`
+    tests > test.spec.ts > should pass > projectA [2:0]
+      enqueued
+      started
+      failed
+        test.spec.ts:[3:14 - 3:14]
+        Error: projectA
+        <br>
+            at tests/test.spec.ts:4:15
+    tests > test.spec.ts > should pass > projectB [2:0]
+      enqueued
+      started
+      failed
+        test.spec.ts:[3:14 - 3:14]
+        Error: projectB
+        <br>
+            at tests/test.spec.ts:4:15
+    tests > test.spec.ts > should pass > projectC [2:0]
+      enqueued
+      started
+      failed
+        test.spec.ts:[3:14 - 3:14]
+        Error: projectC
+        <br>
+            at tests/test.spec.ts:4:15
+  `);
+});
+
+test('should discover tests after running one test', async ({ activate }) => {
+  const { testController } = await activate({
+    'playwright.config.js': `module.exports = { testDir: 'tests' }`,
+    'tests/test1.spec.ts': `
+      import { test } from '@playwright/test';
+      test('one', async () => {});
+    `,
+    'tests/test2.spec.ts': `
+      import { test } from '@playwright/test';
+      test('two', async () => {});
+    `,
+  });
+
+  await testController.expandTestItems(/test1.spec.ts/);
+  const testItems = testController.findTestItems(/one/);
+  const testRun = await testController.run(testItems);
+
+  expect(testRun.renderLog()).toBe(`
+    tests > test1.spec.ts > one [2:0]
+      enqueued
+      enqueued
+      started
+      passed
+  `);
+
+  await testController.expandTestItems(/test2.spec.ts/);
+
+  await expect(testController).toHaveTestTree(`
+    -   tests
+      -   test1.spec.ts
+        - ✅ one [2:0]
+      -   test2.spec.ts
+        -   two [2:0]
+  `);
+});
+
+test('should provisionally enqueue nested tests', async ({ activate }) => {
+  const { testController } = await activate({
+    'playwright.config.js': `module.exports = { testDir: 'tests' }`,
+    'tests/test.spec.ts': `
+      import { test } from '@playwright/test';
+      test('1', async () => {});
+      test('2', async () => {});
+      test.describe('group', () => {
+        test('3', async () => {});
+        test('4', async () => {});
+      });
+    `,
+  });
+
+  await testController.expandTestItems(/test.spec.ts/);
+  const testItems = testController.findTestItems(/test.spec.ts/);
+  const testRun = await testController.run(testItems);
+
+  await expect(testController).toHaveTestTree(`
+    -   tests
+      -   test.spec.ts
+        - ✅ 1 [2:0]
+        - ✅ 2 [3:0]
+        -   group [4:0]
+          - ✅ 3 [5:0]
+          - ✅ 4 [6:0]
+  `);
+
+  expect(testRun.renderLog()).toBe(`
+    tests > test.spec.ts > 1 [2:0]
+      enqueued
+      enqueued
+      started
+      passed
+    tests > test.spec.ts > 2 [3:0]
+      enqueued
+      enqueued
+      started
+      passed
+    tests > test.spec.ts > group > 3 [5:0]
+      enqueued
+      enqueued
+      started
+      passed
+    tests > test.spec.ts > group > 4 [6:0]
+      enqueued
+      enqueued
+      started
+      passed
+  `);
+});
+
+test('should run tests for folders above root', async ({ activate }) => {
+  const { testController } = await activate({
+    'playwright.config.js': `module.exports = { testDir: 'builder/playwright/tests' }`,
+    'builder/playwright/tests/test.spec.ts': `
+      import { test } from '@playwright/test';
+      test('one', async () => {});
+    `,
+  });
+
+  const testItems = testController.findTestItems(/builder/);
+  const testRun = await testController.run(testItems);
+
+  expect(testRun.renderLog()).toBe(`
+    builder > playwright > tests > test.spec.ts > one [2:0]
+      enqueued
+      started
+      passed
+  `);
+});
+
+test('should produce output twice', async ({ activate }) => {
+  const { testController } = await activate({
+    'playwright.config.js': `module.exports = {
+      testDir: 'tests',
+      reporter: 'line',
+    }`,
+    'tests/test.spec.ts': `
+      import { test } from '@playwright/test';
+      test('one', async () => {
+        console.log('some output');
+      });
+    `,
+  });
+
+  const testItems = testController.findTestItems(/test.spec.ts/);
+  expect(testItems.length).toBe(1);
+
+  const testRun1 = await testController.run(testItems);
+  expect(testRun1.renderLog({ output: true })).toBe(`
+    tests > test.spec.ts > one [2:0]
+      enqueued
+      started
+      passed
+    Output:
+
+
+    Running 1 test using 1 worker
+
+    [1/1] tests${path.sep}test.spec.ts:3:11 › one
+    tests${path.sep}test.spec.ts:3:11 › one
+    some output
+
+      1 passed (XXms)
+
+  `);
+
+  const testRun2 = await testController.run(testItems);
+  expect(testRun2.renderLog({ output: true })).toBe(`
+    tests > test.spec.ts > one [2:0]
+      enqueued
+      enqueued
+      started
+      passed
+    Output:
+
+    Running 1 test using 1 worker
+
+    [1/1] tests${path.sep}test.spec.ts:3:11 › one
+    tests${path.sep}test.spec.ts:3:11 › one
+    some output
+
+      1 passed (XXms)
+
+  `);
+});
+
+test('should disable tracing when reusing context', async ({ activate, showBrowser }) => {
+  test.skip(!showBrowser);
+
+  const { testController } = await activate({
+    'playwright.config.js': `module.exports = { testDir: 'tests', use: { trace: 'on' } }`,
+    'tests/test.spec.ts': `
+      import { test } from '@playwright/test';
+      test('one', async ({ page }) => {});
+    `,
+  });
+
+  const testItems = testController.findTestItems(/test.spec.ts/);
+  expect(testItems.length).toBe(1);
+  await testController.run(testItems);
+
+  expect(fs.existsSync(test.info().outputPath('test-results', 'test-one', 'trace.zip'))).toBe(false);
+});
+
+test('should force workers=1 when reusing the browser', async ({ activate, showBrowser }) => {
+  test.skip(!showBrowser);
+
+  const { testController } = await activate({
+    'playwright.config.js': `module.exports = { testDir: 'tests', workers: 2 }`,
+    'tests/test1.spec.ts': `
+      import { test } from '@playwright/test';
+      test('one', async ({ page }) => {});
+    `,
+    'tests/test2.spec.ts': `
+      import { test } from '@playwright/test';
+      test('one', async ({ page }) => {});
+    `,
+    'tests/test3.spec.ts': `
+      import { test } from '@playwright/test';
+      test('one', async ({ page }) => {});
+    `,
+  });
+
+  const testRun = await testController.run();
+  expect(testRun.renderLog({ output: true })).toContain('Running 3 tests using 1 worker');
+});
+
+test('Run global setup should be disabled if there is no global setup or webserver', { annotation: { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/38132' } }, async ({ activate }) => {
+  const { testController, vscode, workspaceFolder } = await activate({
+    'playwright.config.js': `module.exports = {}`,
+    'global-setup.js': `
+      export default () => {}
+    `,
+    'tests/test.spec.ts': `
+      import { test } from '@playwright/test';
+      test('one', () => {});
+    `,
+  });
+  await expect(testController).toHaveTestTree(`
+    -   tests
+      -   test.spec.ts
+  `);
+  const webView = vscode.webViews.get('playwright-repl.settingsView')!;
+  await expect(webView.getByRole('button', { name: 'Run global setup' })).toBeDisabled();
+
+  await workspaceFolder.changeFile('playwright.config.js', `module.exports = { globalSetup: './global-setup.js' }`);
+  await expect(webView.getByRole('button', { name: 'Run global setup' })).toBeEnabled();
+
+  await workspaceFolder.changeFile('playwright.config.js', `module.exports = {}`);
+  await expect(webView.getByRole('button', { name: 'Run global setup' })).toBeDisabled();
+
+  await workspaceFolder.changeFile('playwright.config.js', `module.exports = { webServer: { command: 'npm start', url: 'http://localhost:3000' } }`);
+  await expect(webView.getByRole('button', { name: 'Run global setup' })).toBeEnabled();
+});
+
+test.describe('runGlobalSetupOnEachRun', { annotation: { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/32121' } }, () => {
+  function expectOrdering(log: string, items: string[]) {
+    items.forEach(item => expect(log).toContain(item));
+
+    const indices = items.map(item => log.indexOf(item));
+    expect(indices, `log contains entries ${JSON.stringify(items)} in order`).toEqual(indices.sort());
+  }
+
+  const files = {
+    'playwright.config.js': `module.exports = {
+      testDir: 'tests',
+      globalSetup: './globalSetup.js',
+      globalTeardown: './globalTeardown.js',
+    }`,
+    'globalSetup.js': `
+      export default () => console.log('RUNNING SETUP');
+    `,
+    'globalTeardown.js': `
+      export default () => console.log('RUNNING TEARDOWN');
+    `,
+    'tests/test.spec.ts': `
+      import { test } from '@playwright/test';
+      test('one', () => {
+        console.log('RUNNING TEST');
+      });
+    `,
+  };
+
+  test('if disabled, should run global setup only once and teardown never automatically', async ({ activate }) => {
+    const { testController } = await activate(files);
+
+    const firstRun = (await testController.run()).renderOutput();
+    expectOrdering(firstRun, ['RUNNING SETUP', 'RUNNING TEST']);
+    expect(firstRun).not.toContain('RUNNING TEARDOWN');
+
+    const secondRun = (await testController.run()).renderOutput();
+    expect(secondRun).toContain('RUNNING TEST');
+    expect(secondRun).not.toContain('RUNNING SETUP');
+    expect(secondRun).not.toContain('RUNNING TEARDOWN');
+  });
+
+  test('should always run global setup and teardown if runGlobalSetupOnEachRun is enabled', async ({ activate }) => {
+    const { testController } = await activate(files, { runGlobalSetupOnEachRun: true });
+
+    const firstRun = (await testController.run()).renderOutput();
+    expectOrdering(firstRun, ['RUNNING SETUP', 'RUNNING TEST']);
+    expect(firstRun).not.toContain('RUNNING TEARDOWN');
+
+    const secondRun = (await testController.run()).renderOutput();
+    expectOrdering(secondRun, ['RUNNING TEARDOWN', 'RUNNING SETUP', 'RUNNING TEST']);
+  });
+});
+
+test('should provide page snapshot to copilot', async ({ activate }) => {
+  const { testController } = await activate({
+    'playwright.config.js': `module.exports = { testDir: 'tests', workers: 2 }`,
+    'tests/test1.spec.ts': `
+        import { test, expect } from '@playwright/test';
+  
+        test('one', async ({ page }) => {
+          await page.setContent('<button>click me</button>');
+          expect(1).toBe(2);
+        });
+      `,
+  });
+
+  const testRun = await testController.run();
+  const allMessages = [...testRun.entries.values()].flat().flatMap(e => e.messages ?? []);
+  const log = allMessages.map(m => m.message.render()).join('\n');
+  expect(log).toContain(`<details><summary>Context for AI</summary>`);
+  expect(log).toContain(`# Page snapshot`);
+  expect(log).toContain(`- button "click me"`);
+});
+
+test('should not run global setup for other project', async ({ activate }) => {
+  const { vscode, testController } = await activate({
+    'tests1/playwright.config.js': `module.exports = { testDir: '.', globalSetup: './globalSetup.js' }`,
+    'tests1/globalSetup.js': `
+      export default () => { throw new Error('RUNNING GLOBAL SETUP'); }
+    `,
+    'tests2/playwright.config.js': `module.exports = { testDir: '.' }`,
+    'tests2/example.spec.ts': `
+      import { test } from '@playwright/test';
+      test('two', async () => {});
+    `,
+  });
+  await enableConfigs(vscode, [`tests1${path.sep}playwright.config.js`, `tests2${path.sep}playwright.config.js`]);
+  await expect(testController).toHaveTestTree(`
+    -   tests2
+      -   example.spec.ts
+  `);
+  await testController.expandTestItems(/.*/);
+  await expect(testController).toHaveTestTree(`
+    -   tests2
+      -   example.spec.ts
+        -   two [2:0]
+  `);
+  const items = testController.findTestItems(/two/);
+  const testRun = await testController.run(items);
+  expect(testRun.renderOutput()).not.toContain('RUNNING GLOBAL SETUP');
+});
+
+test('should run single test defined outside of .spec.ts file', { annotation: { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/37930' } }, async ({ activate }) => {
+  const { testController } = await activate({
+    'playwright.config.js': `module.exports = { testDir: '.' }`,
+    'example.spec.ts': `
+      import './impl';
+    `,
+    'impl.ts': `
+      import { test } from '@playwright/test';
+      test('one', async () => {});
+    `,
+  });
+  await expect(testController).toHaveTestTree(`
+    -   example.spec.ts
+  `);
+  await testController.expandTestItems(/.*/);
+  await expect(testController).toHaveTestTree(`
+    -   example.spec.ts
+      -   one [2:0]
+  `);
+  const items = testController.findTestItems(/one/);
+  const testRun = await testController.run(items);
+  expect(testRun.renderLog()).toEqual(`
+    example.spec.ts > one [2:0]
+      enqueued
+      enqueued
+      started
+      passed
+  `);
+});
+
+test('should start webServer', async ({ activate }, testInfo) => {
+  const port = testInfo.parallelIndex * 4 + 42130;
+  const { testController } = await activate({
+    'server.mjs': `
+      import http from "node:http";
+      http.createServer((req, res) => {
+        res.end('<h1>Hello world</h1>');
+      }).listen(${port})
+    `,
+    'playwright.config.js': `module.exports = {
+      use: {
+        baseURL: 'http://localhost:${port}'
+      },
+      webServer: {
+        command: 'node server.mjs',
+        url: 'http://localhost:${port}',
+      },
+    }`,
+    'tests/test.spec.ts': `
+      import { test, expect } from '@playwright/test';
+      test('one', async ({ page }) => {
+        await page.goto("/");
+        await expect(page.getByRole('heading')).toHaveText('Hello world');
+      });
+    `,
+  });
+
+  const testRun = await testController.run();
+  expect(testRun.renderLog()).toContain('passed');
+});
+
+test('should start webServer with npx command', async ({ activate }, testInfo) => {
+  test.skip(process.platform === 'win32', 'npx on windows is weird');
+  const port = testInfo.parallelIndex * 4 + 42130;
+  const { testController } = await activate({
+    'node_modules/.bin/server': `
+#!/usr/bin/env node
+
+const http = require("node:http");
+
+http.createServer((req, res) => {
+  res.end('<h1>Hello world</h1>');
+}).listen(${port})
+    `.trim(),
+    'playwright.config.js': `module.exports = {
+      use: {
+        baseURL: 'http://localhost:${port}'
+      },
+      webServer: {
+        command: 'server',
+        url: 'http://localhost:${port}',
+      },
+    }`,
+    'tests/test.spec.ts': `
+      import { test, expect } from '@playwright/test';
+      test('one', async ({ page }) => {
+        await page.goto("/");
+        await expect(page.getByRole('heading')).toHaveText('Hello world');
+      });
+    `,
+  });
+
+  fs.chmodSync(testInfo.outputPath('node_modules', '.bin', 'server'), 0o775);
+
+  const testRun = await testController.run();
+  expect(testRun.renderLog({ output: true })).toContain('passed');
+});
+
+test('should only end test run after all config reporters exited', { annotation: { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/37867' } }, async ({ activate }) => {
+  const { testController } = await activate({
+    'playwright.config.js': `module.exports = {
+      reporter: [['./my-reporter.js']],
+    }`,
+    'my-reporter.js': `
+      export default class MyReporter {
+        async onExit() {
+          console.log("%onExit started");
+          await new Promise(f => setTimeout(f, 100));
+          console.log("%onExit ended");
+        }
+      }
+    `,
+    'tests/test.spec.ts': `
+      import { test } from '@playwright/test';
+      test('one', async () => {});
+    `,
+  });
+
+  const events: string[] = [];
+  testController.onDidCreateTestRun(run => {
+    run.onDidOutput(msg => {
+      if (msg.startsWith('%'))
+        events.push(msg.slice(1).trim());
+    });
+    run.onDidEnd(() => {
+      events.push('testRun ended');
+    });
+  });
+  await testController.run();
+  expect(events).toEqual([
+    'onExit started',
+    'onExit ended',
+    'testRun ended',
+  ]);
+});
+
+test('should run both file and specific test from another file', async ({ activate }) => {
+  test.fail(true, `
+    Since we specify both locations and test IDs, the single test doesnt get found.
+    It's a rare case because the UI doesn't support it, it can only be done via API.
+    In watch mode, the _runWatchedTests implementation separates files and test IDs,
+    which also prevents the bug.
+  `);
+
+  const { vscode, testController } = await activate({
+    'playwright.config.js': `module.exports = { testDir: 'tests' }`,
+    'tests/foo.spec.ts': `
+      import { test } from '@playwright/test';
+      test('foo-test', async () => {});
+    `,
+    'tests/bar.spec.ts': `
+      import { test } from '@playwright/test';
+      test('bar-test', async () => {});
+    `,
+  });
+
+  await testController.expandTestItems(/.*/);
+  const [fooFile] = testController.findTestItems(/foo.spec.ts$/);
+  const [barTest] = testController.findTestItems(/bar-test/);
+  const testRun = await testController.run([fooFile, barTest]);
+
+  await expect(vscode).toHaveConnectionLog(expect.arrayContaining([{
+    method: 'runTests',
+    params: expect.objectContaining({
+      locations: [
+        expect.stringContaining(`foo\\.spec\\.ts`),
+        expect.stringContaining(`bar\\.spec\\.ts`),
+      ],
+      testIds: [expect.any(String)]
+    })
+  }]));
+  expect(testRun.renderLog()).toBe(`
+    tests > foo.spec.ts > bar-test [2:0]
+      enqueued
+      enqueued
+      started
+      passed
+    tests > bar.spec.ts > foo-test [2:0]
+      enqueued
+      enqueued
+      started
+      passed
+  `);
+});

--- a/packages/vscode/tests/settings.spec.ts
+++ b/packages/vscode/tests/settings.spec.ts
@@ -1,0 +1,280 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { enableProjects, expect, test } from './utils';
+
+test.beforeEach(async ({ showBrowser }) => {
+  test.skip(showBrowser);
+});
+
+test('should toggle settings', async ({ activate }) => {
+  const { vscode } = await activate({
+    'playwright.config.js': `module.exports = {}`,
+  });
+  const configuration = vscode.workspace.getConfiguration('playwright-repl');
+
+  expect(configuration.get('reuseBrowser')).toBe(false);
+  await vscode.commands.executeCommand('playwright-repl.toggle.reuseBrowser');
+  expect(configuration.get('reuseBrowser')).toBe(true);
+  await vscode.commands.executeCommand('playwright-repl.toggle.reuseBrowser');
+  expect(configuration.get('reuseBrowser')).toBe(false);
+});
+
+test('should toggle setting from webview', async ({ activate }) => {
+  const { vscode } = await activate({
+    'playwright.config.js': `module.exports = {}`,
+  });
+
+  const webView = vscode.webViews.get('playwright-repl.settingsView')!;
+  const configuration = vscode.workspace.getConfiguration('playwright-repl');
+
+  expect(configuration.get('reuseBrowser')).toBe(false);
+  await webView.getByLabel('Show browser').click();
+  expect(configuration.get('reuseBrowser')).toBe(true);
+});
+
+test('should select-all/unselect-all', async ({ activate }) => {
+  const { vscode } = await activate({
+    'playwright.config.ts': `
+      import { defineConfig } from '@playwright/test';
+      export default defineConfig({
+        projects: [
+          { name: 'foo', testMatch: 'foo.ts' },
+          { name: 'bar', testMatch: 'bar.ts' },
+        ]
+      });
+    `,
+  });
+
+  await enableProjects(vscode, ['foo']);
+
+  const webView = vscode.webViews.get('playwright-repl.settingsView')!;
+
+  await expect(webView.locator('body')).toMatchAriaSnapshot(`
+    - heading "PROJECTS":
+      - button "Select All"
+    - checkbox "foo" [checked]
+    - checkbox "bar" [checked=false]
+  `);
+
+  await webView.getByRole('checkbox', { name: 'bar' }).check();
+
+  await expect(webView.locator('body')).toMatchAriaSnapshot(`
+    - heading "PROJECTS":
+      - button "Unselect All"
+    - checkbox "foo" [checked]
+    - checkbox "bar" [checked]
+  `);
+
+  await webView.getByRole('button', { name: 'Unselect All' }).click();
+
+  await expect(webView.locator('body')).toMatchAriaSnapshot(`
+    - heading "PROJECTS":
+      - button "Select All"
+    - checkbox "foo" [checked=false]
+    - checkbox "bar" [checked=false]
+  `);
+
+  await webView.getByRole('button', { name: 'Select All' }).click();
+  await expect(webView.locator('body')).toMatchAriaSnapshot(`
+    - heading "PROJECTS":
+      - button "Unselect All"
+    - checkbox "foo" [checked]
+    - checkbox "bar" [checked]
+  `);
+});
+
+test('should reflect changes to setting', async ({ activate }) => {
+  const { vscode } = await activate({
+    'playwright.config.js': `module.exports = {}`,
+  });
+
+  const configuration = vscode.workspace.getConfiguration('playwright-repl');
+  await vscode.commands.executeCommand('playwright-repl.toggle.reuseBrowser');
+  expect(configuration.get('reuseBrowser')).toBe(true);
+
+  const webView = vscode.webViews.get('playwright-repl.settingsView')!;
+  await expect(webView.getByLabel('Show browser')).toBeChecked();
+});
+
+test('should open test results', async ({ activate }) => {
+  const { vscode } = await activate({
+    'playwright.config.js': `module.exports = {}`,
+  });
+
+  const webView = vscode.webViews.get('playwright-repl.settingsView')!;
+  await webView.getByText('Reveal test output').click();
+  expect(vscode.commandLog.filter(f => f !== 'testing.getExplorerSelection')).toEqual(['testing.showMostRecentOutput']);
+});
+
+test('should support playwright.env', async ({ activate }) => {
+  const { testController } = await activate({
+    'playwright.config.js': `module.exports = {}`,
+    'example.spec.ts': `
+      import { test } from '@playwright/test';
+      test('one', async () => {
+        console.log('foo=' + process.env.FOO);
+        console.log('bar=' + process.env.BAR);
+      });
+    `,
+  }, {
+    env: {
+      'FOO': 'foo-value',
+      'BAR': { prop: 'bar-value' },
+    }
+  });
+
+  const testItems = testController.findTestItems(/example.spec.ts/);
+  expect(testItems.length).toBe(1);
+
+  const testRun = await testController.run(testItems);
+  const output = testRun.renderLog({ output: true });
+  expect(output).toContain(`foo=foo-value`);
+  expect(output).toContain(`bar={"prop":"bar-value"}`);
+});
+
+test('should reload when playwright.env changes', async ({ activate }) => {
+  const { vscode, testController } = await activate({
+    'playwright.config.js': `module.exports = {}`,
+    'example.spec.ts': `
+      import { test } from '@playwright/test';
+      test('one', async () => {
+        console.log('foo=' + process.env.FOO);
+        console.log('bar=' + process.env.BAR);
+      });
+    `,
+  }, {
+    env: {
+      'FOO': 'foo-value',
+      'BAR': { prop: 'bar-value' },
+    }
+  });
+
+  const configuration = vscode.workspace.getConfiguration('playwright-repl');
+  configuration.update('env', {
+    'FOO': 'foo-value',
+    'BAR': { prop: 'bar-value' },
+  }, true);
+
+  // Changes to settings will trigger async update.
+  await expect.poll(() => testController.findTestItems(/Loading/)).toHaveLength(1);
+  // That will finish.
+  await expect.poll(() => testController.findTestItems(/Loading/)).toHaveLength(0);
+
+  const testItems = testController.findTestItems(/example.spec.ts/);
+  expect(testItems.length).toBe(1);
+
+  const testRun = await testController.run(testItems);
+  const output = testRun.renderLog({ output: true });
+  expect(output).toContain(`foo=foo-value`);
+  expect(output).toContain(`bar={"prop":"bar-value"}`);
+});
+
+test('should sync project enabled state to workspace settings', async ({ activate }) => {
+  const { vscode, testController } = await activate({
+    'playwright.config.ts': `
+      import { defineConfig } from '@playwright/test';
+      export default defineConfig({
+        projects: [
+          { name: 'foo', testMatch: 'foo.ts' },
+          { name: 'bar', testMatch: 'bar.ts' },
+        ]
+      });
+    `,
+  });
+
+  await enableProjects(vscode, ['foo']);
+
+  const webView = vscode.webViews.get('playwright-repl.settingsView')!;
+
+  await expect(webView.getByTestId('projects')).toMatchAriaSnapshot(`
+    - checkbox "foo" [checked]
+    - checkbox "bar" [checked=false]
+  `);
+  await testController.run(testController.findTestItems(/example.spec.ts/));
+  expect(vscode.context.workspaceState.get('playwright-repl.workspace-settings')).toEqual({
+    configs: [
+      {
+        enabled: true,
+        projects: [
+          {
+            enabled: true,
+            name: 'foo',
+          },
+          {
+            enabled: false,
+            name: 'bar',
+          },
+        ],
+        relativeConfigFile: 'playwright.config.ts',
+        selected: true,
+      },
+    ],
+  });
+
+  await webView.getByRole('checkbox', { name: 'bar' }).check();
+  await expect(webView.getByTestId('projects')).toMatchAriaSnapshot(`
+    - checkbox "foo" [checked]
+    - checkbox "bar" [checked]
+  `);
+  expect(vscode.context.workspaceState.get('playwright-repl.workspace-settings')).toEqual(expect.objectContaining({
+    configs: [
+      expect.objectContaining({
+        enabled: true,
+        projects: [
+          expect.objectContaining({ name: 'foo', enabled: true }),
+          expect.objectContaining({ name: 'bar', enabled: true }),
+        ]
+      })
+    ]
+  }));
+});
+
+test('should read project enabled state from workspace settings', async ({ vscode, activate }) => {
+  vscode.context.workspaceState.update('playwright-repl.workspace-settings', {
+    configs: [
+      {
+        relativeConfigFile: 'playwright.config.ts',
+        selected: true,
+        enabled: true,
+        projects: [
+          { name: 'foo', enabled: true },
+          { name: 'bar', enabled: false }
+        ]
+      }
+    ]
+  });
+
+  await activate({
+    'playwright.config.ts': `
+      import { defineConfig } from '@playwright/test';
+      export default defineConfig({
+        projects: [
+          { name: 'foo', testMatch: 'foo.ts' },
+          { name: 'bar', testMatch: 'bar.ts' },
+          { name: 'baz', testMatch: 'baz.ts' },
+        ]
+      });
+    `,
+  });
+
+  const webView = vscode.webViews.get('playwright-repl.settingsView')!;
+  await expect(webView.getByTestId('projects')).toMatchAriaSnapshot(`
+    - checkbox "foo" [checked]
+    - checkbox "bar" [checked=false]
+    - checkbox "baz" [checked=false]
+  `);
+});

--- a/packages/vscode/tests/source-map.spec.ts
+++ b/packages/vscode/tests/source-map.spec.ts
@@ -1,0 +1,343 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { escapedPathSep, expect, test } from './utils';
+
+test('should list files', async ({ activate }) => {
+  const { vscode, testController } = await activate({
+    'playwright.config.js': `module.exports = { testDir: 'build' }`,
+    'tests/test.spec.ts': testSpecTs,
+    'build/test.spec.js': testSpecJs('test.spec'),
+    'build/test.spec.js.map': testSpecJsMap('test.spec'),
+  });
+  await expect(testController).toHaveTestTree(`
+    -   tests
+      -   test.spec.ts
+  `);
+  await expect(vscode).toHaveConnectionLog([
+    { method: 'listFiles', params: {} },
+  ]);
+});
+
+test('should list tests on expand', async ({ activate }) => {
+  const { vscode, testController } = await activate({
+    'playwright.config.js': `module.exports = { testDir: 'build' }`,
+    'tests/test.spec.ts': testSpecTs,
+    'build/test.spec.js': testSpecJs('test.spec'),
+    'build/test.spec.js.map': testSpecJsMap('test.spec'),
+  });
+
+  await testController.expandTestItems(/test.spec.ts/);
+  await expect(testController).toHaveTestTree(`
+    -   tests
+      -   test.spec.ts
+        -   one [2:0]
+        -   two [3:0]
+  `);
+
+  await expect(vscode).toHaveConnectionLog([
+    { method: 'listFiles', params: {} },
+    {
+      method: 'listTests',
+      params: expect.objectContaining({
+        locations: [expect.stringContaining(`tests${escapedPathSep}test\\.spec\\.ts`)],
+      })
+    },
+  ]);
+});
+
+test('should list tests for visible editors', async ({ activate }) => {
+  const { vscode, testController } = await activate({
+    'playwright.config.js': `module.exports = { testDir: 'build' }`,
+    'tests/test.spec.ts': testSpecTs,
+    'build/test.spec.js': testSpecJs('test.spec'),
+    'build/test.spec.js.map': testSpecJsMap('test.spec'),
+  });
+
+  await vscode.openEditors('**/test.spec.ts');
+  await new Promise(f => testController.onDidChangeTestItem(f));
+
+  await expect(testController).toHaveTestTree(`
+    -   tests
+      -   test.spec.ts
+        -   one [2:0]
+        -   two [3:0]
+  `);
+
+  await expect(vscode).toHaveConnectionLog([
+    { method: 'listFiles', params: {} },
+    {
+      method: 'listTests',
+      params: expect.objectContaining({
+        locations: [expect.stringContaining('test\\.spec\\.ts')],
+      })
+    },
+  ]);
+});
+
+test('should pick new files', async ({ activate }) => {
+  const { vscode, workspaceFolder, testController } = await activate({
+    'playwright.config.js': `module.exports = { testDir: 'build' }`,
+    'tests/test-1.spec.ts': testSpecTs,
+    'build/test-1.spec.js': testSpecJs('test-1.spec'),
+    'build/test-1.spec.js.map': testSpecJsMap('test-1.spec'),
+  });
+
+  await expect(testController).toHaveTestTree(`
+    -   tests
+      -   test-1.spec.ts
+  `);
+
+
+  await Promise.all([
+    new Promise(f => testController.onDidChangeTestItem(f)),
+    workspaceFolder.addFile('tests/test-2.spec.ts', testSpecTs),
+    workspaceFolder.addFile('build/test-2.spec.js', testSpecJs('test-2.spec')),
+    workspaceFolder.addFile('build/test-2.spec.js.map', testSpecJsMap('test-2.spec')),
+  ]);
+
+  await expect(testController).toHaveTestTree(`
+    -   tests
+      -   test-1.spec.ts
+      -   test-2.spec.ts
+  `);
+
+  await expect(vscode).toHaveConnectionLog([
+    { method: 'listFiles', params: {} },
+    { method: 'listFiles', params: {} },
+  ]);
+});
+
+test('should remove deleted files', async ({ activate }) => {
+  const { vscode, workspaceFolder, testController } = await activate({
+    'playwright.config.js': `module.exports = { testDir: 'build' }`,
+    'tests/test-1.spec.ts': testSpecTs,
+    'tests/test-2.spec.ts': testSpecTs,
+    'tests/test-3.spec.ts': testSpecTs,
+    'build/test-1.spec.js': testSpecJs('test-1.spec'),
+    'build/test-2.spec.js': testSpecJs('test-2.spec'),
+    'build/test-3.spec.js': testSpecJs('test-3.spec'),
+    'build/test-1.spec.js.map': testSpecJsMap('test-1.spec'),
+    'build/test-2.spec.js.map': testSpecJsMap('test-2.spec'),
+    'build/test-3.spec.js.map': testSpecJsMap('test-3.spec'),
+  });
+
+  await expect(testController).toHaveTestTree(`
+    -   tests
+      -   test-1.spec.ts
+      -   test-2.spec.ts
+      -   test-3.spec.ts
+  `);
+
+  await expect(vscode).toHaveConnectionLog([
+    { method: 'listFiles', params: {} },
+  ]);
+
+  await Promise.all([
+    new Promise(f => testController.onDidChangeTestItem(f)),
+    workspaceFolder.removeFile('tests/test-2.spec.ts'),
+    workspaceFolder.removeFile('build/test-2.spec.js'),
+    workspaceFolder.removeFile('build/test-2.spec.js.map'),
+  ]);
+
+  await expect(testController).toHaveTestTree(`
+    -   tests
+      -   test-1.spec.ts
+      -   test-3.spec.ts
+  `);
+
+  await expect(vscode).toHaveConnectionLog([
+    { method: 'listFiles', params: {} },
+    { method: 'listFiles', params: {} },
+  ]);
+});
+
+test('should discover new tests', async ({ activate }) => {
+  const { vscode, testController, workspaceFolder } = await activate({
+    'playwright.config.js': `module.exports = { testDir: 'build' }`,
+    'tests/test.spec.ts': testSpecTs,
+    'build/test.spec.js': testSpecJs('test.spec'),
+    'build/test.spec.js.map': testSpecJsMap('test.spec'),
+  });
+
+  await testController.expandTestItems(/test.spec.ts/);
+
+  await expect(vscode).toHaveConnectionLog([
+    { method: 'listFiles', params: {} },
+    {
+      method: 'listTests',
+      params: expect.objectContaining({
+        locations: [expect.stringContaining(`tests${escapedPathSep}test\\.spec\\.ts`)],
+      })
+    },
+  ]);
+  vscode.commandLog.length = 0;
+
+  await Promise.all([
+    new Promise(f => testController.onDidChangeTestItem(f)),
+    workspaceFolder.changeFile('tests/test.spec.ts', testSpecTsAfter),
+    workspaceFolder.changeFile('build/test.spec.js', testSpecJsAfter),
+    workspaceFolder.changeFile('build/test.spec.js.map', testSpecJsMapAfter),
+  ]);
+
+  await expect(testController).toHaveTestTree(`
+    -   tests
+      -   test.spec.ts
+        -   new [2:0]
+        -   one [3:0]
+        -   two [4:0]
+  `);
+
+  await expect(vscode).toHaveConnectionLog([
+    { method: 'listFiles', params: {} },
+    {
+      method: 'listTests',
+      params: expect.objectContaining({
+        locations: [expect.stringContaining(`tests${escapedPathSep}test\\.spec\\.ts`)],
+      })
+    },
+    {
+      method: 'listTests',
+      params: expect.objectContaining({
+        locations: [expect.stringContaining(`tests${escapedPathSep}test\\.spec\\.ts`)],
+      })
+    },
+  ]);
+
+});
+
+test('should run all tests', async ({ activate }) => {
+  const { vscode, testController } = await activate({
+    'playwright.config.js': `module.exports = { testDir: 'build' }`,
+    'tests/test.spec.ts': testSpecTs,
+    'build/test.spec.js': testSpecJs('test.spec'),
+    'build/test.spec.js.map': testSpecJsMap('test.spec'),
+  });
+
+  const testRun = await testController.run();
+  expect(testRun.renderLog()).toBe(`
+    tests > test.spec.ts > one [2:0]
+      enqueued
+      started
+      passed
+    tests > test.spec.ts > two [3:0]
+      enqueued
+      started
+      passed
+  `);
+
+  await expect(vscode).toHaveConnectionLog([
+    { method: 'listFiles', params: {} },
+    { method: 'runGlobalSetup', params: {} },
+    {
+      method: 'runTests',
+      params: expect.objectContaining({
+        locations: [],
+        testIds: undefined
+      })
+    },
+  ]);
+});
+
+test('should run one test', async ({ activate }) => {
+  const { vscode, testController } = await activate({
+    'playwright.config.js': `module.exports = { testDir: 'build' }`,
+    'tests/test.spec.ts': testSpecTs,
+    'build/test.spec.js': testSpecJs('test.spec'),
+    'build/test.spec.js.map': testSpecJsMap('test.spec'),
+  });
+
+  await testController.expandTestItems(/test.spec/);
+  const testItems = testController.findTestItems(/one/);
+  const testRun = await testController.run(testItems);
+
+  expect(testRun.renderLog()).toBe(`
+    tests > test.spec.ts > one [2:0]
+      enqueued
+      enqueued
+      started
+      passed
+  `);
+
+  await expect(vscode).toHaveConnectionLog([
+    { method: 'listFiles', params: {} },
+    {
+      method: 'listTests',
+      params: expect.objectContaining({
+        locations: [expect.stringContaining(`tests${escapedPathSep}test\\.spec\\.ts`)],
+      })
+    },
+    { method: 'runGlobalSetup', params: {} },
+    {
+      method: 'runTests',
+      params: expect.objectContaining({
+        locations: [
+          expect.stringContaining(`tests${escapedPathSep}test\\.spec\\.ts`),
+        ],
+        testIds: [
+          expect.any(String),
+        ]
+      })
+    },
+  ]);
+});
+
+
+const testSpecTs = `import { test } from '@playwright/test';
+
+test('one', async ({}) => {});
+test('two', async ({}) => {});`;
+
+
+const testSpecJs = (name: string) => `var import_test = require("@playwright/test");
+(0, import_test.test)("one", async ({}) => {
+});
+(0, import_test.test)("two", async ({}) => {
+});
+//# sourceMappingURL=${name}.js.map`;
+
+
+const testSpecJsMap = (name: string) => `{
+  "version": 3,
+  "sources": ["../tests/${name}.ts"],
+  "mappings": "AAAA,kBAAqB;AAErB,sBAAK,OAAO,OAAO,OAAO;AAAA;AAC1B,sBAAK,OAAO,OAAO,OAAO;AAAA;",
+  "names": []
+}`;
+
+
+const testSpecTsAfter = `import { test } from '@playwright/test';
+
+test('new', async ({}) => {});
+test('one', async ({}) => {});
+test('two', async ({}) => {});`;
+
+
+const testSpecJsAfter = `var import_test = require("@playwright/test");
+(0, import_test.test)("new", async ({}) => {
+});
+(0, import_test.test)("one", async ({}) => {
+});
+(0, import_test.test)("two", async ({}) => {
+});
+//# sourceMappingURL=test.spec.js.map`;
+
+
+const testSpecJsMapAfter = `{
+  "version": 3,
+  "sources": ["../tests/test.spec.ts"],
+  "mappings": "AAAA,kBAAqB;AAErB,sBAAK,OAAO,OAAO,OAAO;AAAA;AAC1B,sBAAK,OAAO,OAAO,OAAO;AAAA;AAC1B,sBAAK,OAAO,OAAO,OAAO;AAAA;",
+  "names": []
+}`;

--- a/packages/vscode/tests/trace-viewer.spec.ts
+++ b/packages/vscode/tests/trace-viewer.spec.ts
@@ -1,0 +1,181 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { enableConfigs, expect, selectConfig, selectTestItem, test, traceViewerInfo } from './utils';
+
+test.skip(({ showTrace }) => !showTrace);
+
+test('@smoke should open trace viewer', async ({ activate }) => {
+  const { vscode, testController } = await activate({
+    'playwright.config.js': `module.exports = { testDir: 'tests' }`,
+    'tests/test.spec.ts': `
+      import { test } from '@playwright/test';
+      test('should pass', async () => {});
+    `,
+  });
+
+  await testController.run();
+  await testController.expandTestItems(/test.spec/);
+  selectTestItem(testController.findTestItems(/pass/)[0]);
+
+  await expect.poll(() => traceViewerInfo(vscode)).toMatchObject({
+    traceFile: expect.stringContaining('pass'),
+  });
+});
+
+test('should change opened file in trace viewer', async ({ activate }) => {
+  const { vscode, testController } = await activate({
+    'playwright.config.js': `module.exports = { testDir: 'tests' }`,
+    'tests/test.spec.ts': `
+      import { test } from '@playwright/test';
+      test('one', async () => {});
+      test('two', async () => {});
+    `,
+  });
+
+  await testController.run();
+  await testController.expandTestItems(/test.spec/);
+
+  selectTestItem(testController.findTestItems(/one/)[0]);
+
+  await expect.poll(() => traceViewerInfo(vscode)).toMatchObject({
+    traceFile: expect.stringContaining('one'),
+  });
+
+  selectTestItem(testController.findTestItems(/two/)[0]);
+
+  await expect.poll(() => traceViewerInfo(vscode)).toMatchObject({
+    traceFile: expect.stringContaining('two'),
+  });
+});
+
+test('should not open trace viewer if test did not run', async ({ activate }) => {
+  const { vscode, testController } = await activate({
+    'playwright.config.js': `module.exports = { testDir: 'tests' }`,
+    'tests/test.spec.ts': `
+      import { test } from '@playwright/test';
+      test('should pass', async () => {});
+    `,
+  });
+
+  await testController.expandTestItems(/test.spec/);
+  selectTestItem(testController.findTestItems(/pass/)[0]);
+
+  await expect.poll(() => traceViewerInfo(vscode)).toMatchObject({
+    traceFile: undefined,
+  });
+});
+
+test('should refresh trace viewer while test is running', async ({ activate, createLatch }) => {
+  const latch = createLatch();
+
+  const { vscode, testController } = await activate({
+    'playwright.config.js': `module.exports = { testDir: 'tests' }`,
+    'tests/test.spec.ts': `
+      import { test } from '@playwright/test';
+      test('should pass', async () => ${latch.blockingCode});
+    `,
+  });
+
+  await testController.expandTestItems(/test.spec/);
+  selectTestItem(testController.findTestItems(/pass/)[0]);
+
+  const testRunPromise = testController.run();
+  await expect.poll(() => traceViewerInfo(vscode)).toMatchObject({
+    traceFile: expect.stringMatching(/\.json$/),
+  });
+
+  latch.open();
+  await testRunPromise;
+
+  await expect.poll(() => traceViewerInfo(vscode)).toMatchObject({
+    traceFile: expect.stringMatching(/\.zip$/),
+  });
+});
+
+test('should close trace viewer if test configs refreshed', async ({ activate }) => {
+  const { vscode, testController } = await activate({
+    'playwright.config.js': `module.exports = { testDir: 'tests' }`,
+    'tests/test.spec.ts': `
+      import { test } from '@playwright/test';
+      test('should pass', async () => {});
+    `,
+  });
+
+  await testController.run();
+  await testController.expandTestItems(/test.spec/);
+  selectTestItem(testController.findTestItems(/pass/)[0]);
+
+  await expect.poll(() => traceViewerInfo(vscode)).toMatchObject({
+    traceFile: expect.stringContaining('pass'),
+  });
+
+  await testController.refreshHandler!(null);
+
+  await expect.poll(() => traceViewerInfo(vscode)).toMatchObject({
+    traceFile: undefined,
+    visible: false,
+  });
+});
+
+test('should open new trace viewer when another test config is selected', async ({ activate }) => {
+  const { vscode, testController } = await activate({
+    'playwright1.config.js': `module.exports = { testDir: 'tests1' }`,
+    'playwright2.config.js': `module.exports = { testDir: 'tests2' }`,
+    'tests1/test.spec.ts': `
+      import { test } from '@playwright/test';
+      test('one', () => {});
+      `,
+    'tests2/test.spec.ts': `
+      import { test } from '@playwright/test';
+      test('one', () => {});
+      `,
+  });
+
+  await enableConfigs(vscode, ['playwright1.config.js', 'playwright2.config.js']);
+  await selectConfig(vscode, 'playwright1.config.js');
+
+  await testController.expandTestItems(/test.spec/);
+  const testItems = testController.findTestItems(/one/);
+  await testController.run(testItems);
+
+  selectTestItem(testItems[0]);
+
+  await expect.poll(() => traceViewerInfo(vscode)).toMatchObject({
+    serverUrlPrefix: expect.stringContaining('http'),
+    testConfigFile: expect.stringContaining('playwright1.config.js'),
+  });
+  const serverUrlPrefix1 = traceViewerInfo(vscode);
+
+  // closes opened trace viewer
+  await selectConfig(vscode, 'playwright2.config.js');
+
+  await expect.poll(() => traceViewerInfo(vscode)).toMatchObject({
+    traceFile: undefined,
+    visible: false,
+  });
+
+  // opens trace viewer from selected test config
+  selectTestItem(testItems[0]);
+
+  await expect.poll(() => traceViewerInfo(vscode)).toMatchObject({
+    serverUrlPrefix: expect.stringContaining('http'),
+    testConfigFile: expect.stringContaining('playwright2.config.js'),
+  });
+  const serverUrlPrefix2 = traceViewerInfo(vscode);
+
+  expect(serverUrlPrefix2).not.toBe(serverUrlPrefix1);
+});

--- a/packages/vscode/tests/track-configs.spec.ts
+++ b/packages/vscode/tests/track-configs.spec.ts
@@ -1,0 +1,204 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { TestItem } from './mock/vscode';
+import { enableConfigs, expect, test } from './utils';
+import path from 'node:path';
+
+test('should load first config', async ({ activate }) => {
+  const { vscode, testController, workspaceFolder } = await activate({});
+  await expect(testController).toHaveTestTree(`
+  `);
+
+  await workspaceFolder.addFile('playwright.config.js', `module.exports = { testDir: 'tests' }`);
+  await workspaceFolder.addFile('tests/test.spec.ts', `
+    import { test } from '@playwright/test';
+    test('one', async () => {});
+  `);
+
+  await expect(testController).toHaveTestTree(`
+    -   tests
+      -   test.spec.ts
+  `);
+
+  await expect(vscode).toHaveConnectionLog([
+    { method: 'listFiles', params: {} },
+  ]);
+});
+
+test('should load second config', async ({ activate }) => {
+  const { vscode, testController, workspaceFolder } = await activate({
+    'playwright1.config.js': `module.exports = { testDir: 'tests1' }`,
+    'tests1/test.spec.ts': `
+      import { test } from '@playwright/test';
+      test('one', async () => {});
+    `,
+  });
+  await expect(testController).toHaveTestTree(`
+    -   tests1
+      -   test.spec.ts
+  `);
+
+  await workspaceFolder.addFile('playwright2.config.js', `module.exports = { testDir: 'tests2' }`);
+  await workspaceFolder.addFile('tests2/test.spec.ts', `
+    import { test } from '@playwright/test';
+    test('one', async () => {});
+  `);
+
+  await enableConfigs(vscode, ['playwright1.config.js', 'playwright2.config.js']);
+  await expect(testController).toHaveTestTree(`
+    -   tests1
+      -   test.spec.ts
+    -   tests2
+      -   test.spec.ts
+  `);
+
+  await expect(vscode).toHaveConnectionLog([
+    { method: 'listFiles', params: {} },
+    { method: 'listFiles', params: {} },
+    { method: 'listFiles', params: {} },
+  ]);
+});
+
+test('should remove model for config', async ({ activate }) => {
+  const { vscode, testController, workspaceFolder } = await activate({
+    'playwright1.config.js': `module.exports = { testDir: 'tests1' }`,
+    'playwright2.config.js': `module.exports = { testDir: 'tests2' }`,
+    'tests1/test.spec.ts': `
+      import { test } from '@playwright/test';
+      test('one', async () => {});
+    `,
+    'tests2/test.spec.ts': `
+      import { test } from '@playwright/test';
+      test('one', async () => {});
+    `,
+  });
+
+  await enableConfigs(vscode, ['playwright1.config.js', 'playwright2.config.js']);
+
+  await expect(testController).toHaveTestTree(`
+    -   tests1
+      -   test.spec.ts
+    -   tests2
+      -   test.spec.ts
+  `);
+
+  await workspaceFolder.removeFile('playwright1.config.js');
+
+  await expect(testController).toHaveTestTree(`
+    -   tests2
+      -   test.spec.ts
+  `);
+
+  await expect(vscode).toHaveConnectionLog([
+    { method: 'listFiles', params: {} },
+    { method: 'listFiles', params: {} },
+    { method: 'listFiles', params: {} },
+  ]);
+});
+
+test('should show config loading errors', async ({ vscode, activate }) => {
+  const { testController } = await activate({
+    'playwright1.config.js': `
+      throw new Error('kaboom');
+    `,
+    'playwright2.config.js': `
+      module.exports = { testDir: 'tests' }
+    `,
+  });
+  await enableConfigs(vscode, ['playwright1.config.js', 'playwright2.config.js']);
+
+  await expect(testController).toHaveTestTree(`
+    -    [playwright1.config.js — Error: kaboom] [1:12]
+      Error: kaboom
+  `);
+
+  const testItems = testController.findTestItems(/.*/);
+  void testController.run(testItems);
+  await expect.poll(() => vscode.window.activeTextEditor?.document.uri.toString()).toContain('playwright1.config.js');
+});
+
+test('should order configs intuitively', async ({ activate }) => {
+  const { vscode } = await activate({
+    'extension/playwright.config.ts': `module.exports = {};`,
+    'playwright.bail.config.ts': `module.exports = {};`,
+    'playwright.config.ts': `module.exports = {};`,
+  });
+
+  const webView = vscode.webViews.get('playwright-repl.settingsView')!;
+  await expect(webView.locator('body')).toMatchAriaSnapshot(`
+    - combobox "Select Playwright Config":
+      - option "playwright.config.ts"
+  `);
+
+  await expect.poll(async () => {
+    const items = new Promise(resolve => {
+      vscode.window.mockQuickPick = async (items: TestItem[]) => {
+        resolve(items.map(i => i.label));
+        return items;
+      };
+    });
+
+    await webView.getByTitle('Toggle Playwright Configs').click();
+
+    return items;
+  }).toEqual([
+    'playwright.config.ts',
+    `playwright.bail.config.ts`,
+    `extension${path.sep}playwright.config.ts`,
+  ]);
+});
+
+function debounceAsync<T>(fn: (...args: any[]) => Promise<T>, delay: number) {
+  const pendingCalls: ((result: T) => void)[] = [];
+  let debounce: NodeJS.Timeout | undefined;
+  return function(...args: any[]): Promise<T> {
+    return new Promise(resolve => {
+      pendingCalls.push(resolve);
+      clearTimeout(debounce);
+      debounce = setTimeout(async () => {
+        const result = await fn(...args);
+        for (const call of pendingCalls)
+          call(result);
+        pendingCalls.length = 0;
+      }, delay);
+    });
+  };
+}
+
+test('git checkout should not lead to duplicate configs', { annotation: { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/37764' } }, async ({ activate }) => {
+  const { vscode, workspaceFolder } = await activate({
+    'playwright.config.js': `module.exports = {};`,
+    'playwright-two.config.js': `module.exports = {};`,
+  });
+
+  // Simulate VS Code coalescing findFiles calls
+  vscode.workspace.findFiles = debounceAsync(vscode.workspace.findFiles, 50);
+
+  await Promise.all([
+    workspaceFolder.changeFile('playwright.config.js', `module.exports = {}`),
+    workspaceFolder.changeFile('playwright-two.config.js', `module.exports = {}`),
+  ]);
+
+  await expect.poll(async () => {
+    const webView = vscode.webViews.get('playwright-repl.settingsView')!;
+    const [testItems] = await Promise.all([
+      new Promise<TestItem[]>(resolve => { vscode.window.mockQuickPick = resolve; }),
+      webView.getByTitle('Toggle Playwright Configs').click(),
+    ]);
+    return testItems.map(i => i.label);
+  }).toEqual(['playwright.config.js', 'playwright-two.config.js']);
+});

--- a/packages/vscode/tests/update-snapshots.spec.ts
+++ b/packages/vscode/tests/update-snapshots.spec.ts
@@ -1,0 +1,117 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import fs from 'fs';
+import { expect, test } from './utils';
+
+for (const mode of ['3-way', 'overwrite', 'patch'] as const) {
+  test('should update missing snapshots ' + mode, async ({ activate }, testInfo) => {
+    const { vscode, testController } = await activate({
+      'playwright.config.ts': `
+        import { defineConfig } from '@playwright/test';
+        export default defineConfig({});
+      `,
+      'test.spec.ts': `
+        import { test, expect } from '@playwright/test';
+        test('should pass', async ({ page }) => {
+          await page.setContent('<button>Click me</button>');
+          await expect(page.locator('body')).toMatchAriaSnapshot('');
+        });
+      `,
+    });
+
+    const webView = vscode.webViews.get('playwright-repl.settingsView')!;
+    await webView.getByRole('combobox', { name: 'Update method' }).selectOption(mode);
+    await webView.getByRole('combobox', { name: 'Update snapshots' }).selectOption('missing');
+
+    await testController.run();
+
+    let expectation;
+    if (mode === '3-way') {
+      expectation = `<<<<<<< HEAD
+          await expect(page.locator('body')).toMatchAriaSnapshot('');
+=======
+          await expect(page.locator('body')).toMatchAriaSnapshot(\`
+            - button "Click me"
+          \`);
+>>>>>>> SNAPSHOT`;
+    } else if (mode === 'overwrite') {
+      expectation = `
+          await page.setContent('<button>Click me</button>');
+          await expect(page.locator('body')).toMatchAriaSnapshot(\`
+            - button "Click me"
+          \`);`;
+    } else {
+      expectation = `
+          await page.setContent('<button>Click me</button>');
+          await expect(page.locator('body')).toMatchAriaSnapshot('');`;
+    }
+
+    await expect.poll(() => {
+      return fs.promises.readFile(testInfo.outputPath('test.spec.ts'), 'utf8');
+    }).toContain(expectation);
+  });
+}
+
+for (const mode of ['3-way' , 'overwrite', 'patch'] as const) {
+  test('should update all snapshots ' + mode, async ({ activate }, testInfo) => {
+    const { vscode, testController } = await activate({
+      'playwright.config.ts': `
+        import { defineConfig } from '@playwright/test';
+        export default defineConfig({});
+      `,
+      'test.spec.ts': `
+        import { test, expect } from '@playwright/test';
+        test('should pass', async ({ page }) => {
+          await page.setContent('<button>Click me</button>');
+          await expect(page.locator('body')).toMatchAriaSnapshot(\`
+            - button
+          \`);
+        });
+      `,
+    });
+
+    const webView = vscode.webViews.get('playwright-repl.settingsView')!;
+    await webView.getByRole('combobox', { name: 'Update method' }).selectOption(mode);
+    await webView.getByRole('combobox', { name: 'Update snapshots' }).selectOption('all');
+
+    await testController.run();
+
+    let expectation;
+    if (mode === '3-way') {
+      expectation = `<<<<<<< HEAD
+            - button
+=======
+            - button "Click me"
+>>>>>>> SNAPSHOT`;
+    } else if (mode === 'overwrite') {
+      expectation = `
+          await page.setContent('<button>Click me</button>');
+          await expect(page.locator('body')).toMatchAriaSnapshot(\`
+            - button "Click me"
+          \`);`;
+    } else {
+      expectation = `
+          await expect(page.locator('body')).toMatchAriaSnapshot(\`
+            - button
+          \`);`;
+    }
+
+    await expect.poll(() => {
+      return fs.promises.readFile(testInfo.outputPath('test.spec.ts'), 'utf8');
+    }).toContain(expectation);
+  });
+}

--- a/packages/vscode/tests/utils.ts
+++ b/packages/vscode/tests/utils.ts
@@ -1,0 +1,276 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { expect as baseExpect, test as baseTest, Browser, BrowserContextOptions, chromium, Page } from '@playwright/test';
+// @ts-ignore
+import { Extension } from '../dist/extension';
+import { TestController, VSCode, WorkspaceFolder, TestRun, TestItem } from './mock/vscode';
+
+import crypto from 'crypto';
+import fs from 'fs';
+import path from 'path';
+
+process.env.PW_DEBUG_CONTROLLER_HEADLESS = '1';
+// the x-pw-highlight element has otherwise a closed shadow root.
+process.env.PWTEST_UNDER_TEST = '1';
+
+type ActivateResult = {
+  vscode: VSCode,
+  testController: TestController;
+  workspaceFolder: WorkspaceFolder;
+};
+
+type Latch = {
+  blockingCode: string;
+  open: () => void;
+  close: () => void;
+};
+
+type TestFixtures = {
+  vscode: VSCode,
+  activate: (files: { [key: string]: string }, options?: { rootDir?: string, workspaceFolders?: [string, any][], env?: Record<string, any>, runGlobalSetupOnEachRun?: boolean }) => Promise<ActivateResult>;
+  createLatch: () => Latch;
+};
+
+export type WorkerOptions = {
+  showBrowser: boolean;
+  showTrace?: boolean;
+  vsCodeVersion: number;
+};
+
+// Make sure connect tests work with the locally-rolled version.
+process.env.PW_VERSION_OVERRIDE = require('@playwright/test/package.json').version;
+
+export const expect = baseExpect.extend({
+  async toHaveTestTree(testController: TestController, expectedTree: string) {
+    try {
+      await expect.poll(() => testController.renderTestTree()).toBe(expectedTree);
+      return { pass: true, message: () => '' };
+    } catch (e) {
+      return {
+        pass: false,
+        message: () => String(e)
+      };
+    }
+  },
+
+  async toHaveProjectTree(vscode: VSCode, expectedTree: string) {
+    try {
+      await expect.poll(() => vscode.renderProjectTree().then(s => s.trim().replace(/\\/, '/'))).toBe(expectedTree.trim());
+      return { pass: true, message: () => '' };
+    } catch (e) {
+      return {
+        pass: false,
+        message: () => String(e)
+      };
+    }
+  },
+
+  async toHaveOutput(testRun: TestRun, expectedOutput: string | RegExp) {
+    try {
+      await expect.poll(() => testRun.renderOutput()).toMatch(expectedOutput);
+      return { pass: true, message: () => '' };
+    } catch (e) {
+      return {
+        pass: false,
+        message: () => String(e)
+      };
+    }
+  },
+
+  async toHaveConnectionLog(vscode: VSCode, expectedLog: any) {
+    const filterCommands = new Set(['ping', 'initialize']);
+    const filteredLog = () => {
+      return vscode.connectionLog.filter(e => !filterCommands.has(e.method));
+    };
+    try {
+      await expect.poll(() => filteredLog()).toEqual(expectedLog);
+      return { pass: true, message: () => '' };
+    } catch (e) {
+      return {
+        pass: false,
+        message: () => String(e)
+      };
+    }
+  },
+});
+
+let _l10Bundles: [bundle: string, contents: Record<string, string>][];
+function l10Bundles() {
+  if (!_l10Bundles) {
+    const l10nDir = path.resolve(__dirname, '..', 'l10n');
+    _l10Bundles = fs.readdirSync(l10nDir).map(file => [file, JSON.parse(fs.readFileSync(path.join(l10nDir, file), 'utf-8'))]);
+  }
+  return _l10Bundles;
+}
+
+export const test = baseTest.extend<TestFixtures, WorkerOptions>({
+  showBrowser: [false, { option: true, scope: 'worker' }],
+  showTrace: [undefined, { option: true, scope: 'worker' }],
+  vsCodeVersion: [1.86, { option: true, scope: 'worker' }],
+
+  vscode: async ({ browser, vsCodeVersion }, use) => {
+    const vscode = new VSCode(vsCodeVersion, path.resolve(__dirname, '..'), browser);
+    await use(vscode);
+
+    if (process.env.VALIDATE_L10N) {
+      for (const message of vscode.l10n.accessedMessages) {
+        for (const [bundle, contents] of l10Bundles())
+          expect.soft(contents[message], `message "${message}" missing in ${bundle}`).toBeDefined();
+      }
+    }
+  },
+
+  activate: async ({ vscode, showBrowser, showTrace }, use, testInfo) => {
+    const instances: VSCode[] = [];
+    await use(async (files: { [key: string]: string }, options?: { rootDir?: string, workspaceFolders?: [string, any][], env?: Record<string, any>, runGlobalSetupOnEachRun?: boolean }) => {
+      if (options?.workspaceFolders) {
+        for (const wf of options?.workspaceFolders)
+          await vscode.addWorkspaceFolder(wf[0], wf[1]);
+      } else {
+        await vscode.addWorkspaceFolder(options?.rootDir || testInfo.outputDir, files);
+      }
+
+      const configuration = vscode.workspace.getConfiguration('playwright-repl');
+      if (options?.env)
+        configuration.update('env', options.env);
+      if (options?.runGlobalSetupOnEachRun)
+        configuration.update('runGlobalSetupOnEachRun', true);
+      if (showBrowser)
+        configuration.update('reuseBrowser', true);
+      if (showTrace) {
+        configuration.update('showTrace', true);
+
+        // prevents spawn trace viewer process from opening app and browser
+        vscode.env.remoteName = 'ssh-remote';
+        process.env.PWTEST_UNDER_TEST = '1';
+      }
+
+      const extension = new Extension(vscode, vscode.context);
+      vscode.extensions.push(extension);
+      await vscode.activate();
+
+      instances.push(vscode);
+      return {
+        vscode,
+        testController: vscode.testControllers[0],
+        workspaceFolder: vscode.workspace.workspaceFolders[0],
+      };
+    });
+    for (const vscode of instances)
+      vscode.dispose();
+  },
+
+  // Copied from https://github.com/microsoft/playwright/blob/7e7319da7d84de6648900e27e6d844bec9071222/tests/playwright-test/ui-mode-fixtures.ts#L132
+  createLatch: async ({}, use, testInfo) => {
+    await use(() => {
+      const latchFile = path.join(testInfo.project.outputDir, createGuid() + '.latch');
+      return {
+        blockingCode: `await ((${waitForLatch})(${JSON.stringify(latchFile)}))`,
+        open: () => fs.writeFileSync(latchFile, 'ok'),
+        close: () => fs.unlinkSync(latchFile),
+      };
+    });
+  },
+});
+
+export async function connectToSharedBrowser(vscode: VSCode) {
+  await expect.poll(() => vscode.extensions[0].browserServerWSForTest()).toBeTruthy();
+  const wsEndpoint = new URL(vscode.extensions[0].browserServerWSForTest());
+  wsEndpoint.searchParams.set('connect', 'first');
+  return await chromium.connect(wsEndpoint.toString());
+}
+
+export async function waitForRecorderMode(vscode: VSCode, mode: string) {
+  await expect.poll(() => vscode.extensions[0].recorderModeForTest()).toBe(mode);
+}
+
+export async function waitForPage(browser: Browser, params?: BrowserContextOptions) {
+  let pages: Page[] = [];
+  await expect.poll(async () => {
+    const context = browser.contexts()[0] ?? await (browser as any)._newContextForReuse(params);
+    pages = context.pages();
+    return pages.length;
+  }).toBeTruthy();
+  return pages[0];
+}
+
+export async function enableConfigs(vscode: VSCode, labels: string[]) {
+  let success = false;
+  const webView = vscode.webViews.get('playwright-repl.settingsView')!;
+  while (!success) {
+    vscode.window.mockQuickPick = async (items: TestItem[]) => {
+      let allFound = true;
+      for (const label of labels) {
+        if (!items.find(i => i.label === label))
+          allFound = false;
+      }
+      // Wait for all the selected options to become available, discard.
+      if (!allFound) {
+        await new Promise(f => setTimeout(f, 100));
+        return undefined;
+      }
+      success = true;
+      return items.filter(i => labels.includes(i.label));
+    };
+    await webView.getByTitle('Toggle Playwright Configs').click();
+  }
+}
+
+export async function selectConfig(vscode: VSCode, label: string) {
+  const webView = vscode.webViews.get('playwright-repl.settingsView')!;
+  await webView.getByTestId('models').selectOption({ label });
+}
+
+export async function enableProjects(vscode: VSCode, projects: string[]) {
+  const webView = vscode.webViews.get('playwright-repl.settingsView')!;
+  for (const project of projects)
+    await expect(webView.getByTestId('projects').getByLabel(project)).toBeVisible();
+  for (const checkbox of await webView.getByTestId('projects').locator('label').all()) {
+    await checkbox.uncheck(); // ensure change, so that settings get saved
+    if (projects.includes(await checkbox.textContent() ?? ''))
+      await checkbox.check();
+  }
+}
+
+function escapeRegex(text: string) {
+  return text.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+export const escapedPathSep = escapeRegex(path.sep);
+
+export function selectTestItem(testItem: TestItem) {
+  testItem.testController.vscode.extensions[0].fireTreeItemSelectedForTest(testItem);
+}
+
+export async function singleWebViewByPanelType(vscode: VSCode, viewType: string) {
+  await expect.poll(() => vscode.webViewsByPanelType(viewType)).toHaveLength(1);
+  return vscode.webViewsByPanelType(viewType)[0];
+}
+
+export async function traceViewerInfo(vscode: VSCode): Promise<{ type: 'spawn', serverUrlPrefix?: string, testConfigFile: string, traceFile: string } | undefined> {
+  return await vscode.extensions[0].traceViewerInfoForTest();
+}
+
+async function waitForLatch(latchFile: string) {
+  const fs = require('fs');
+  while (!fs.existsSync(latchFile))
+    await new Promise(f => setTimeout(f, 250));
+}
+
+function createGuid(): string {
+  return crypto.randomBytes(16).toString('hex');
+}

--- a/packages/vscode/tests/vscode-shim.ts
+++ b/packages/vscode/tests/vscode-shim.ts
@@ -1,0 +1,21 @@
+/**
+ * Shim for the 'vscode' module in test builds.
+ *
+ * Our recorder.ts and picker.ts do `import * as vscode from 'vscode'`
+ * which fails outside VS Code. This shim provides a global proxy that
+ * gets populated when the mock VSCode instance is created in tests.
+ *
+ * TODO: Phase 1 should refactor recorder/picker to accept vscode as
+ * a parameter (like upstream does), eliminating the need for this shim.
+ */
+
+const vscodeProxy: Record<string, any> = new Proxy({} as any, {
+  get(_target, prop) {
+    const g = (globalThis as any).__vscodeShim;
+    if (g && prop in g) return g[prop];
+    // Return a no-op for properties not yet set (module load time)
+    return undefined;
+  },
+});
+
+module.exports = vscodeProxy;

--- a/packages/vscode/tests/watch.spec.ts
+++ b/packages/vscode/tests/watch.spec.ts
@@ -1,0 +1,847 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { TestRun } from './mock/vscode';
+import { enableConfigs, enableProjects, escapedPathSep, expect, selectConfig, test } from './utils';
+import path from 'path';
+import { writeFile } from 'node:fs/promises';
+
+test('should watch all tests', async ({ activate }) => {
+  const { vscode, testController, workspaceFolder } = await activate({
+    'playwright.config.js': `module.exports = { testDir: 'tests' }`,
+    'tests/test-1.spec.ts': `
+      import { test } from '@playwright/test';
+      test('should pass', async () => {});
+    `,
+    'tests/test-2.spec.ts': `
+      import { test, expect } from '@playwright/test';
+      test('should fail', async () => { expect(1).toBe(2); });
+    `,
+  });
+
+  await testController.watch();
+
+  const [testRun] = await Promise.all([
+    new Promise<TestRun>(f => testController.onDidCreateTestRun(testRun => {
+      testRun.onDidEnd(() => f(testRun));
+    })),
+    workspaceFolder.changeFile('tests/test-1.spec.ts', `
+      import { test } from '@playwright/test';
+      test('should pass', async () => {});
+    `),
+  ]);
+
+  expect(testRun.renderLog()).toBe(`
+    tests > test-1.spec.ts > should pass [2:0]
+      enqueued
+      enqueued
+      started
+      passed
+  `);
+
+  await expect(vscode).toHaveConnectionLog([
+    { method: 'listFiles', params: {} },
+    { method: 'runGlobalSetup', params: {} },
+    {
+      method: 'runTests',
+      params: expect.objectContaining({
+        locations: [],
+        testIds: undefined
+      })
+    },
+    {
+      method: 'watch',
+      params: expect.objectContaining({
+        fileNames: [
+          expect.stringContaining(`tests${path.sep}`),
+        ],
+      })
+    },
+    {
+      method: 'listTests',
+      params: expect.objectContaining({
+        locations: [expect.stringContaining(`tests${escapedPathSep}test-1\\.spec\\.ts`)],
+      })
+    },
+    {
+      method: 'runTests',
+      params: expect.objectContaining({
+        locations: [expect.stringContaining(`tests${escapedPathSep}test-1\\.spec\\.ts`)],
+        testIds: undefined
+      })
+    },
+  ]);
+});
+
+test('should unwatch all tests', async ({ activate }) => {
+  const { vscode, testController, workspaceFolder } = await activate({
+    'playwright.config.js': `module.exports = { testDir: 'tests' }`,
+    'tests/test-1.spec.ts': `
+      import { test } from '@playwright/test';
+      test('should pass', async () => {});
+    `,
+    'tests/test-2.spec.ts': `
+      import { test, expect } from '@playwright/test';
+      test('should fail', async () => { expect(1).toBe(2); });
+    `,
+  });
+
+  const watchRequest = await testController.watch();
+  watchRequest.token.source.cancel();
+
+  const testRuns: TestRun[] = [];
+  testController.onDidCreateTestRun(testRun => { testRuns.push(testRun); });
+  await workspaceFolder.changeFile('tests/test-1.spec.ts', `
+    import { test } from '@playwright/test';
+    test('should pass', async () => {});
+  `);
+
+  await new Promise(f => setTimeout(f, 500));
+
+  expect(testRuns).toHaveLength(0);
+
+  await expect(vscode).toHaveConnectionLog([
+    { method: 'listFiles', params: {} },
+    { method: 'runGlobalSetup', params: {} },
+    {
+      method: 'runTests',
+      params: expect.objectContaining({
+        locations: [],
+        testIds: undefined
+      })
+    },
+    {
+      method: 'watch',
+      params: expect.objectContaining({
+        fileNames: [
+          expect.stringContaining(`tests${path.sep}`),
+        ],
+      })
+    },
+    {
+      method: 'watch',
+      params: expect.objectContaining({
+        fileNames: [],
+      })
+    },
+    {
+      method: 'listTests',
+      params: expect.objectContaining({
+        locations: [expect.stringContaining(`tests${escapedPathSep}test-1\\.spec\\.ts`)],
+      })
+    },
+  ]);
+});
+
+test('should watch test file', async ({ activate }) => {
+  const { testController, workspaceFolder } = await activate({
+    'playwright.config.js': `module.exports = { testDir: 'tests' }`,
+    'tests/test-1.spec.ts': `
+      import { test } from '@playwright/test';
+      test('should pass', async () => {});
+    `,
+    'tests/test-2.spec.ts': `
+      import { test, expect } from '@playwright/test';
+      test('should fail', async () => { expect(1).toBe(2); });
+    `,
+  });
+
+  const testItem2 = testController.findTestItems(/test-2/);
+  const [testRun] = await Promise.all([
+    new Promise<TestRun>(f => testController.onDidCreateTestRun(testRun => {
+      testRun.onDidEnd(() => f(testRun));
+    })),
+    testController.watch(testItem2),
+  ]);
+
+  expect(testRun.renderLog()).toBe(`
+    tests > test-2.spec.ts > should fail [2:0]
+      enqueued
+      started
+      failed
+  `);
+
+  const [watchRun] = await Promise.all([
+    new Promise<TestRun>(f => testController.onDidCreateTestRun(testRun => {
+      testRun.onDidEnd(() => f(testRun));
+    })),
+    workspaceFolder.changeFile('tests/test-1.spec.ts', `
+      import { test } from '@playwright/test';
+      test('should pass', async () => {});
+    `),
+    workspaceFolder.changeFile('tests/test-2.spec.ts', `
+      import { test } from '@playwright/test';
+      test('should pass', async () => {});
+    `),
+  ]);
+
+  expect(watchRun.renderLog()).toBe(`
+    tests > test-2.spec.ts > should pass [2:0]
+      enqueued
+      enqueued
+      started
+      passed
+  `);
+});
+
+test('should watch tests via helper', async ({ activate }) => {
+  const { vscode, testController, workspaceFolder } = await activate({
+    'playwright.config.js': `module.exports = { testDir: 'tests' }`,
+    'tests/helper.ts': `
+      export const foo = 42;
+    `,
+    'tests/test.spec.ts': `
+      import { test, expect } from '@playwright/test';
+      import { foo } from './helper';
+      test('should pass', async () => {
+        expect(foo).toBe(42);
+      });
+    `,
+  });
+
+  await testController.watch();
+
+  const [testRun] = await Promise.all([
+    new Promise<TestRun>(f => testController.onDidCreateTestRun(testRun => {
+      testRun.onDidEnd(() => f(testRun));
+    })),
+    workspaceFolder.changeFile('tests/helper.ts', `
+      export const foo = 43;
+    `),
+  ]);
+
+  expect(testRun.renderLog()).toBe(`
+    tests > test.spec.ts > should pass [3:0]
+      enqueued
+      enqueued
+      started
+      failed
+  `);
+
+  await expect(vscode).toHaveConnectionLog([
+    { method: 'listFiles', params: {} },
+    { method: 'runGlobalSetup', params: {} },
+    {
+      method: 'runTests',
+      params: expect.objectContaining({
+        locations: [],
+        testIds: undefined
+      })
+    },
+    {
+      method: 'watch',
+      params: expect.objectContaining({
+        fileNames: [expect.stringContaining(`tests${path.sep}`)],
+      })
+    },
+    {
+      method: 'runTests',
+      params: expect.objectContaining({
+        locations: [expect.stringContaining(`tests${escapedPathSep}test\\.spec\\.ts`)],
+        testIds: undefined
+      })
+    },
+  ]);
+});
+
+test('should watch one test in a file', async ({ activate }) => {
+  const { vscode, testController, workspaceFolder } = await activate({
+    'playwright.config.js': `module.exports = { testDir: 'tests' }`,
+    'tests/test.spec.ts': `
+      import { test } from '@playwright/test';
+      test('pass 1', async () => {});
+      test('pass 2', async () => {});
+    `,
+  });
+
+  await testController.expandTestItems(/test.spec/);
+  const testItems = testController.findTestItems(/pass 1/);
+  await testController.watch(testItems);
+
+  const [testRun] = await Promise.all([
+    new Promise<TestRun>(f => testController.onDidCreateTestRun(testRun => {
+      testRun.onDidEnd(() => f(testRun));
+    })),
+    workspaceFolder.changeFile('tests/test.spec.ts', `
+      import { test } from '@playwright/test';
+      test('pass 1', async () => {});
+      test('pass 2', async () => {});
+      test('pass 3', async () => {});
+    `),
+  ]);
+
+  expect(testRun.renderLog()).toBe(`
+    tests > test.spec.ts > pass 1 [2:0]
+      enqueued
+      enqueued
+      started
+      passed
+  `);
+
+  await expect(vscode).toHaveConnectionLog([
+    { method: 'listFiles', params: {} },
+    {
+      method: 'listTests',
+      params: expect.objectContaining({
+        locations: [expect.stringContaining(`tests${escapedPathSep}test\\.spec\\.ts`)],
+      })
+    },
+    { method: 'runGlobalSetup', params: {} },
+    {
+      method: 'runTests',
+      params: expect.objectContaining({
+        locations: [
+          expect.stringContaining(`tests${escapedPathSep}test\\.spec\\.ts`),
+        ],
+        testIds: [
+          expect.any(String)
+        ]
+      })
+    },
+    {
+      method: 'watch',
+      params: expect.objectContaining({
+        fileNames: [expect.stringContaining(`tests${path.sep}test.spec.ts`)],
+      })
+    },
+    {
+      method: 'listTests',
+      params: expect.objectContaining({
+        locations: [expect.stringContaining(`tests${escapedPathSep}test\\.spec\\.ts`)],
+      })
+    },
+    {
+      method: 'runTests',
+      params: expect.objectContaining({
+        locations: [
+          expect.stringContaining(`tests${escapedPathSep}test\\.spec\\.ts`),
+        ],
+        testIds: [expect.any(String)]
+      })
+    },
+  ]);
+});
+
+test('should watch two tests in a file', async ({ activate }) => {
+  const { vscode, testController, workspaceFolder } = await activate({
+    'playwright.config.js': `module.exports = { testDir: 'tests' }`,
+    'tests/test.spec.ts': `
+      import { test } from '@playwright/test';
+      test('pass 1', async () => {});
+      test('pass 2', async () => {});
+    `,
+  });
+
+  await testController.expandTestItems(/test.spec/);
+  const testItems = testController.findTestItems(/pass/);
+  await testController.watch(testItems);
+
+  const [testRun] = await Promise.all([
+    new Promise<TestRun>(f => testController.onDidCreateTestRun(testRun => {
+      testRun.onDidEnd(() => f(testRun));
+    })),
+    workspaceFolder.changeFile('tests/test.spec.ts', `
+      import { test } from '@playwright/test';
+      test('pass 1', async () => {});
+      test('pass 2', async () => {});
+      test('pass 3', async () => {});
+    `),
+  ]);
+
+  expect(testRun.renderLog()).toBe(`
+    tests > test.spec.ts > pass 1 [2:0]
+      enqueued
+      enqueued
+      started
+      passed
+    tests > test.spec.ts > pass 2 [3:0]
+      enqueued
+      enqueued
+      started
+      passed
+  `);
+
+  await expect(vscode).toHaveConnectionLog([
+    { method: 'listFiles', params: {} },
+    {
+      method: 'listTests',
+      params: expect.objectContaining({
+        locations: [expect.stringContaining(`tests${escapedPathSep}test\\.spec\\.ts`)],
+      })
+    },
+    { method: 'runGlobalSetup', params: {} },
+    {
+      method: 'runTests',
+      params: expect.objectContaining({
+        locations: [
+          expect.stringContaining(`tests${escapedPathSep}test\\.spec\\.ts`),
+        ],
+        testIds: [
+          expect.any(String),
+          expect.any(String),
+        ]
+      })
+    },
+    {
+      method: 'watch',
+      params: expect.objectContaining({
+        fileNames: [expect.stringContaining(`tests${path.sep}test.spec.ts`)],
+      })
+    },
+    {
+      method: 'listTests',
+      params: expect.objectContaining({
+        locations: [expect.stringContaining(`tests${escapedPathSep}test\\.spec\\.ts`)],
+      })
+    },
+    {
+      method: 'runTests',
+      params: expect.objectContaining({
+        locations: [
+          expect.stringContaining(`tests${escapedPathSep}test\\.spec\\.ts`),
+        ],
+        testIds: [expect.any(String), expect.any(String)]
+      })
+    },
+  ]);
+});
+
+test('should batch watched tests, not queue', async ({ activate }, testInfo) => {
+  if (process.platform === 'win32')
+    test.slow();
+
+  const semaphore = testInfo.outputPath('semaphore.txt');
+  const { testController, workspaceFolder } = await activate({
+    'playwright.config.js': `module.exports = { testDir: 'tests' }`,
+    'tests/watched.spec.ts': `
+      import { test } from '@playwright/test';
+      test('foo', async () => {
+        console.log('watched content #1');
+      });
+    `,
+    'tests/long-test.spec.ts': `
+      import { test } from '@playwright/test';
+      import { existsSync } from 'node:fs';
+      import { setTimeout } from 'node:timers/promises';
+      test('long test', async () => {
+        console.log('long test started');
+        while (!existsSync('${semaphore}'))
+          await setTimeout(10);
+      });
+    `,
+  });
+
+  await testController.expandTestItems(/.*/);
+  await testController.watch(testController.findTestItems(/watched/));
+
+  // start blocking run
+  const longTestRun = await new Promise<TestRun>(f => {
+    testController.onDidCreateTestRun(f);
+    void testController.run(testController.findTestItems(/long-test/));
+  });
+  await expect.poll(() => longTestRun.renderOutput()).toContain('long test started');
+
+  // fill up queue
+  const queuedTestRuns: TestRun[] = [];
+  testController.onDidCreateTestRun(r => queuedTestRuns.push(r));
+  await workspaceFolder.changeFile('tests/watched.spec.ts', `
+    import { test } from '@playwright/test';
+    test('foo', async () => {
+      console.log('watched content #2');
+    });
+  `);
+  await workspaceFolder.changeFile('tests/watched.spec.ts', `
+    import { test } from '@playwright/test';
+    test('foo', async () => {
+      console.log('watched content #3');
+    });
+  `);
+  await workspaceFolder.changeFile('tests/watched.spec.ts', `
+    import { test } from '@playwright/test';
+    test('foo', async () => {
+      console.log('watched content #4');
+    });
+  `);
+
+  // end blocking run to start queued runs
+  await new Promise(async f => {
+    longTestRun.onDidEnd(f);
+    await writeFile(semaphore, '');
+  });
+
+  // wait for another run to be done, so we know the queue is empty
+  await testController.run(testController.findTestItems(/watched/));
+
+  // one batched run for all changes plus the one above
+  expect(queuedTestRuns.length).toBe(2);
+});
+
+test('should only watch a test from the enabled project when multiple projects share the same test directory', async ({ activate }) => {
+  const { vscode, testController, workspaceFolder } = await activate({
+    'playwright-1.config.js': `module.exports = { testDir: 'tests', projects: [{ name: 'project-from-config1' }] }`,
+    'playwright-2.config.js': `module.exports = { testDir: 'tests', projects: [{ name: 'project-from-config2' }, { name: 'project-from-config2-two' }] }`,
+    'tests/test.spec.ts': `
+      import { test } from '@playwright/test';
+      test('pass 1', async () => {});
+      test('pass 2', async () => {});
+    `,
+  });
+
+  await enableConfigs(vscode, [`playwright-1.config.js`, `playwright-2.config.js`]);
+
+  await selectConfig(vscode, `playwright-2.config.js`);
+
+  const webView = vscode.webViews.get('playwright-repl.settingsView')!;
+  // Wait for the projects to be loaded.
+  await expect(webView.getByTestId('projects').locator('div').locator('label')).toHaveCount(2);
+  // Disable the project from config 2.
+  await enableProjects(vscode, []);
+  await expect(vscode).toHaveProjectTree(`
+  config: playwright-2.config.js
+    [ ] project-from-config2
+    [ ] project-from-config2-two
+`);
+
+  await testController.expandTestItems(/test.spec/);
+  const testItems = testController.findTestItems(/pass 1/);
+  expect(testItems).toHaveLength(1);
+  await testController.watch(testItems);
+  const [testRun] = await Promise.all([
+    new Promise<TestRun>(f => testController.onDidCreateTestRun(testRun => {
+      testRun.onDidEnd(() => f(testRun));
+    })),
+    workspaceFolder.changeFile('tests/test.spec.ts', `
+      import { test } from '@playwright/test';
+      test('pass 1', async () => {});
+      test('pass 2', async () => {});
+      test('pass 3', async () => {});
+    `),
+  ]);
+
+  expect(testRun.renderLog()).toBe(`
+    tests > test.spec.ts > pass 1 [2:0]
+      enqueued
+      enqueued
+      started
+      passed
+  `);
+
+  await expect(vscode).toHaveConnectionLog([
+    { method: 'listFiles', params: {} },
+    { method: 'listFiles', params: {} },
+    {
+      method: 'listTests',
+      params: expect.objectContaining({
+        locations: [expect.stringContaining(`tests${escapedPathSep}test\\.spec\\.ts`)],
+      })
+    },
+    { method: 'runGlobalSetup', params: {} },
+    {
+      method: 'runTests',
+      params: expect.objectContaining({
+        locations: [
+          expect.stringContaining(`tests${escapedPathSep}test\\.spec\\.ts`),
+        ],
+        testIds: [
+          expect.any(String)
+        ]
+      })
+    },
+    {
+      method: 'watch',
+      params: expect.objectContaining({
+        fileNames: [expect.stringContaining(`tests${path.sep}test.spec.ts`)],
+      })
+    },
+    {
+      method: 'watch',
+      params: expect.objectContaining({
+        fileNames: [expect.stringContaining(`tests${path.sep}test.spec.ts`)],
+      })
+    },
+    {
+      method: 'listTests',
+      params: expect.objectContaining({
+        locations: [expect.stringContaining(`tests${escapedPathSep}test\\.spec\\.ts`)],
+      })
+    },
+    {
+      method: 'runTests',
+      params: expect.objectContaining({
+        locations: [
+          expect.stringContaining(`tests${escapedPathSep}test\\.spec\\.ts`),
+        ],
+        testIds: [expect.any(String)]
+      })
+    },
+  ]);
+});
+
+test('watching all tests should also execute newly added files', async ({ activate }) => {
+  const { testController, workspaceFolder, vscode } = await activate({
+    'playwright.config.js': `module.exports = { testDir: 'tests' }`,
+    'tests/foo.spec.ts': `
+      import { test } from '@playwright/test';
+      test('should pass', async () => {});
+    `,
+  });
+
+  await testController.watch();
+
+  await workspaceFolder.addFile('tests/bar.spec.ts', `
+    import { test } from '@playwright/test';
+    test('scaffolding', async () => {});
+  `);
+  await vscode.openEditors('**/tests/bar.spec.ts');
+
+  await expect(testController).toHaveTestTree(`
+    -   tests
+      -   bar.spec.ts
+        -   scaffolding [2:0]
+      -   foo.spec.ts
+        - ✅ should pass [2:0]
+  `);
+
+  const [testRun] = await Promise.all([
+    new Promise<TestRun>(f => testController.onDidCreateTestRun(f)),
+    workspaceFolder.changeFile('tests/bar.spec.ts', `
+      import { test } from '@playwright/test';
+      test('implemented', async () => {});
+    `)
+  ]);
+  await new Promise(f => testRun.onDidEnd(f));
+
+  expect(testRun.renderLog()).toContain('bar.spec.ts');
+  expect(testRun.renderLog()).toContain('implemented');
+});
+
+test('should watch test suite and run tests when file in suite is saved', async ({ activate }) => {
+  const { testController, workspaceFolder } = await activate({
+    'playwright.config.js': `module.exports = { testDir: 'tests' }`,
+    'tests/completing-todos/complete-single-todo.spec.ts': `
+      import { test } from '@playwright/test';
+      test('should complete single todo', async () => {});
+    `,
+    'tests/completing-todos/complete-all-todos.spec.ts': `
+      import { test } from '@playwright/test';
+      test('should complete all todos', async () => {});
+    `,
+  });
+
+  await testController.watch(testController.findTestItems(/completing-todos/));
+
+  await Promise.all([
+    new Promise(f => testController.onDidCreateTestRun(run => run.onDidEnd(f))),
+    workspaceFolder.changeFile('tests/completing-todos/complete-single-todo.spec.ts', `
+      import { test } from '@playwright/test';
+      test('should complete single todo - modified', async () => {});
+    `),
+  ]);
+});
+
+test('expanding watch from spec to file should work', async ({ activate }) => {
+  const { testController, workspaceFolder } = await activate({
+    'playwright.config.js': `module.exports = { testDir: 'tests' }`,
+    'tests/foo.spec.ts': `
+      import { test } from '@playwright/test';
+      test('foo', async () => {});
+      test('bar', async () => {});
+    `,
+  });
+
+  await testController.expandTestItems(/.*/);
+
+  let [testRun] = await Promise.all([
+    new Promise<TestRun>(f => testController.onDidCreateTestRun(testRun => {
+      testRun.onDidEnd(() => f(testRun));
+    })),
+    testController.watch(testController.findTestItems(/bar/)),
+  ]);
+  expect(testRun.renderLog()).toBe(`
+    tests > foo.spec.ts > bar [3:0]
+      enqueued
+      enqueued
+      started
+      passed
+  `);
+
+  [testRun] = await Promise.all([
+    new Promise<TestRun>(f => testController.onDidCreateTestRun(testRun => {
+      testRun.onDidEnd(() => f(testRun));
+    })),
+    testController.watch(testController.findTestItems(/foo\.spec/))
+  ]);
+  expect(testRun.renderLog()).toBe(`
+    tests > foo.spec.ts > foo [2:0]
+      enqueued
+      enqueued
+      started
+      passed
+    tests > foo.spec.ts > bar [3:0]
+      enqueued
+      enqueued
+      started
+      passed
+  `);
+
+  [testRun] = await Promise.all([
+    new Promise<TestRun>(f => testController.onDidCreateTestRun(testRun => {
+      testRun.onDidEnd(() => f(testRun));
+    })),
+    workspaceFolder.changeFile('tests/foo.spec.ts', `
+      import { test } from '@playwright/test';
+      test('foo', async () => { throw new Error('kaboom'); });
+      test('bar', async () => {});
+    `),
+  ]);
+
+  expect.soft(testRun.renderLog()).toBe(`
+    tests > foo.spec.ts > foo [2:0]
+      enqueued
+      enqueued
+      started
+      failed
+    tests > foo.spec.ts > bar [3:0]
+      enqueued
+      enqueued
+      started
+      passed
+  `);
+
+  await expect(testController).toHaveTestTree(`
+    -   tests
+      -   foo.spec.ts
+        - ❌ foo [2:0]
+        - ✅ bar [3:0]
+  `);
+});
+
+test('should watch test defined outside of .spec.ts file', { annotation: { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/37930' } }, async ({ activate }) => {
+  const { vscode, testController, workspaceFolder } = await activate({
+    'playwright.config.js': `module.exports = { testDir: '.' }`,
+    'example.spec.ts': `
+      import './impl';
+    `,
+    'impl.ts': `
+      import { test } from '@playwright/test';
+      test('one', async () => {});
+    `,
+  });
+
+  await testController.watch();
+
+  const [testRun] = await Promise.all([
+    new Promise<TestRun>(f => testController.onDidCreateTestRun(testRun => {
+      testRun.onDidEnd(() => f(testRun));
+    })),
+    workspaceFolder.changeFile('impl.ts', `
+      import { test } from '@playwright/test';
+      test('one', async () => { /* modified */ });
+    `),
+  ]);
+
+  expect.soft(testRun.renderLog()).toBe(`
+    example.spec.ts > one [2:0]
+      enqueued
+      enqueued
+      started
+      passed
+  `);
+
+  await expect.soft(vscode).toHaveConnectionLog([
+    { method: 'listFiles', params: {} },
+    { method: 'runGlobalSetup', params: {} },
+    {
+      method: 'runTests',
+      params: expect.objectContaining({
+        locations: [],
+      })
+    },
+    {
+      method: 'watch',
+      params: expect.objectContaining({
+        fileNames: [test.info().outputDir + path.sep],
+      })
+    },
+    {
+      method: 'runTests',
+      params: expect.objectContaining({
+        locations: [expect.stringContaining(`example\\.spec\\.ts`)],
+      })
+    },
+  ]);
+});
+
+test.fail('does not record output of test discovered through watch', async ({ activate }) => {
+  const { vscode, testController, workspaceFolder } = await activate({
+    'playwright.config.js': `module.exports = { testDir: '.' }`,
+    'example.spec.ts': `
+      import './impl';
+    `,
+    'impl.ts': `
+      import { test } from '@playwright/test';
+      test('one', async () => {});
+    `,
+  });
+
+  await testController.watch();
+
+  const [testRun] = await Promise.all([
+    new Promise<TestRun>(f => testController.onDidCreateTestRun(testRun => {
+      testRun.onDidEnd(() => f(testRun));
+    })),
+    workspaceFolder.changeFile('impl.ts', `
+      import { test } from '@playwright/test';
+      test('one', async () => {});
+      test('two', async () => {});
+    `),
+  ]);
+
+  expect.soft(testRun.renderLog(), 'second test was discovered through watch, tree doesnt yet have an item for it').toBe(`
+    example.spec.ts > one [2:0]
+      enqueued
+      enqueued
+      started
+      passed
+    example.spec.ts > two [3:0]
+      enqueued
+      enqueued
+      started
+      passed
+  `);
+  await expect.soft(vscode).toHaveConnectionLog([
+    { method: 'listFiles', params: {} },
+    { method: 'runGlobalSetup', params: {} },
+    {
+      method: 'runTests',
+      params: expect.objectContaining({
+        locations: [],
+      })
+    },
+    {
+      method: 'watch',
+      params: expect.objectContaining({
+        fileNames: [test.info().outputDir + path.sep],
+      })
+    },
+    {
+      method: 'runTests',
+      params: expect.objectContaining({
+        locations: [expect.stringContaining(`example\\.spec\\.ts`)],
+      })
+    },
+  ]);
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -298,6 +298,12 @@ importers:
       esbuild:
         specifier: ^0.25.0
         version: 0.25.12
+      glob:
+        specifier: ^8.1.0
+        version: 8.1.0
+      minimatch:
+        specifier: ^10.2.4
+        version: 10.2.4
       stack-utils:
         specifier: ^2.0.6
         version: 2.0.6
@@ -1827,6 +1833,9 @@ packages:
   brace-expansion@1.1.13:
     resolution: {integrity: sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==}
 
+  brace-expansion@2.0.3:
+    resolution: {integrity: sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==}
+
   brace-expansion@5.0.4:
     resolution: {integrity: sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==}
     engines: {node: 18 || 20 || >=22}
@@ -2324,6 +2333,9 @@ packages:
     resolution: {integrity: sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA==}
     engines: {node: '>=14.14'}
 
+  fs.realpath@1.0.0:
+    resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
+
   fsevents@2.3.2:
     resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -2373,6 +2385,11 @@ packages:
   glob@13.0.6:
     resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
     engines: {node: 18 || 20 || >=22}
+
+  glob@8.1.0:
+    resolution: {integrity: sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==}
+    engines: {node: '>=12'}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   globby@14.1.0:
     resolution: {integrity: sha512-0Ia46fDOaT7k4og1PDW4YbodWWr3scS2vAr2lTbsplOt2WkKp0vQbkI9wKis/T5LV/dqPjO3bpS/z6GTJB82LA==}
@@ -2464,6 +2481,10 @@ packages:
   index-to-position@1.2.0:
     resolution: {integrity: sha512-Yg7+ztRkqslMAS2iFaU+Oa4KTSidr63OsFGlOrJoW981kIYO3CGCS3wA95P1mUi/IVSJkn0D479KTJpVpvFNuw==}
     engines: {node: '>=18'}
+
+  inflight@1.0.6:
+    resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
+    deprecated: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
 
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
@@ -2833,6 +2854,10 @@ packages:
 
   minimatch@3.1.5:
     resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
+
+  minimatch@5.1.9:
+    resolution: {integrity: sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==}
+    engines: {node: '>=10'}
 
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
@@ -5340,6 +5365,10 @@ snapshots:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
+  brace-expansion@2.0.3:
+    dependencies:
+      balanced-match: 1.0.2
+
   brace-expansion@5.0.4:
     dependencies:
       balanced-match: 4.0.4
@@ -5905,6 +5934,8 @@ snapshots:
       jsonfile: 6.2.0
       universalify: 2.0.1
 
+  fs.realpath@1.0.0: {}
+
   fsevents@2.3.2:
     optional: true
 
@@ -5960,6 +5991,14 @@ snapshots:
       minimatch: 10.2.4
       minipass: 7.1.3
       path-scurry: 2.0.2
+
+  glob@8.1.0:
+    dependencies:
+      fs.realpath: 1.0.0
+      inflight: 1.0.6
+      inherits: 2.0.4
+      minimatch: 5.1.9
+      once: 1.4.0
 
   globby@14.1.0:
     dependencies:
@@ -6059,6 +6098,11 @@ snapshots:
   imurmurhash@0.1.4: {}
 
   index-to-position@1.2.0: {}
+
+  inflight@1.0.6:
+    dependencies:
+      once: 1.4.0
+      wrappy: 1.0.2
 
   inherits@2.0.4: {}
 
@@ -6378,6 +6422,10 @@ snapshots:
   minimatch@3.1.5:
     dependencies:
       brace-expansion: 1.1.13
+
+  minimatch@5.1.9:
+    dependencies:
+      brace-expansion: 2.0.3
 
   minimist@1.2.8: {}
 


### PR DESCRIPTION
## Summary
- Phase 0 of #638: copy and adapt playwright-vscode mock test suite (136 passing, 24 skipped)
- Add `build-test.mjs` — test-specific build that bundles `@playwright-repl/core` inline and shims `vscode` module
- Fix two config prefix bugs found by the tests (`settingsModel.ts` and `extension.ts` used `playwright.` instead of `playwright-repl.`)
- Add CI step for mock tests in `test.yml`

## Test plan
- [x] `npx playwright test --config tests/playwright.config.ts --project default` — 136 passed, 0 failed
- [ ] CI passes on ubuntu and macos

Closes #638 phase 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)