### PR TITLE
perf: reuse webview pages across mock tests via WebviewPagePool

### DIFF
--- a/packages/vscode/tests/playwright/assert-view.spec.ts
+++ b/packages/vscode/tests/playwright/assert-view.spec.ts
@@ -5,17 +5,12 @@
  */
 
 import { expect, test } from './utils';
-
-test.beforeEach(async ({ showBrowser }) => {
-  test.skip(showBrowser);
-});
-
 test('should show pick button and assertion type dropdown on activate', async ({ activate }) => {
   const { vscode } = await activate({
     'playwright.config.js': `module.exports = {}`,
   });
 
-  const assertView = vscode.webViews.get('playwright-repl.assertView')!;
+  const assertView = await vscode.webView('playwright-repl.assertView');
   await expect(assertView.locator('#pickBtn')).toBeVisible();
   await expect(assertView.locator('#assertType')).toBeVisible();
   await expect(assertView.locator('#assertType option')).not.toHaveCount(0);
@@ -26,7 +21,7 @@ test('should populate locator and assertion when showAssertion is called', async
     'playwright.config.js': `module.exports = {}`,
   });
 
-  const assertView = vscode.webViews.get('playwright-repl.assertView')!;
+  const assertView = await vscode.webView('playwright-repl.assertView');
   const extension = vscode.extensions[0];
 
   // Simulate picking an element — call showAssertion on the assert view
@@ -48,7 +43,7 @@ test('should rebuild assertion when type changes', async ({ activate }) => {
     'playwright.config.js': `module.exports = {}`,
   });
 
-  const assertView = vscode.webViews.get('playwright-repl.assertView')!;
+  const assertView = await vscode.webView('playwright-repl.assertView');
   const extension = vscode.extensions[0];
 
   const assertViewInstance = (extension as any)._assertView;
@@ -68,7 +63,7 @@ test('should toggle negate checkbox to add .not.', async ({ activate }) => {
     'playwright.config.js': `module.exports = {}`,
   });
 
-  const assertView = vscode.webViews.get('playwright-repl.assertView')!;
+  const assertView = await vscode.webView('playwright-repl.assertView');
   const extension = vscode.extensions[0];
 
   const assertViewInstance = (extension as any)._assertView;
@@ -88,7 +83,7 @@ test('should switch to snapshot mode', async ({ activate }) => {
     'playwright.config.js': `module.exports = {}`,
   });
 
-  const assertView = vscode.webViews.get('playwright-repl.assertView')!;
+  const assertView = await vscode.webView('playwright-repl.assertView');
   const extension = vscode.extensions[0];
 
   const assertViewInstance = (extension as any)._assertView;
@@ -109,7 +104,7 @@ test('should show arg input for types that need arguments', async ({ activate })
     'playwright.config.js': `module.exports = {}`,
   });
 
-  const assertView = vscode.webViews.get('playwright-repl.assertView')!;
+  const assertView = await vscode.webView('playwright-repl.assertView');
   const extension = vscode.extensions[0];
 
   const assertViewInstance = (extension as any)._assertView;

--- a/packages/vscode/tests/playwright/auto-close.spec.ts
+++ b/packages/vscode/tests/playwright/auto-close.spec.ts
@@ -44,7 +44,7 @@ test('should be closed with Close all Browsers button', async ({ activate }) => 
     `
   });
 
-  const webView = vscode.webViews.get('playwright-repl.settingsView')!;
+  const webView = await vscode.webView('playwright-repl.settingsView');
   const closeAllBrowsers = webView.getByRole('button', { name: 'Close all browsers' });
   await expect(closeAllBrowsers).toBeDisabled();
   const reusedBrowser = await vscode.extensions[0].reusedBrowserForTest();
@@ -104,7 +104,7 @@ test('should enact "Show Browser" setting change after test finishes', async ({ 
   const reusedBrowser = vscode.extensions[0].reusedBrowserForTest();
   await expect.poll(() => !!reusedBrowser._backend, 'wait until test started').toBeTruthy();
 
-  const webView = vscode.webViews.get('playwright-repl.settingsView')!;
+  const webView = await vscode.webView('playwright-repl.settingsView');
   await webView.getByRole('checkbox', { name: 'Show Browser' }).uncheck();
   await expect.poll(() => !!reusedBrowser._backend, 'contrary to setting change, browser stays open during test run').toBeTruthy();
   latch.open();

--- a/packages/vscode/tests/playwright/codegen.spec.ts
+++ b/packages/vscode/tests/playwright/codegen.spec.ts
@@ -49,7 +49,7 @@ test('should generate code', async ({ activate }) => {
     `,
   });
 
