### PR TITLE
feat: add --command flag to CLI for single-command execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,14 @@ pw> screenshot
 
 Standalone launches a fresh Chromium with the extension pre-installed — keyword commands and JavaScript both work. Use `--headless` for CI/scripting.
 
+**Single-command mode** — run one command and exit, useful for automation tools like Claude Code:
+
+```bash
+playwright-repl --bridge --command "snapshot"
+playwright-repl --bridge --command "goto https://example.com"
+playwright-repl --bridge --command "click \"Interested\""
+```
+
 > **[Full CLI docs](packages/cli/README.md)**
 
 ---

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -50,6 +50,7 @@ playwright-repl --bridge                      # start bridge server, wait for ex
 playwright-repl --bridge --replay script.pw   # replay a script via bridge
 playwright-repl --bridge --replay examples/   # replay all .pw files
 playwright-repl --bridge --bridge-port 9877   # custom port (default 9876)
+playwright-repl --bridge --command "snapshot"  # run one command and exit
 ```
 
 The extension connects automatically — no need to open the side panel.
@@ -77,6 +78,9 @@ playwright-repl --replay session.pw --step
 # Start REPL with recording enabled
 playwright-repl --record my-test.pw
 
+# Run a single command and exit
+playwright-repl --bridge --command "snapshot"
+
 # Pipe commands
 echo -e "goto https://example.com\nsnapshot" | playwright-repl
 ```
@@ -97,6 +101,7 @@ Both modes auto-detect keyword commands and JavaScript expressions. For DOM acce
 | `--headless` | Run browser in headless mode (default: headed) |
 | `--bridge` | Connect to existing Chrome via WebSocket bridge |
 | `--bridge-port <port>` | Bridge server port (default: `9876`) |
+| `--command <cmd>` | Run a single command, print output, and exit |
 | `--config <file>` | Path to config file |
 | `--replay <files...>` | Replay `.pw` or `.js` file(s) or folder(s) |
 | `--record <file>` | Start REPL with recording to file |

--- a/packages/cli/src/playwright-repl.ts
+++ b/packages/cli/src/playwright-repl.ts
@@ -5,6 +5,7 @@
  *
  * Usage:
  *   playwright-repl [options]
+ *   playwright-repl --bridge --command "snapshot"
  *   playwright-repl --replay session.pw
  *   playwright-repl --replay session.pw --step
  *   playwright-repl --replay file1.pw file2.pw
