### PR TITLE
refactor: extract WebviewBase abstract class

### DIFF
--- a/packages/vscode/src/assertView.ts
+++ b/packages/vscode/src/assertView.ts
@@ -2,8 +2,7 @@
  * Assert Builder — dedicated panel for building and testing Playwright assertions.
  */
 
-import { DisposableBase } from './disposableBase';
-import { getNonce, html } from './utils';
+import { WebviewBase } from './webviewBase';
 import type { IBrowserManager } from './browser';
 import type { Picker } from './picker';
 import * as vscodeTypes from './vscodeTypes';
@@ -50,25 +49,19 @@ export function filterTypes(tag?: string, inputType?: string): AssertionType[] {
   return filtered;
 }
 
-export class AssertView extends DisposableBase implements vscodeTypes.WebviewViewProvider {
-  private _vscode: vscodeTypes.VSCode;
-  private _view: vscodeTypes.WebviewView | undefined;
-  private _extensionUri: vscodeTypes.Uri;
+export class AssertView extends WebviewBase {
   private _browserManager: IBrowserManager | undefined;
   private _picker: Picker | undefined;
   private _locator = '';
   private _assertion = '';
   private _ariaSnapshot = '';
 
+  get viewId() { return 'playwright-repl.assertView'; }
+  get scriptName() { return 'assertView.script.js'; }
+  get bodyClass() { return 'assert-view'; }
+
   constructor(vscode: vscodeTypes.VSCode, extensionUri: vscodeTypes.Uri) {
-    super();
-    this._vscode = vscode;
-    this._extensionUri = extensionUri;
-    this._disposables = [
-      vscode.window.registerWebviewViewProvider('playwright-repl.assertView', this, {
-        webviewOptions: { retainContextWhenHidden: true },
-      }),
-    ];
+    super(vscode, extensionUri);
   }
 
   setBrowserManager(browserManager: IBrowserManager) {
@@ -88,118 +81,11 @@ export class AssertView extends DisposableBase implements vscodeTypes.WebviewVie
     await this._vscode.commands.executeCommand('playwright-repl.assertView.focus');
     if (!this._view)
       await new Promise(r => setTimeout(r, 200));
-    void this._view?.webview.postMessage({
-      method: 'update',
-      params: { locator, assertion, types, ariaSnapshot: this._ariaSnapshot },
-    });
+    this.postMessage('update', { locator, assertion, types, ariaSnapshot: this._ariaSnapshot });
   }
 
-  resolveWebviewView(webviewView: vscodeTypes.WebviewView) {
-    this._view = webviewView;
-
-    webviewView.webview.options = {
-      enableScripts: true,
-      localResourceRoots: [this._extensionUri],
-    };
-
-    webviewView.webview.html = htmlForWebview(this._vscode, this._extensionUri, webviewView.webview);
-
-    this._disposables.push(webviewView.webview.onDidReceiveMessage(async data => {
-      if (data.method === 'pick') {
-        await this._vscode.commands.executeCommand('playwright-repl.assertBuilder');
-      } else if (data.method === 'verify') {
-        await this._verify(data.params.assertion);
-      } else if (data.method === 'rebuild') {
-        this._rebuildAssertion(data.params.type, data.params.arg, data.params.negate);
-      } else if (data.method === 'rebuildSnapshot') {
-        this._rebuildSnapshotAssertion(data.params.snapshot, data.params.negate);
-      } else if (data.method === 'locatorChanged') {
-        this._locator = data.params.locator;
-      }
-    }));
-
-    // Send types on init
-    void webviewView.webview.postMessage({
-      method: 'init',
-      params: { types: ALL_ASSERTION_TYPES },
-    });
-  }
-
-  private _rebuildAssertion(type: string, arg?: string, negate?: boolean) {
-    if (!this._locator && !type.startsWith('toHave')) return;
-    const typeDef = ALL_ASSERTION_TYPES.find(t => t.value === type);
-    if (!typeDef) return;
-
-    const not = negate ? 'not.' : '';
-    const isPageLevel = type === 'toHaveURL' || type === 'toHaveTitle';
-    const target = isPageLevel ? 'page' : this._locator;
-    let assertion: string;
-    if (typeDef.argType === 'pair' && arg) {
-      const parts = arg.split(',').map(s => s.trim());
-      assertion = `await expect(${target}).${not}${type}('${parts[0] || ''}', '${parts[1] || ''}');`;
-    } else if (typeDef.needsArg && arg) {
-      const argStr = typeDef.argType === 'number' ? arg : `'${arg.replace(/'/g, "\\'")}'`;
-      assertion = `await expect(${target}).${not}${type}(${argStr});`;
-    } else {
-      assertion = `await expect(${target}).${not}${type}();`;
-    }
-
-    this._assertion = assertion;
-    void this._view?.webview.postMessage({
-      method: 'assertionUpdated',
-      params: { assertion },
-    });
-  }
-
-  private _rebuildSnapshotAssertion(snapshot?: string, negate?: boolean) {
-    if (!this._locator) return;
-    const not = negate ? 'not.' : '';
-    const assertion = snapshot
-      ? `await expect(${this._locator}).${not}toMatchAriaSnapshot(\`\n${snapshot}\n\`);`
-      : `await expect(${this._locator}).${not}toMatchAriaSnapshot(\`\`);`;
-
-    this._assertion = assertion;
-    void this._view?.webview.postMessage({
-      method: 'assertionUpdated',
-      params: { assertion },
-    });
-  }
-
-  private async _verify(assertion: string) {
-    if (!this._browserManager?.isRunning() || !assertion) return;
-    this._assertion = assertion;
-    void this._view?.webview.postMessage({ method: 'verifyProcessing', params: { processing: true } });
-    try {
-      const result = await this._browserManager.runCommand(assertion);
-      const passed = !result.isError;
-      void this._view?.webview.postMessage({
-        method: 'verifyResult',
-        params: { passed, error: passed ? null : result.text },
-      });
-    } catch (e: unknown) {
-      void this._view?.webview.postMessage({
-        method: 'verifyResult',
-        params: { passed: false, error: (e as Error).message },
-      });
-    }
-    void this._view?.webview.postMessage({ method: 'verifyProcessing', params: { processing: false } });
-  }
-}
-
-function htmlForWebview(vscode: vscodeTypes.VSCode, extensionUri: vscodeTypes.Uri, webview: vscodeTypes.Webview) {
-  const style = webview.asWebviewUri(vscode.Uri.joinPath(extensionUri, 'media', 'common.css'));
-  const script = webview.asWebviewUri(vscode.Uri.joinPath(extensionUri, 'dist', 'assertView.script.js'));
-  const nonce = getNonce();
-
-  return html`
-    <!DOCTYPE html>
-    <html lang="en">
-    <head>
-      <meta charset="UTF-8">
-      <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src ${webview.cspSource} 'unsafe-inline'; script-src 'nonce-${nonce}';">
-      <meta name="viewport" content="width=device-width, initial-scale=1.0">
-      <link href="${style}" rel="stylesheet">
-      <title>Assert</title>
+  bodyHtml(_webview: vscodeTypes.Webview): string {
+    return `
       <style>
         body.assert-view {
           user-select: text;
@@ -289,8 +175,6 @@ function htmlForWebview(vscode: vscodeTypes.VSCode, extensionUri: vscodeTypes.Ur
           margin-right: 6px;
         }
       </style>
-    </head>
-    <body class="assert-view">
       <div class="section">
         <div class="hbox">
           <span class="step-num">1</span>
@@ -332,8 +216,72 @@ function htmlForWebview(vscode: vscodeTypes.VSCode, extensionUri: vscodeTypes.Ur
           <span id="verifyResult" style="font-size:13px;margin-left:6px;display:none;"></span>
         </div>
       </div>
-    </body>
-    <script nonce="${nonce}" src="${script}"></script>
-    </html>
-  `;
+    `;
+  }
+
+  async onMessage(data: any) {
+    if (data.method === 'pick') {
+      await this._vscode.commands.executeCommand('playwright-repl.assertBuilder');
+    } else if (data.method === 'verify') {
+      await this._verify(data.params.assertion);
+    } else if (data.method === 'rebuild') {
+      this._rebuildAssertion(data.params.type, data.params.arg, data.params.negate);
+    } else if (data.method === 'rebuildSnapshot') {
+      this._rebuildSnapshotAssertion(data.params.snapshot, data.params.negate);
+    } else if (data.method === 'locatorChanged') {
+      this._locator = data.params.locator;
+    }
+  }
+
+  protected onViewReady() {
+    this.postMessage('init', { types: ALL_ASSERTION_TYPES });
+  }
+
+  private _rebuildAssertion(type: string, arg?: string, negate?: boolean) {
+    if (!this._locator && !type.startsWith('toHave')) return;
+    const typeDef = ALL_ASSERTION_TYPES.find(t => t.value === type);
+    if (!typeDef) return;
+
+    const not = negate ? 'not.' : '';
+    const isPageLevel = type === 'toHaveURL' || type === 'toHaveTitle';
+    const target = isPageLevel ? 'page' : this._locator;
+    let assertion: string;
+    if (typeDef.argType === 'pair' && arg) {
+      const parts = arg.split(',').map(s => s.trim());
+      assertion = `await expect(${target}).${not}${type}('${parts[0] || ''}', '${parts[1] || ''}');`;
+    } else if (typeDef.needsArg && arg) {
+      const argStr = typeDef.argType === 'number' ? arg : `'${arg.replace(/'/g, "\\'")}'`;
+      assertion = `await expect(${target}).${not}${type}(${argStr});`;
+    } else {
+      assertion = `await expect(${target}).${not}${type}();`;
+    }
+
+    this._assertion = assertion;
+    this.postMessage('assertionUpdated', { assertion });
+  }
+
+  private _rebuildSnapshotAssertion(snapshot?: string, negate?: boolean) {
+    if (!this._locator) return;
+    const not = negate ? 'not.' : '';
+    const assertion = snapshot
+      ? `await expect(${this._locator}).${not}toMatchAriaSnapshot(\`\n${snapshot}\n\`);`
+      : `await expect(${this._locator}).${not}toMatchAriaSnapshot(\`\`);`;
+
+    this._assertion = assertion;
+    this.postMessage('assertionUpdated', { assertion });
+  }
+
+  private async _verify(assertion: string) {
+    if (!this._browserManager?.isRunning() || !assertion) return;
+    this._assertion = assertion;
+    this.postMessage('verifyProcessing', { processing: true });
+    try {
+      const result = await this._browserManager.runCommand(assertion);
+      const passed = !result.isError;
+      this.postMessage('verifyResult', { passed, error: passed ? null : result.text });
+    } catch (e: unknown) {
+      this.postMessage('verifyResult', { passed: false, error: (e as Error).message });
+    }
+    this.postMessage('verifyProcessing', { processing: false });
+  }
 }

--- a/packages/vscode/src/replView.ts
+++ b/packages/vscode/src/replView.ts
@@ -2,8 +2,7 @@
  * REPL Webview — interactive command panel for Playwright REPL.
  */
 
-import { DisposableBase } from './disposableBase';
-import { getNonce, html } from './utils';
+import { WebviewBase } from './webviewBase';
 import type { IBrowserManager } from './browser';
 import * as vscodeTypes from './vscodeTypes';
 import { COMMANDS, CATEGORIES, ALIASES } from '@playwright-repl/core';
@@ -12,26 +11,20 @@ function core() {
   return { COMMANDS, CATEGORIES, ALIASES };
 }
 
-export class ReplView extends DisposableBase implements vscodeTypes.WebviewViewProvider {
-  private _vscode: vscodeTypes.VSCode;
-  private _view: vscodeTypes.WebviewView | undefined;
-  private _extensionUri: vscodeTypes.Uri;
+export class ReplView extends WebviewBase {
   private _browserManager: IBrowserManager | undefined;
   private _history: string[] = [];
   private _commandCount = 0;
 
+  get viewId() { return 'playwright-repl.replView'; }
+  get scriptName() { return 'replView.script.js'; }
+  get bodyClass() { return 'repl-view'; }
+
   constructor(vscode: vscodeTypes.VSCode, extensionUri: vscodeTypes.Uri) {
-    super();
-    this._vscode = vscode;
-    this._extensionUri = extensionUri;
-    this._disposables = [
-      vscode.window.registerWebviewViewProvider('playwright-repl.replView', this, {
-        webviewOptions: { retainContextWhenHidden: true },
-      }),
-    ];
+    super(vscode, extensionUri);
   }
 
-  setIBrowserManager(browserManager: IBrowserManager) {
+  setBrowserManager(browserManager: IBrowserManager) {
     this._browserManager = browserManager;
   }
 
@@ -43,27 +36,83 @@ export class ReplView extends DisposableBase implements vscodeTypes.WebviewViewP
     this._appendOutput('Browser disconnected.', 'error');
   }
 
-  resolveWebviewView(webviewView: vscodeTypes.WebviewView) {
-    this._view = webviewView;
+  bodyHtml(_webview: vscodeTypes.Webview): string {
+    return `
+      <style>
+        body.repl-view {
+          display: flex;
+          flex-direction: column;
+          height: 100vh;
+          overflow: hidden;
+          font-family: var(--vscode-editor-font-family, 'Consolas, monospace');
+          font-size: var(--vscode-editor-font-size, 13px);
+          user-select: text;
+        }
+        #output {
+          flex: 1;
+          overflow-y: auto;
+          padding: 4px 8px;
+          white-space: pre-wrap;
+          word-break: break-word;
+        }
+        .line { line-height: 1.4; }
+        .line-command { color: var(--vscode-terminal-ansiBrightWhite, var(--vscode-editor-foreground)); }
+        .line-command::before { content: 'pw> '; color: var(--vscode-terminal-ansiGreen); }
+        .line-output { color: var(--vscode-editor-foreground); }
+        .line-error { color: var(--vscode-terminal-ansiRed); }
+        .line-info { color: var(--vscode-terminal-ansiCyan, var(--vscode-descriptionForeground)); }
+        #input-row {
+          display: flex;
+          align-items: flex-start;
+          padding: 4px 8px;
+          border-top: 1px solid var(--vscode-panelInput-border, var(--vscode-panel-border));
+        }
+        #prompt {
+          color: var(--vscode-terminal-ansiGreen);
+          margin-right: 4px;
+          flex: none;
+        }
+        #command-input {
+          flex: 1;
+          border: none;
+          outline: none;
+          background: transparent;
+          color: var(--vscode-editor-foreground);
+          font-family: inherit;
+          font-size: inherit;
+          padding: 2px 0;
+          resize: none;
+          overflow: hidden;
+          line-height: 1.4;
+          field-sizing: content;
+          max-height: 40vh;
+        }
+        #command-input::placeholder {
+          color: var(--vscode-input-placeholderForeground);
+        }
+        #command-input:disabled {
+          opacity: 0.5;
+        }
+      </style>
+      <div id="output"></div>
+      <div id="input-row">
+        <span id="prompt">pw&gt;</span>
+        <textarea id="command-input" rows="1" placeholder="Type a command..." autofocus></textarea>
+      </div>
+    `;
+  }
 
-    webviewView.webview.options = {
-      enableScripts: true,
-      localResourceRoots: [this._extensionUri],
-    };
+  async onMessage(data: any) {
+    if (data.method === 'execute') {
+      await this._execute(data.params.command);
+    } else if (data.method === 'getHistory') {
+      this.postMessage('history', { history: this._history });
+    } else if (data.method === 'savePdf') {
+      await this._savePdf(data.params.dataUri);
+    }
+  }
 
-    webviewView.webview.html = htmlForWebview(this._vscode, this._extensionUri, webviewView.webview);
-
-    this._disposables.push(webviewView.webview.onDidReceiveMessage(async data => {
-      if (data.method === 'execute') {
-        await this._execute(data.params.command);
-      } else if (data.method === 'getHistory') {
-        void this._view?.webview.postMessage({ method: 'history', params: { history: this._history } });
-      } else if (data.method === 'savePdf') {
-        await this._savePdf(data.params.dataUri);
-      }
-    }));
-
-    // Send welcome message
+  protected onViewReady() {
     const connected = this._browserManager?.isRunning() ?? false;
     this._appendOutput('Playwright REPL\nType commands. Use ↑↓ for history.', 'info');
     this._appendOutput(connected ? 'Connected to browser.' : 'Waiting for browser... Launch with Ctrl+Shift+P → "Launch Browser"', connected ? 'info' : 'error');
@@ -146,7 +195,7 @@ export class ReplView extends DisposableBase implements vscodeTypes.WebviewViewP
 
     // .clear — clear output
     if (trimmed === '.clear') {
-      void this._view?.webview.postMessage({ method: 'clear' });
+      this.postMessage('clear');
       return true;
     }
 
@@ -218,20 +267,19 @@ export class ReplView extends DisposableBase implements vscodeTypes.WebviewViewP
       return true;
     }
 
-
     return false;
   }
 
   private _appendOutput(text: string, type: 'output' | 'error' | 'info') {
-    void this._view?.webview.postMessage({ method: 'output', params: { text, type } });
+    this.postMessage('output', { text, type });
   }
 
   private _appendImage(dataUri: string) {
-    void this._view?.webview.postMessage({ method: 'image', params: { dataUri } });
+    this.postMessage('image', { dataUri });
   }
 
   private _appendPdf(dataUri: string) {
-    void this._view?.webview.postMessage({ method: 'pdf', params: { dataUri } });
+    this.postMessage('pdf', { dataUri });
   }
 
   private async _savePdf(dataUri: string) {
@@ -248,89 +296,6 @@ export class ReplView extends DisposableBase implements vscodeTypes.WebviewViewP
   }
 
   private _setProcessing(processing: boolean) {
-    void this._view?.webview.postMessage({ method: 'processing', params: { processing } });
+    this.postMessage('processing', { processing });
   }
-}
-
-function htmlForWebview(vscode: vscodeTypes.VSCode, extensionUri: vscodeTypes.Uri, webview: vscodeTypes.Webview) {
-  const style = webview.asWebviewUri(vscode.Uri.joinPath(extensionUri, 'media', 'common.css'));
-  const script = webview.asWebviewUri(vscode.Uri.joinPath(extensionUri, 'dist', 'replView.script.js'));
-  const nonce = getNonce();
-
-  return html`
-    <!DOCTYPE html>
-    <html lang="en">
-    <head>
-      <meta charset="UTF-8">
-      <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src ${webview.cspSource} 'unsafe-inline'; script-src 'nonce-${nonce}'; img-src data:;">
-      <meta name="viewport" content="width=device-width, initial-scale=1.0">
-      <link href="${style}" rel="stylesheet">
-      <title>REPL</title>
-      <style>
-        body.repl-view {
-          display: flex;
-          flex-direction: column;
-          height: 100vh;
-          overflow: hidden;
-          font-family: var(--vscode-editor-font-family, 'Consolas, monospace');
-          font-size: var(--vscode-editor-font-size, 13px);
-          user-select: text;
-        }
-        #output {
-          flex: 1;
-          overflow-y: auto;
-          padding: 4px 8px;
-          white-space: pre-wrap;
-          word-break: break-word;
-        }
-        .line { line-height: 1.4; }
-        .line-command { color: var(--vscode-terminal-ansiBrightWhite, var(--vscode-editor-foreground)); }
-        .line-command::before { content: 'pw> '; color: var(--vscode-terminal-ansiGreen); }
-        .line-output { color: var(--vscode-editor-foreground); }
-        .line-error { color: var(--vscode-terminal-ansiRed); }
-        .line-info { color: var(--vscode-terminal-ansiCyan, var(--vscode-descriptionForeground)); }
-        #input-row {
-          display: flex;
-          align-items: flex-start;
-          padding: 4px 8px;
-          border-top: 1px solid var(--vscode-panelInput-border, var(--vscode-panel-border));
-        }
-        #prompt {
-          color: var(--vscode-terminal-ansiGreen);
-          margin-right: 4px;
-          flex: none;
-        }
-        #command-input {
-          flex: 1;
-          border: none;
-          outline: none;
-          background: transparent;
-          color: var(--vscode-editor-foreground);
-          font-family: inherit;
-          font-size: inherit;
-          padding: 2px 0;
-          resize: none;
-          overflow: hidden;
-          line-height: 1.4;
-          field-sizing: content;
-          max-height: 40vh;
-        }
-        #command-input::placeholder {
-          color: var(--vscode-input-placeholderForeground);
-        }
-        #command-input:disabled {
-          opacity: 0.5;
-        }
-      </style>
-    </head>
-    <body class="repl-view">
-      <div id="output"></div>
-      <div id="input-row">
-        <span id="prompt">pw&gt;</span>
-        <textarea id="command-input" rows="1" placeholder="Type a command..." autofocus></textarea>
-      </div>
-    </body>
-    <script nonce="${nonce}" src="${script}"></script>
-    </html>
-  `;
 }

--- a/packages/vscode/src/webviewBase.ts
+++ b/packages/vscode/src/webviewBase.ts
@@ -1,0 +1,88 @@
+/**
+ * WebviewBase — abstract base class for webview panels.
+ *
+ * Extracts shared boilerplate from ReplView, AssertView, LocatorsView:
+ * - WebviewViewProvider registration
+ * - resolveWebviewView with options, HTML, message handler
+ * - postMessage helper
+ * - HTML skeleton (CSP, nonce, common.css, script)
+ */
+
+import { DisposableBase } from './disposableBase';
+import { getNonce, html } from './utils';
+import * as vscodeTypes from './vscodeTypes';
+
+export abstract class WebviewBase extends DisposableBase implements vscodeTypes.WebviewViewProvider {
+  protected _vscode: vscodeTypes.VSCode;
+  protected _view: vscodeTypes.WebviewView | undefined;
+  protected _extensionUri: vscodeTypes.Uri;
+
+  /** Unique view identifier, e.g. 'playwright-repl.replView' */
+  abstract get viewId(): string;
+  /** Script filename in dist/, e.g. 'replView.script.js' */
+  abstract get scriptName(): string;
+  /** CSS class for the body element, e.g. 'repl-view' */
+  abstract get bodyClass(): string;
+  /** View-specific HTML: inline styles + body content */
+  abstract bodyHtml(webview: vscodeTypes.Webview): string;
+  /** Handle messages from the webview script */
+  abstract onMessage(data: any): Promise<void> | void;
+
+  constructor(vscode: vscodeTypes.VSCode, extensionUri: vscodeTypes.Uri, options?: { retainContextWhenHidden?: boolean }) {
+    super();
+    this._vscode = vscode;
+    this._extensionUri = extensionUri;
+    this._disposables.push(
+      vscode.window.registerWebviewViewProvider(this.viewId, this, {
+        webviewOptions: { retainContextWhenHidden: options?.retainContextWhenHidden ?? true },
+      }),
+    );
+  }
+
+  resolveWebviewView(webviewView: vscodeTypes.WebviewView) {
+    this._view = webviewView;
+
+    webviewView.webview.options = {
+      enableScripts: true,
+      localResourceRoots: [this._extensionUri],
+    };
+
+    webviewView.webview.html = this._buildHtml(webviewView.webview);
+
+    this._disposables.push(
+      webviewView.webview.onDidReceiveMessage(data => this.onMessage(data)),
+    );
+
+    this.onViewReady();
+  }
+
+  /** Override to run logic after the webview is resolved (e.g. send initial data). */
+  protected onViewReady() {}
+
+  /** Send a message to the webview. */
+  protected postMessage(method: string, params?: Record<string, any>) {
+    void this._view?.webview.postMessage({ method, params });
+  }
+
+  private _buildHtml(webview: vscodeTypes.Webview): string {
+    const style = webview.asWebviewUri(this._vscode.Uri.joinPath(this._extensionUri, 'media', 'common.css'));
+    const script = webview.asWebviewUri(this._vscode.Uri.joinPath(this._extensionUri, 'dist', this.scriptName));
+    const nonce = getNonce();
+
+    return html`
+      <!DOCTYPE html>
+      <html lang="en">
+      <head>
+        <meta charset="UTF-8">
+        <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src ${webview.cspSource} 'unsafe-inline'; script-src 'nonce-${nonce}'; img-src data:;">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <link href="${style}" rel="stylesheet">
+      </head>
+      <body class="${this.bodyClass}">
+        ${this.bodyHtml(webview)}
+      </body>
+      <script nonce="${nonce}" src="${script}"></script>
+      </html>
+    `;
+  }
+}


### PR DESCRIPTION
## Summary
- Phase 2 of #638: extract shared webview boilerplate into `WebviewBase` abstract class
- ReplView and AssertView now extend WebviewBase (~60 lines of duplication removed)
- LocatorsView left as-is (forked from Microsoft, upstream merge risk)

## WebviewBase provides
- `resolveWebviewView()` — options, HTML, message handler wiring
- `postMessage(method, params)` — typed helper
- HTML skeleton — CSP, nonce, common.css, script loading
- `onViewReady()` — hook for post-init logic

## Subclasses implement
- `viewId`, `scriptName`, `bodyClass` — identifiers
- `bodyHtml()` — view-specific HTML + styles
- `onMessage()` — message handler

## Test plan
- [x] Production build passes
- [x] Playwright mock tests pass (repl-view + assert-view)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)