-  const webView = vscode.webViews.get('playwright-repl.settingsView')!;
+  const webView = await vscode.webView('playwright-repl.settingsView');
   await webView.getByRole('checkbox', { name: 'default' }).setChecked(false);
   await webView.getByRole('checkbox', { name: 'germany' }).setChecked(true);
   await webView.getByText('Record new').click();
@@ -89,7 +89,7 @@ test('running test should stop the recording', async ({ activate, showBrowser })
     `,
   });
 
-  const webView = vscode.webViews.get('playwright-repl.settingsView')!;
+  const webView = await vscode.webView('playwright-repl.settingsView');
   await webView.getByText('Record new').click();
   await expect.poll(() => vscode.lastWithProgressData, { timeout: 0 }).toEqual({ message: 'recording\u2026' });
 
@@ -128,7 +128,7 @@ test('Record at Cursor should respect custom testId', async ({ activate, showBro
   expect(editor.document.uri.path).toContain('test.spec.ts');
   editor.selection = new vscode.Selection(4, 0, 4, 0);
 
-  const webView = vscode.webViews.get('playwright-repl.settingsView')!;
+  const webView = await vscode.webView('playwright-repl.settingsView');
   await webView.getByText('Record at cursor').click();
   await expect.poll(() => vscode.lastWithProgressData, { timeout: 0 }).toEqual({ message: 'recording\u2026' });
 

--- a/packages/vscode/tests/playwright/mock/vscode.ts
+++ b/packages/vscode/tests/playwright/mock/vscode.ts
@@ -21,10 +21,106 @@ import { Disposable, EventEmitter, Event } from '../../../src/upstream/events';
 import { minimatch } from 'minimatch';
 import { ChildProcessWithoutNullStreams, spawn } from 'child_process';
 import which from 'which';
-import { Browser, Page } from '@playwright/test';
+import { Browser, BrowserContext, Page } from '@playwright/test';
 import { CancellationToken } from '../../../src/vscodeTypes';
 
 /* eslint-disable no-restricted-properties */
+
+// ─── WebviewPagePool ───
+// Worker-scoped pool that reuses a single BrowserContext and lazily-created
+// Pages across tests. Pages are created on first access and reset (not
+// destroyed) between tests, avoiding expensive context/page re-creation.
+
+type WebviewSlot = {
+  page: Page;
+  /** Swap the handler that receives messages from the page (via exposeFunction). */
+  setMessageHandler(handler: (data: any) => void): void;
+  /** Swap the handler that receives visibility changes (via page 'load' event). */
+  setVisibilityHandler(handler: (state: 'visible' | 'hidden') => void): void;
+};
+
+export class WebviewPagePool {
+  private _context: BrowserContext | null = null;
+  private _slots = new Map<string, WebviewSlot>();
+
+  constructor(private _browser: Browser, private _extensionDir: string) {}
+
+  /**
+   * Return the reusable Page for `name`. On first call the page is created
+   * inside a shared BrowserContext; subsequent calls return the cached page.
+   *
+   * `html` is the webview HTML to serve at http://localhost/ (set by the
+   * extension during resolveWebviewView).
+   */
+  async getOrCreatePage(
+    name: string,
+    html: { current: string },
+    messageHandler: { current: (data: any) => void },
+    visibilityHandler: { current: (state: 'visible' | 'hidden') => void },
+  ): Promise<Page> {
+    const existing = this._slots.get(name);
+    if (existing) {
+      // Reuse — swap handlers and re-navigate to pick up new html.
+      existing.setMessageHandler(data => messageHandler.current(data));
+      existing.setVisibilityHandler(state => visibilityHandler.current(state));
+      await existing.page.goto('http://localhost');
+      return existing.page;
+    }
+
+    // First time — create context (once) and page.
+    if (!this._context) {
+      this._context = await this._browser.newContext();
+    }
+    const page = await this._context.newPage();
+
+    // Mutable handler refs — swapped per test via setters.
+    let msgHandler = (data: any) => messageHandler.current(data);
+    let visHandler = (state: 'visible' | 'hidden') => visibilityHandler.current(state);
+
+    await page.route('**/*', async route => {
+      const url = route.request().url();
+      if (!url.startsWith('http://localhost/'))
+        await route.continue();
+      else if (url === 'http://localhost/')
+        await route.fulfill({ body: html.current });
+      else if (url === 'http://localhost/hidden')
+        await route.fulfill({ body: 'hidden webview' });
+      else {
+        const suffix = url.substring('http://localhost/'.length);
+        const buffer = fs.readFileSync(path.join(this._extensionDir, suffix));
+        await route.fulfill({ body: buffer });
+      }
+    });
+
+    page.on('load', () => {
+      const url = page.url();
+      if (url === 'http://localhost/')
+        visHandler('visible');
+      else if (url === 'http://localhost/hidden')
+        visHandler('hidden');
+    });
+
+    await page.addInitScript(() => {
+      (globalThis as any).acquireVsCodeApi = () => globalThis;
+    });
+    await page.goto('http://localhost');
+    await page.exposeFunction('postMessage', (data: any) => msgHandler(data));
+
+    this._slots.set(name, {
+      page,
+      setMessageHandler: h => { msgHandler = h; },
+      setVisibilityHandler: h => { visHandler = h; },
+    });
+
+    return page;
+  }
+
+  async close() {
+    await this._context?.close();
+    this._context = null;
+    this._slots.clear();
+  }
+}
 
 export class Uri {
   scheme = 'file';
@@ -989,8 +1085,10 @@ export class VSCode {
   readonly extensions: any[] = [];
   private _webviewProviders = new Map<string, any>();
   private _browser: Browser;
+  private _pool?: WebviewPagePool;
   private _webViewsByPanelType = new Map<string, Set<Page>>();
   readonly webViews = new Map<string, Page>();
+  private _pendingWebviews = new Map<string, () => Promise<Page>>();
   readonly commandLog: string[] = [];
   readonly l10n = new L10n();
   lastWithProgressData: any;
@@ -1002,7 +1100,7 @@ export class VSCode {
   readonly diagnosticsCollections: DiagnosticsCollection[] = [];
   private _clipboardText = '';
 
-  constructor(readonly versionNumber: number, baseDir: string, browser: Browser) {
+  constructor(readonly versionNumber: number, baseDir: string, browser: Browser, pool?: WebviewPagePool) {
     this.version = String(versionNumber);
     const workspaceStateStorage = new Map();
     const workspaceState = {
@@ -1011,6 +1109,7 @@ export class VSCode {
     };
     this.context = { subscriptions: [], extensionUri: Uri.file(baseDir), workspaceState };
     this._browser = browser;
+    this._pool = pool;
     (globalThis as any).__logForTest = (message: any) => this.connectionLog.push(message);
     const commands = new Map<string, () => Promise<void>>();
     this.commands.registerCommand = (name: string, callback: () => Promise<void>) => {
@@ -1230,18 +1329,100 @@ export class VSCode {
     for (const extension of this.extensions)
       await extension.activate();
 
-    for (const [name, provider] of this._webviewProviders) {
-      const { webview, pagePromise } = this._createWebviewAndPage();
-      provider?.resolveWebviewView({ webview, onDidChangeVisibility: () => disposable });
-      const page = await pagePromise;
-      if (page)
-        this.webViews.set(name, page);
+    if (this._pool) {
+      // Deferred mode: create webview mocks and resolve providers, but don't
+      // create pages yet.  Pages are created lazily via webView().
+      for (const [name, provider] of this._webviewProviders) {
+        const htmlRef = { current: '' };
+        const messageHandlerRef = { current: (_data: any) => {} };
+        const visibilityHandlerRef = { current: (_state: 'visible' | 'hidden') => {} };
+        const didReceiveMessage = new EventEmitter<any>();
+        const didChangeVisibility = new EventEmitter<'visible' | 'hidden'>();
+
+        messageHandlerRef.current = (data: any) => didReceiveMessage.fire(data);
+        visibilityHandlerRef.current = (state: 'visible' | 'hidden') => didChangeVisibility.fire(state);
+
+        const webview: any = {};
+        webview.asWebviewUri = (uri: Uri) => path.relative(this.context.extensionUri.fsPath, uri.fsPath).replace(/\\/g, '/');
+        webview.onDidReceiveMessage = didReceiveMessage.event;
+        webview.onDidChangeVisibility = didChangeVisibility.event;
+        webview.cspSource = 'http://localhost/';
+
+        let initializedPage: Page | undefined;
+        const pendingMessages: any[] = [];
+        webview.postMessage = (data: any) => {
+          if (!initializedPage) {
+            pendingMessages.push(data);
+            return;
+          }
+          initializedPage.evaluate((data: any) => {
+            const event = new globalThis.Event('message');
+            (event as any).data = data;
+            (globalThis as any).dispatchEvent(event);
+          }, data).catch(() => {});
+        };
+
+        provider?.resolveWebviewView({ webview, onDidChangeVisibility: () => disposable });
+
+        // Capture html after resolveWebviewView sets it.
+        htmlRef.current = webview.html || '';
+
+        // Store a lazy creator — page is only created when webView() is called.
+        this._pendingWebviews.set(name, async () => {
+          // Update html ref in case it changed.
+          htmlRef.current = webview.html || '';
+          const page = await this._pool!.getOrCreatePage(name, htmlRef, messageHandlerRef, visibilityHandlerRef);
+          initializedPage = page;
+          for (const m of pendingMessages)
+            webview.postMessage(m);
+          pendingMessages.length = 0;
+          return page;
+        });
+
+        // Dispose event emitters when this VSCode instance is disposed.
+        this.context.subscriptions.push(didReceiveMessage, didChangeVisibility);
+      }
+    } else {
+      // Legacy mode: create pages eagerly (no pool).
+      for (const [name, provider] of this._webviewProviders) {
+        const { webview, pagePromise } = this._createWebviewAndPage();
+        provider?.resolveWebviewView({ webview, onDidChangeVisibility: () => disposable });
+        const page = await pagePromise;
+        if (page)
+          this.webViews.set(name, page);
+      }
     }
+  }
+
+  /**
+   * Lazily get (or create) the Page for a webview provider.
+   * When using a WebviewPagePool, the page is created on first call and
+   * reused from the pool on subsequent calls (even across tests).
+   * Falls back to the eager webViews map when no pool is used.
+   */
+  async webView(name: string): Promise<Page> {
+    // Already materialized?
+    const existing = this.webViews.get(name);
+    if (existing)
+      return existing;
+
+    // Lazy creation via pool.
+    const creator = this._pendingWebviews.get(name);
+    if (creator) {
+      const page = await creator();
+      this.webViews.set(name, page);
+      this._pendingWebviews.delete(name);
+      return page;
+    }
+
+    throw new Error(`No webview provider registered for "${name}"`);
   }
 
   dispose() {
     for (const d of this.context.subscriptions)
       d.dispose();
+    this._pendingWebviews.clear();
+    this.webViews.clear();
   }
 
   webViewsByPanelType(viewType: string) {
@@ -1357,7 +1538,7 @@ export class VSCode {
 
   async renderProjectTree(): Promise<string> {
     const result: string[] = [''];
-    const webView = this.webViews.get('playwright-repl.settingsView')!;
+    const webView = await this.webView('playwright-repl.settingsView');
     const selectedConfig = await webView.getByTestId('models').evaluate((e: HTMLSelectElement) => e.selectedOptions[0].textContent);
     result.push(`    config: ${selectedConfig}`);
     const projectLocators = await webView.getByTestId('projects').locator('div').locator('label').filter({ visible: true }).all();

--- a/packages/vscode/tests/playwright/pick-selector.spec.ts
+++ b/packages/vscode/tests/playwright/pick-selector.spec.ts
@@ -27,7 +27,7 @@ test('should pick locator and dismiss the toolbar', async ({ activate }) => {
     'playwright.config.js': `module.exports = {}`,
   });
 
-  const settingsView = vscode.webViews.get('playwright-repl.settingsView')!;
+  const settingsView = await vscode.webView('playwright-repl.settingsView');
   await settingsView.getByText('Pick locator').click();
   await waitForRecorderMode(vscode, 'inspecting');
 
@@ -39,7 +39,7 @@ test('should pick locator and dismiss the toolbar', async ({ activate }) => {
   `);
   await page.locator('h1').first().click();
 