@@ -46,6 +47,7 @@ Options:
   --cdp-port <number>    Chrome CDP port (default: 9222)
   --include-snapshot     Include snapshot in update command responses
   --verbose              Show raw response headers (### Result, ### Snapshot, etc.)
+  --command <cmd>        Run a single command, print output, and exit
   --config <file>        Path to config file
   --replay <files...>   Replay .pw file(s) or folder(s)
   --record <file>        Start REPL with recording to file
@@ -76,6 +78,7 @@ Examples:
   playwright-repl --replay login.pw --step  # step through replay
   playwright-repl --replay tests/         # replay all .pw files in folder
   playwright-repl --replay a.pw b.pw      # replay multiple files
+  playwright-repl --bridge --command "snapshot"  # run one command and exit
   echo "open https://example.com" | playwright-repl  # pipe commands
 `);
   process.exit(0);

--- a/packages/cli/src/playwright-repl.ts
+++ b/packages/cli/src/playwright-repl.ts
@@ -17,7 +17,7 @@ import { startRepl } from './repl.js';
 
 const args = minimist(process.argv.slice(2), {
   boolean: ['headed', 'headless', 'persistent', 'help', 'step', 'silent', 'spawn', 'bridge', 'engine', 'include-snapshot', 'verbose'],
-  string: ['session', 'browser', 'profile', 'config', 'replay', 'record', 'connect', 'port', 'cdp-port', 'bridge-port'],
+  string: ['session', 'browser', 'profile', 'config', 'replay', 'record', 'connect', 'port', 'cdp-port', 'bridge-port', 'command'],
   alias: { s: 'session', h: 'help', b: 'browser', q: 'silent' },
   default: { session: 'default' },
 });
@@ -88,6 +88,8 @@ if (args.replay) {
   for (const a of args._ as string[]) replayFiles.push(String(a));
 }
 
+const commandArg = args.command as string | undefined;
+
 startRepl({
   session: args.session as string,
   headed: args.headless ? false : args.headed ? true : undefined,
@@ -100,9 +102,10 @@ startRepl({
   cdpPort: args['cdp-port'] ? parseInt(args['cdp-port'] as string, 10) : undefined,
   config: args.config as string,
   replay: replayFiles.length > 0 ? replayFiles : undefined,
+  command: commandArg,
+  silent: (args.silent as boolean) || !!commandArg,
   record: args.record as string,
   step: args.step as boolean,
-  silent: args.silent as boolean,
   bridge: args.bridge as boolean,
   engine: args.engine as boolean,
   bridgePort: args['bridge-port'] ? parseInt(args['bridge-port'] as string, 10) : undefined,

--- a/packages/cli/src/repl.ts
+++ b/packages/cli/src/repl.ts
@@ -999,7 +999,7 @@ export async function startRepl(opts: ReplOpts = {}): Promise<void> {
   if (opts.bridge) {
     const port = opts.bridgePort ?? 9876;
     const srv = new BridgeServer();
-    await srv.start(port);
+    await srv.start(port, { silent: !!opts.command });
     log(`Bridge server listening on ws://localhost:${port}`);
     if (opts.command) {
       await srv.waitForConnection(30000);

--- a/packages/cli/src/repl.ts
+++ b/packages/cli/src/repl.ts
@@ -26,6 +26,7 @@ export interface ReplOpts extends EngineOpts {
   record?: string;
   step?: boolean;
   silent?: boolean;
+  command?: string;
   bridge?: boolean;
   bridgePort?: number;
   engine?: boolean;
@@ -959,6 +960,23 @@ export async function startRepl(opts: ReplOpts = {}): Promise<void> {
   const log = (...args: unknown[]) => { if (!silent) console.log(...args); };
 
   log(`${c.bold}${c.magenta}🎭 Playwright REPL${c.reset} ${c.dim}v${replVersion}${c.reset}`);
+
+  // ─── Single-command mode (--command flag) ──────────────────────
+
+  if (opts.command) {
+    if (opts.bridge) {
+      const port = opts.bridgePort ?? 9876;
+      const srv = new BridgeServer();
+      await srv.start(port);
+      await srv.waitForConnection(30000);
+      const parsed = parseInput(opts.command);
+      if (!parsed) { process.stderr.write('Invalid command\n'); process.exit(1); }
+      const result = await srv.run(parsed);
+      process.stdout.write((result.text ?? '') + '\n');
+      process.exit(result.isError ? 1 : 0);
+    }
+    // For non-bridge modes, fall through to normal startup
+  }
 
   // ─── Standalone mode (new: serviceWorker.evaluate) ─────────────
 

--- a/packages/cli/src/repl.ts
+++ b/packages/cli/src/repl.ts
@@ -961,23 +961,6 @@ export async function startRepl(opts: ReplOpts = {}): Promise<void> {
 
   log(`${c.bold}${c.magenta}🎭 Playwright REPL${c.reset} ${c.dim}v${replVersion}${c.reset}`);
 
-  // ─── Single-command mode (--command flag) ──────────────────────
-
-  if (opts.command) {
-    if (opts.bridge) {
-      const port = opts.bridgePort ?? 9876;
-      const srv = new BridgeServer();
-      await srv.start(port);
-      await srv.waitForConnection(30000);
-      const parsed = parseInput(opts.command);
-      if (!parsed) { process.stderr.write('Invalid command\n'); process.exit(1); }
-      const result = await srv.run(parsed);
-      process.stdout.write((result.text ?? '') + '\n');
-      process.exit(result.isError ? 1 : 0);
-    }
-    // For non-bridge modes, fall through to normal startup
-  }
-
   // ─── Standalone mode (new: serviceWorker.evaluate) ─────────────
 
   if (!opts.bridge && !opts.connect && !opts.engine) {
@@ -991,6 +974,12 @@ export async function startRepl(opts: ReplOpts = {}): Promise<void> {
         // Default to headed for evaluate mode (interactive REPL with extension)
         await conn.start(extPath, { headed: opts.headed ?? true, chromium });
         log(`${c.green}✓${c.reset} Browser ready (with extension)`);
+        if (opts.command) {
+          const result = await conn.run(opts.command);
+          process.stdout.write((result.text ?? '') + '\n');
+          await conn.close();
+          process.exit(result.isError ? 1 : 0);
+        }
         log(`${c.dim}Type .help for commands, JavaScript supported${c.reset}\n`);
         if (opts.replay && opts.replay.length > 0) {
           await runBridgeReplayMode(opts, conn as any);
@@ -1012,6 +1001,13 @@ export async function startRepl(opts: ReplOpts = {}): Promise<void> {
     const srv = new BridgeServer();
     await srv.start(port);
     log(`Bridge server listening on ws://localhost:${port}`);
+    if (opts.command) {
+      await srv.waitForConnection(30000);
+      const result = await srv.run(opts.command);
+      process.stdout.write((result.text ?? '') + '\n');
+      srv.close();
+      process.exit(result.isError ? 1 : 0);
+    }
     if (opts.replay && opts.replay.length > 0) {
       await runBridgeReplayMode(opts, srv);
     } else {
@@ -1032,6 +1028,20 @@ export async function startRepl(opts: ReplOpts = {}): Promise<void> {
   } catch (err: unknown) {
     console.error(`${c.red}✗${c.reset} Failed to start: ${(err as Error).message}`);
     process.exit(1);
+  }
+
+  if (opts.command) {
+    const parsed = parseInput(opts.command);
+    if (!parsed) {
+      process.stderr.write('Invalid command\n');
+      conn.close();
+      process.exit(1);
+      return; // unreachable, but satisfies TS control-flow
+    }
+    const result = await conn.run(parsed);
+    process.stdout.write((result.text ?? '') + '\n');
+    conn.close();
+    process.exit(result.isError ? 1 : 0);
   }
 
   // ─── Session + readline ──────────────────────────────────────────

--- a/packages/cli/test/repl-startrepl.test.ts
+++ b/packages/cli/test/repl-startrepl.test.ts
@@ -21,6 +21,24 @@ vi.mock('../src/engine.js', () => ({
   }),
 }));
 
+const mockBridgeStart = vi.fn().mockResolvedValue(undefined);
+const mockBridgeClose = vi.fn();
+const mockBridgeRun = vi.fn().mockResolvedValue({ text: 'Snapshot result', isError: false });
+const mockBridgeWaitForConnection = vi.fn().mockResolvedValue(undefined);
+
+vi.mock('@playwright-repl/core', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@playwright-repl/core')>();
+  return {
+    ...actual,
+    BridgeServer: vi.fn(function () {
+      this.start = mockBridgeStart;
+      this.close = mockBridgeClose;
+      this.run = mockBridgeRun;
+      this.waitForConnection = mockBridgeWaitForConnection;
+    }),
+  };
+});
+
 vi.mock('node:readline', () => ({
   default: {
     createInterface: vi.fn(() => {
@@ -40,22 +58,31 @@ import { startRepl } from '../src/repl.js';
 // ─── Tests ──────────────────────────────────────────────────────────────────
 
 describe('startRepl', () => {
-  let logSpy, errorSpy, exitSpy;
+  let logSpy, errorSpy, exitSpy, stdoutSpy, stderrSpy;
 
   beforeEach(() => {
     logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {});
+    stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
     // Reset Engine mock to default
     mockStart.mockReset().mockResolvedValue(undefined);
     mockClose.mockReset();
     mockRun.mockReset().mockResolvedValue({ text: '### Result\nOK' });
+    // Reset BridgeServer mock to default
+    mockBridgeStart.mockReset().mockResolvedValue(undefined);
+    mockBridgeClose.mockReset();
+    mockBridgeRun.mockReset().mockResolvedValue({ text: 'Snapshot result', isError: false });
+    mockBridgeWaitForConnection.mockReset().mockResolvedValue(undefined);
   });
 
   afterEach(() => {
     logSpy.mockRestore();
     errorSpy.mockRestore();
     exitSpy.mockRestore();
+    stdoutSpy.mockRestore();
+    stderrSpy.mockRestore();
     vi.restoreAllMocks();
   });
 
@@ -101,5 +128,64 @@ describe('startRepl', () => {
     await startRepl({ silent: true, record: '/tmp/my-session.pw' });
     // The session should have started recording (no error thrown)
     expect(errorSpy).not.toHaveBeenCalled();
+  });
+
+  // ─── --command flag (engine fallback) ──────────────────────────
+
+  it('--command runs command via engine, writes output, and exits 0', async () => {
+    mockRun.mockResolvedValue({ text: 'Page snapshot', isError: false });
+    await startRepl({ silent: true, command: 'snapshot' });
+    expect(mockStart).toHaveBeenCalled();
+    expect(mockRun).toHaveBeenCalledWith(expect.objectContaining({ _: ['snapshot'] }));
+    expect(stdoutSpy).toHaveBeenCalledWith('Page snapshot\n');
+    expect(mockClose).toHaveBeenCalled();
+    expect(exitSpy).toHaveBeenCalledWith(0);
+  });
+
+  it('--command exits 1 when engine returns isError', async () => {
+    mockRun.mockResolvedValue({ text: 'Error: element not found', isError: true });
+    await startRepl({ silent: true, command: 'click e99' });
+    expect(stdoutSpy).toHaveBeenCalledWith('Error: element not found\n');
+    expect(mockClose).toHaveBeenCalled();
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it('--command writes empty line when result text is null', async () => {
+    mockRun.mockResolvedValue({ text: null, isError: false });
+    await startRepl({ silent: true, command: 'snapshot' });
+    expect(stdoutSpy).toHaveBeenCalledWith('\n');
+    expect(exitSpy).toHaveBeenCalledWith(0);
+  });
+
+  // ─── --command flag (bridge mode) ──────────────────────────────
+
+  it('--command --bridge runs command via BridgeServer and exits 0', async () => {
+    mockBridgeRun.mockResolvedValue({ text: 'Bridge snapshot', isError: false });
+    await startRepl({ silent: true, command: 'snapshot', bridge: true });
+    expect(mockBridgeStart).toHaveBeenCalled();
+    expect(mockBridgeWaitForConnection).toHaveBeenCalledWith(30000);
+    expect(mockBridgeRun).toHaveBeenCalledWith('snapshot');
+    expect(stdoutSpy).toHaveBeenCalledWith('Bridge snapshot\n');
+    expect(mockBridgeClose).toHaveBeenCalled();
+    expect(exitSpy).toHaveBeenCalledWith(0);
+  });
+
+  it('--command --bridge exits 1 on error result', async () => {
+    mockBridgeRun.mockResolvedValue({ text: 'Command failed', isError: true });
+    await startRepl({ silent: true, command: 'click e99', bridge: true });
+    expect(stdoutSpy).toHaveBeenCalledWith('Command failed\n');
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it('--command --bridge uses custom bridge port', async () => {
+    await startRepl({ silent: true, command: 'snapshot', bridge: true, bridgePort: 9877 });
+    expect(mockBridgeStart).toHaveBeenCalledWith(9877);
+  });
+
+  it('--command --bridge does not start interactive loop', async () => {
+    await startRepl({ silent: true, command: 'snapshot', bridge: true });
+    // Should run and exit, not fall through to startBridgeLoop
+    expect(mockBridgeRun).toHaveBeenCalledWith('snapshot');
+    expect(exitSpy).toHaveBeenCalled();
   });
 });

--- a/packages/cli/test/repl-startrepl.test.ts
+++ b/packages/cli/test/repl-startrepl.test.ts
@@ -179,7 +179,7 @@ describe('startRepl', () => {
 
   it('--command --bridge uses custom bridge port', async () => {
     await startRepl({ silent: true, command: 'snapshot', bridge: true, bridgePort: 9877 });
-    expect(mockBridgeStart).toHaveBeenCalledWith(9877);
+    expect(mockBridgeStart).toHaveBeenCalledWith(9877, { silent: true });
   });
 
   it('--command --bridge does not start interactive loop', async () => {

--- a/packages/core/src/bridge-server.ts
+++ b/packages/core/src/bridge-server.ts
@@ -17,6 +17,7 @@ export class BridgeServer {
     private _onEvent?: (event: Record<string, unknown>) => void;
     private heartbeatTimer?: ReturnType<typeof setInterval>;
     private waiters: Array<{ resolve: () => void; reject: (err: Error) => void; timer: ReturnType<typeof setTimeout> }> = [];
+    private _silent = false;
 
     onConnect(fn: () => void)    { this._onConnect = fn; }
     onDisconnect(fn: () => void) { this._onDisconnect = fn; }
@@ -24,7 +25,8 @@ export class BridgeServer {
     get connected()              { return this.socket?.readyState === WebSocket.OPEN; }
     get port()                   { return (this.wss.address() as { port: number }).port; }
 
-    async start(port = 9876): Promise<void> {
+    async start(port = 9876, opts?: { silent?: boolean }): Promise<void> {
+        this._silent = opts?.silent ?? false;
         const createServer = () => new WebSocketServer({
             port,
             host: '127.0.0.1',
@@ -58,7 +60,7 @@ export class BridgeServer {
             console.error(`[bridge ${ts()}] server error: ${err.message}`);
         });
         this.wss.on('connection', (ws) => {
-            console.error(`[bridge ${ts()}] new connection accepted`);
+            if (!this._silent) console.error(`[bridge ${ts()}] new connection accepted`);
             this.socket = ws;
             (ws as any)._alive = true;
 


### PR DESCRIPTION
Enables Claude Code and other automation tools to drive the browser one command at a time via bash, without needing the MCP server:

```bash
playwright-repl --bridge --command "snapshot"
playwright-repl --bridge --command "goto https://talent.toptal.com/portal/eligible-jobs"
playwright-repl --bridge --command "click \"Interested\""
```

**Why:** Claude Code can use this to autonomously drive Playwright via bash subprocesses — reading stdout after each command and deciding the next step. No MCP server conflict, no shared transport issues.

**Changes in `playwright-repl.ts`:**
- Add `'command'` to minimist `string` array
- Declare `commandArg` from `args.command`
- Pass `command: commandArg` and updated `silent` to `startRepl`

**Still needed:** `repl.ts` — add `command?: string` to options interface and handle it by running the command and exiting.