-  const locatorsView = vscode.webViews.get('playwright-repl.locatorsView')!;
+  const locatorsView = await vscode.webView('playwright-repl.locatorsView');
   await expect(locatorsView.locator('body')).toMatchAriaSnapshot(`
     - text: Locator
     - textbox "Locator": "getByRole('heading', { name: 'Hello' })"
@@ -62,7 +62,7 @@ test('should highlight locator on edit', async ({ activate }) => {
     'playwright.config.js': `module.exports = {}`,
   });
 
-  const settingsView = vscode.webViews.get('playwright-repl.settingsView')!;
+  const settingsView = await vscode.webView('playwright-repl.settingsView');
   await settingsView.getByText('Pick locator').click();
   await waitForRecorderMode(vscode, 'inspecting');
 
@@ -74,7 +74,7 @@ test('should highlight locator on edit', async ({ activate }) => {
   `);
   const box = await page.getByRole('heading', { name: 'Hello' }).boundingBox();
 
-  const locatorsView = vscode.webViews.get('playwright-repl.locatorsView')!;
+  const locatorsView = await vscode.webView('playwright-repl.locatorsView');
   await locatorsView.getByRole('textbox', { name: 'Locator' }).fill('h1');
 
   await expect(page.locator('x-pw-highlight')).toBeVisible();
@@ -86,7 +86,7 @@ test('should copy locator to clipboard', async ({ activate }) => {
     'playwright.config.js': `module.exports = {}`,
   });
 
-  const locatorsView = vscode.webViews.get('playwright-repl.locatorsView')!;
+  const locatorsView = await vscode.webView('playwright-repl.locatorsView');
   await locatorsView.getByRole('checkbox', { name: 'Copy on pick' }).check();
   await locatorsView.getByRole('button', { name: 'Pick locator' }).first().click();
   await waitForRecorderMode(vscode, 'inspecting');
@@ -107,7 +107,7 @@ test('should pick locator and use the testIdAttribute from the config', async ({
     'playwright.config.js': `module.exports = { use: { testIdAttribute: 'data-testerid' } }`,
   });
 
-  const settingsView = vscode.webViews.get('playwright-repl.settingsView')!;
+  const settingsView = await vscode.webView('playwright-repl.settingsView');
   await settingsView.getByText('Pick locator').click();
   await waitForRecorderMode(vscode, 'inspecting');
 
@@ -122,7 +122,7 @@ test('should pick locator and use the testIdAttribute from the config', async ({
   `);
   await page.locator('div').click();
 
-  const locatorsView = vscode.webViews.get('playwright-repl.locatorsView')!;
+  const locatorsView = await vscode.webView('playwright-repl.locatorsView');
   await expect(locatorsView.locator('body')).toMatchAriaSnapshot(`
     - text: Locator
     - textbox "Locator": "getByTestId('hello')"
@@ -142,7 +142,7 @@ test('running test should dismiss the toolbar', async ({ activate, showBrowser }
     `,
   });
 
-  const settingsView = vscode.webViews.get('playwright-repl.settingsView')!;
+  const settingsView = await vscode.webView('playwright-repl.settingsView');
   await settingsView.getByRole('button', { name: 'Pick locator' }).click();
   await waitForRecorderMode(vscode, 'inspecting');
 

--- a/packages/vscode/tests/playwright/project-setup.spec.ts
+++ b/packages/vscode/tests/playwright/project-setup.spec.ts
@@ -67,7 +67,7 @@ test('should run setup and teardown projects (1)', async ({ activate }) => {
   expect(output).toContain('from-teardown');
 
   // Ensure the rendered order of the projects is correct.
-  const webView = vscode.webViews.get('playwright-repl.settingsView')!;
+  const webView = await vscode.webView('playwright-repl.settingsView');
   await expect(webView.getByTestId('projects').locator('div').locator('label')).toHaveText([
     'setup',
     'test',

--- a/packages/vscode/tests/playwright/project-tree.spec.ts
+++ b/packages/vscode/tests/playwright/project-tree.spec.ts
@@ -173,7 +173,7 @@ test('should hide project section when there is just one', async ({ activate }) 
     }`
   });
 
-  const webView = vscode.webViews.get('playwright-repl.settingsView')!;
+  const webView = await vscode.webView('playwright-repl.settingsView');
   await expect(webView.getByRole('heading', { name: 'PROJECTS' })).not.toBeVisible();
 });
 
@@ -191,7 +191,7 @@ test('should treat project as enabled when UI for it is hidden', async ({ activa
     `,
   });
 
-  const webView = vscode.webViews.get('playwright-repl.settingsView')!;
+  const webView = await vscode.webView('playwright-repl.settingsView');
 
   await enableProjects(vscode, ['projectTwo']);
   await expect(vscode).toHaveProjectTree(`

--- a/packages/vscode/tests/playwright/repl-view.spec.ts
+++ b/packages/vscode/tests/playwright/repl-view.spec.ts
@@ -6,10 +6,6 @@
 
 import { expect, test } from './utils';
 
-test.beforeEach(async ({ showBrowser }) => {
-  test.skip(showBrowser);
-});
-
 async function typeCommand(replView: any, command: string) {
   const input = replView.locator('#command-input');
   await input.fill(command);
@@ -30,7 +26,7 @@ test('should show welcome message on activate', async ({ activate }) => {
     'playwright.config.js': `module.exports = {}`,
   });
 
-  const replView = vscode.webViews.get('playwright-repl.replView')!;
+  const replView = await vscode.webView('playwright-repl.replView');
   await expect(replView.locator('#output')).toContainText('Playwright REPL');
   await expect(replView.locator('#output')).toContainText('Waiting for browser');
 });
@@ -40,7 +36,7 @@ test('local command .clear should clear output', async ({ activate }) => {
     'playwright.config.js': `module.exports = {}`,
   });
 
-  const replView = vscode.webViews.get('playwright-repl.replView')!;
+  const replView = await vscode.webView('playwright-repl.replView');
   // Output has welcome message
   await expect(replView.locator('#output .line')).not.toHaveCount(0);
 
@@ -54,7 +50,7 @@ test('local command help should show categories', async ({ activate }) => {
     'playwright.config.js': `module.exports = {}`,
   });
 
-  const replView = vscode.webViews.get('playwright-repl.replView')!;
+  const replView = await vscode.webView('playwright-repl.replView');
   await typeCommand(replView, 'help');
   await expect(replView.locator('#output')).toContainText('Available commands');
 });
@@ -64,7 +60,7 @@ test('local command help <unknown> should show error', async ({ activate }) => {
     'playwright.config.js': `module.exports = {}`,
   });
 
-  const replView = vscode.webViews.get('playwright-repl.replView')!;
+  const replView = await vscode.webView('playwright-repl.replView');
   await typeCommand(replView, 'help nonexistent');
   await expect(replView.locator('#output .line-error').last()).toContainText('Unknown command');
 });
@@ -74,7 +70,7 @@ test('local command .history should show session history', async ({ activate }) 
     'playwright.config.js': `module.exports = {}`,
   });
 
-  const replView = vscode.webViews.get('playwright-repl.replView')!;
+  const replView = await vscode.webView('playwright-repl.replView');
   await typeCommand(replView, 'help');
   await typeCommand(replView, '.history');
   // History should contain the 'help' command and '.history' itself
@@ -86,7 +82,7 @@ test('local command .status should show connection status', async ({ activate })
     'playwright.config.js': `module.exports = {}`,
   });
 
-  const replView = vscode.webViews.get('playwright-repl.replView')!;
+  const replView = await vscode.webView('playwright-repl.replView');
   await typeCommand(replView, '.status');
   await expect(replView.locator('#output')).toContainText('Browser: stopped');
   await expect(replView.locator('#output')).toContainText('Commands: 0');
@@ -97,7 +93,7 @@ test('execute when browser not running should show error', async ({ activate }) 
     'playwright.config.js': `module.exports = {}`,
   });
 
-  const replView = vscode.webViews.get('playwright-repl.replView')!;
+  const replView = await vscode.webView('playwright-repl.replView');
   await typeCommand(replView, 'snapshot');
   await expect(replView.locator('#output .line-error').last()).toContainText('Browser not running');
 });
@@ -107,7 +103,7 @@ test('local command .aliases should show aliases', async ({ activate }) => {
     'playwright.config.js': `module.exports = {}`,
   });
 
-  const replView = vscode.webViews.get('playwright-repl.replView')!;
+  const replView = await vscode.webView('playwright-repl.replView');
   await typeCommand(replView, '.aliases');
   await expect(replView.locator('#output')).toContainText('Aliases');
 });
@@ -117,7 +113,7 @@ test('local command .history clear should clear history', async ({ activate }) =
     'playwright.config.js': `module.exports = {}`,
   });
 
-  const replView = vscode.webViews.get('playwright-repl.replView')!;
+  const replView = await vscode.webView('playwright-repl.replView');
   await typeCommand(replView, 'help');
   await typeCommand(replView, '.history clear');
   await expect(replView.locator('#output')).toContainText('History cleared');

--- a/packages/vscode/tests/playwright/run-tests.spec.ts
+++ b/packages/vscode/tests/playwright/run-tests.spec.ts
@@ -1088,7 +1088,7 @@ test('Run global setup should be disabled if there is no global setup or webserv
     -   tests
       -   test.spec.ts
   `);
-  const webView = vscode.webViews.get('playwright-repl.settingsView')!;
+  const webView = await vscode.webView('playwright-repl.settingsView');
   await expect(webView.getByRole('button', { name: 'Run global setup' })).toBeDisabled();
 
   await workspaceFolder.changeFile('playwright.config.js', `module.exports = { globalSetup: './global-setup.js' }`);

--- a/packages/vscode/tests/playwright/settings.spec.ts
+++ b/packages/vscode/tests/playwright/settings.spec.ts
@@ -16,6 +16,8 @@
 
 import { enableProjects, expect, test } from './utils';
 
+// Skip in headed mode: activate() forces reuseBrowser=true, breaking tests
+// that assert on default setting values.
 test.beforeEach(async ({ showBrowser }) => {
   test.skip(showBrowser);
 });
@@ -38,7 +40,7 @@ test('should toggle setting from webview', async ({ activate }) => {
     'playwright.config.js': `module.exports = {}`,
   });
 
-  const webView = vscode.webViews.get('playwright-repl.settingsView')!;
+  const webView = await vscode.webView('playwright-repl.settingsView');
   const configuration = vscode.workspace.getConfiguration('playwright-repl');
 
   expect(configuration.get('reuseBrowser')).toBe(false);
@@ -61,7 +63,7 @@ test('should select-all/unselect-all', async ({ activate }) => {
 
   await enableProjects(vscode, ['foo']);
 
-  const webView = vscode.webViews.get('playwright-repl.settingsView')!;
+  const webView = await vscode.webView('playwright-repl.settingsView');
 
   await expect(webView.locator('body')).toMatchAriaSnapshot(`
     - heading "PROJECTS":
@@ -106,7 +108,7 @@ test('should reflect changes to setting', async ({ activate }) => {
   await vscode.commands.executeCommand('playwright-repl.toggle.reuseBrowser');
   expect(configuration.get('reuseBrowser')).toBe(true);
 
-  const webView = vscode.webViews.get('playwright-repl.settingsView')!;
+  const webView = await vscode.webView('playwright-repl.settingsView');
   await expect(webView.getByLabel('Show browser')).toBeChecked();
 });
 
@@ -115,7 +117,7 @@ test('should open test results', async ({ activate }) => {
     'playwright.config.js': `module.exports = {}`,
   });
 
-  const webView = vscode.webViews.get('playwright-repl.settingsView')!;
+  const webView = await vscode.webView('playwright-repl.settingsView');
   await webView.getByText('Reveal test output').click();
   expect(vscode.commandLog.filter(f => f !== 'testing.getExplorerSelection')).toEqual(['testing.showMostRecentOutput']);
 });
@@ -198,7 +200,7 @@ test('should sync project enabled state to workspace settings', async ({ activat
 
   await enableProjects(vscode, ['foo']);
 
-  const webView = vscode.webViews.get('playwright-repl.settingsView')!;
+  const webView = await vscode.webView('playwright-repl.settingsView');
 
   await expect(webView.getByTestId('projects')).toMatchAriaSnapshot(`
     - checkbox "foo" [checked]
@@ -271,7 +273,7 @@ test('should read project enabled state from workspace settings', async ({ vscod
     `,
   });
 
-  const webView = vscode.webViews.get('playwright-repl.settingsView')!;
+  const webView = await vscode.webView('playwright-repl.settingsView');
   await expect(webView.getByTestId('projects')).toMatchAriaSnapshot(`
     - checkbox "foo" [checked]
     - checkbox "bar" [checked=false]

--- a/packages/vscode/tests/playwright/track-configs.spec.ts
+++ b/packages/vscode/tests/playwright/track-configs.spec.ts
@@ -138,7 +138,7 @@ test('should order configs intuitively', async ({ activate }) => {
     'playwright.config.ts': `module.exports = {};`,
   });
 
-  const webView = vscode.webViews.get('playwright-repl.settingsView')!;
+  const webView = await vscode.webView('playwright-repl.settingsView');
   await expect(webView.locator('body')).toMatchAriaSnapshot(`
     - combobox "Select Playwright Config":
       - option "playwright.config.ts"
@@ -194,7 +194,7 @@ test('git checkout should not lead to duplicate configs', { annotation: { type: 
   ]);
 
   await expect.poll(async () => {
-    const webView = vscode.webViews.get('playwright-repl.settingsView')!;
+    const webView = await vscode.webView('playwright-repl.settingsView');
     const [testItems] = await Promise.all([
       new Promise<TestItem[]>(resolve => { vscode.window.mockQuickPick = resolve; }),
       webView.getByTitle('Toggle Playwright Configs').click(),

--- a/packages/vscode/tests/playwright/update-snapshots.spec.ts
+++ b/packages/vscode/tests/playwright/update-snapshots.spec.ts
@@ -33,7 +33,7 @@ for (const mode of ['3-way', 'overwrite', 'patch'] as const) {
       `,
     });
 
-    const webView = vscode.webViews.get('playwright-repl.settingsView')!;
+    const webView = await vscode.webView('playwright-repl.settingsView');
     await webView.getByRole('combobox', { name: 'Update method' }).selectOption(mode);
     await webView.getByRole('combobox', { name: 'Update snapshots' }).selectOption('missing');
 
@@ -84,7 +84,7 @@ for (const mode of ['3-way' , 'overwrite', 'patch'] as const) {
       `,
     });
 
-    const webView = vscode.webViews.get('playwright-repl.settingsView')!;
+    const webView = await vscode.webView('playwright-repl.settingsView');
     await webView.getByRole('combobox', { name: 'Update method' }).selectOption(mode);
     await webView.getByRole('combobox', { name: 'Update snapshots' }).selectOption('all');
 

--- a/packages/vscode/tests/playwright/utils.ts
+++ b/packages/vscode/tests/playwright/utils.ts
@@ -17,7 +17,7 @@
 import { expect as baseExpect, test as baseTest, Browser, BrowserContextOptions, chromium, Page } from '@playwright/test';
 // @ts-ignore
 import { Extension } from '../../dist/extension';
-import { TestController, VSCode, WorkspaceFolder, TestRun, TestItem } from './mock/vscode';
+import { TestController, VSCode, WebviewPagePool, WorkspaceFolder, TestRun, TestItem } from './mock/vscode';
 
 import crypto from 'crypto';
 import fs from 'fs';
@@ -43,6 +43,10 @@ type TestFixtures = {
   vscode: VSCode,
   activate: (files: { [key: string]: string }, options?: { rootDir?: string, workspaceFolders?: [string, any][], env?: Record<string, any>, runGlobalSetupOnEachRun?: boolean }) => Promise<ActivateResult>;
   createLatch: () => Latch;
+};
+
+type WorkerFixtures = {
+  webviewPool: WebviewPagePool;
 };
 
 export type WorkerOptions = {
@@ -117,13 +121,19 @@ function l10Bundles() {
   return _l10Bundles;
 }
 
-export const test = baseTest.extend<TestFixtures, WorkerOptions>({
+export const test = baseTest.extend<TestFixtures, WorkerOptions & WorkerFixtures>({
   showBrowser: [false, { option: true, scope: 'worker' }],
   showTrace: [undefined, { option: true, scope: 'worker' }],
   vsCodeVersion: [1.86, { option: true, scope: 'worker' }],
 
-  vscode: async ({ browser, vsCodeVersion }, use) => {
-    const vscode = new VSCode(vsCodeVersion, path.resolve(__dirname, '../..'), browser);
+  webviewPool: [async ({ browser }, use) => {
+    const pool = new WebviewPagePool(browser, path.resolve(__dirname, '../..'));
+    await use(pool);
+    await pool.close();
+  }, { scope: 'worker' }],
+
+  vscode: async ({ browser, webviewPool, vsCodeVersion }, use) => {
+    const vscode = new VSCode(vsCodeVersion, path.resolve(__dirname, '../..'), browser, webviewPool);
     await use(vscode);
 
     if (process.env.VALIDATE_L10N) {
@@ -210,7 +220,7 @@ export async function waitForPage(browser: Browser, params?: BrowserContextOptio
 
 export async function enableConfigs(vscode: VSCode, labels: string[]) {
   let success = false;
-  const webView = vscode.webViews.get('playwright-repl.settingsView')!;
+  const webView = await vscode.webView('playwright-repl.settingsView');
   while (!success) {
     vscode.window.mockQuickPick = async (items: TestItem[]) => {
       let allFound = true;
@@ -231,12 +241,12 @@ export async function enableConfigs(vscode: VSCode, labels: string[]) {
 }
 
 export async function selectConfig(vscode: VSCode, label: string) {
-  const webView = vscode.webViews.get('playwright-repl.settingsView')!;
+  const webView = await vscode.webView('playwright-repl.settingsView');
   await webView.getByTestId('models').selectOption({ label });
 }
 
 export async function enableProjects(vscode: VSCode, projects: string[]) {
-  const webView = vscode.webViews.get('playwright-repl.settingsView')!;
+  const webView = await vscode.webView('playwright-repl.settingsView');
   for (const project of projects)
     await expect(webView.getByTestId('projects').getByLabel(project)).toBeVisible();
   for (const checkbox of await webView.getByTestId('projects').locator('label').all()) {

--- a/packages/vscode/tests/playwright/watch.spec.ts
+++ b/packages/vscode/tests/playwright/watch.spec.ts
@@ -504,7 +504,7 @@ test('should only watch a test from the enabled project when multiple projects s
 
   await selectConfig(vscode, `playwright-2.config.js`);
 
-  const webView = vscode.webViews.get('playwright-repl.settingsView')!;
+  const webView = await vscode.webView('playwright-repl.settingsView');
   // Wait for the projects to be loaded.
   await expect(webView.getByTestId('projects').locator('div').locator('label')).toHaveCount(2);
   // Disable the project from config 2.


### PR DESCRIPTION
## Summary
- Add worker-scoped `WebviewPagePool` that creates one `BrowserContext` and lazily-created pages shared across tests, avoiding expensive per-test context+page creation
- Pages are reset between tests by swapping handler closures and re-navigating — `exposeFunction` is called once per page lifetime
- Add lazy `VSCode.webView(name)` method replacing eager `webViews.get()` — tests that don't use webviews pay zero cost
- Remove unnecessary `test.skip(showBrowser)` from assert-view and repl-view (verified they pass in headed mode)

**Before:** 4 contexts + 4 pages created per test (even tests not using webviews)
**After:** 1 context + up to 4 pages per worker total

## Test plan
- [x] Full suite passes: 152 passed, 24 skipped, 0 failed
- [x] Webview-using tests verified (assert-view, repl-view, settings, track-configs)
- [x] assert-view and repl-view verified in `default-reuse` (headed) mode after skip removal
- [ ] Compare CI timing against baseline

Closes #672

🤖 Generated with [Claude Code](https://claude.com/claude-code)