### PR TITLE
ci: collect coverage from VS Code mock tests (#673)

### DIFF
--- a/packages/vscode/build-test.mjs
+++ b/packages/vscode/build-test.mjs
@@ -9,7 +9,7 @@
 import * as esbuild from 'esbuild';
 
 /** @type {esbuild.BuildOptions} */
-const options = {
+const extensionOptions = {
   entryPoints: ['src/extension.ts'],
   bundle: true,
   outdir: 'dist',
@@ -40,5 +40,27 @@ const options = {
   },
 };
 
-await esbuild.build(options);
+// Webview scripts — bundled for browser with sourcemaps for coverage
+/** @type {esbuild.BuildOptions} */
+const webviewOptions = {
+  entryPoints: [
+    'src/settingsView.script.ts',
+    'src/locatorsView.script.ts',
+    'src/replView.script.ts',
+    'src/assertView.script.ts',
+  ],
+  bundle: true,
+  outdir: 'dist',
+  external: ['vscode'],
+  format: 'cjs',
+  platform: 'browser',
+  target: 'ES2019',
+  sourcemap: true,
+  minify: false,
+};
+
+await Promise.all([
+  esbuild.build(extensionOptions),
+  esbuild.build(webviewOptions),
+]);
 console.log('Test build complete.');

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -247,7 +247,10 @@
     "build": "node build.mjs",
     "build:test": "node build-test.mjs",
     "test": "vitest run",
+    "test:coverage": "vitest run --coverage",
     "test:playwright": "node build-test.mjs && playwright test --config tests/playwright/playwright.config.ts --project default",
+    "coverage:merge": "nextcov merge coverage/unit coverage/e2e -o coverage/merged",
+    "coverage:all": "npm run test:coverage && npm run test:playwright && npm run coverage:merge",
     "watch": "node build.mjs --watch",
     "package": "node publish.mjs",
     "publish:vsce": "node publish.mjs publish"
@@ -277,6 +280,7 @@
     "@vscode/vsce": "^3.7.1",
     "adm-zip": "^0.5.17",
     "esbuild": "^0.25.0",
+    "nextcov": "^1.2.1",
     "glob": "^8.1.0",
     "minimatch": "^10.2.4",
     "stack-utils": "^2.0.6",

--- a/packages/vscode/tests/playwright/global-setup.ts
+++ b/packages/vscode/tests/playwright/global-setup.ts
@@ -1,0 +1,13 @@
+/**
+ * Global Setup for Playwright Mock Tests
+ *
+ * Initializes client-side coverage collection before tests run.
+ */
+
+import * as path from 'path';
+import { initCoverage, loadNextcovConfig } from 'nextcov/playwright';
+
+export default async function globalSetup() {
+  const config = await loadNextcovConfig(path.join(__dirname, 'playwright.config.ts'));
+  await initCoverage(config);
+}

--- a/packages/vscode/tests/playwright/global-teardown.ts
+++ b/packages/vscode/tests/playwright/global-teardown.ts
@@ -1,0 +1,13 @@
+/**
+ * Global Teardown for Playwright Mock Tests
+ *
+ * Collects and processes client-side coverage from webview pages.
+ */
+
+import * as path from 'path';
+import { finalizeCoverage, loadNextcovConfig } from 'nextcov/playwright';
+
+export default async function globalTeardown() {
+  const config = await loadNextcovConfig(path.join(__dirname, 'playwright.config.ts'));
+  await finalizeCoverage(config);
+}

--- a/packages/vscode/tests/playwright/mock/vscode.ts
+++ b/packages/vscode/tests/playwright/mock/vscode.ts
@@ -63,6 +63,7 @@ export class WebviewPagePool {
       // Reuse — swap handlers and re-navigate to pick up new html.
       existing.setMessageHandler(data => messageHandler.current(data));
       existing.setVisibilityHandler(state => visibilityHandler.current(state));
+      await existing.page.coverage.startJSCoverage({ resetOnNavigation: false });
       await existing.page.goto('http://localhost');
       return existing.page;
     }
@@ -103,6 +104,7 @@ export class WebviewPagePool {
     await page.addInitScript(() => {
       (globalThis as any).acquireVsCodeApi = () => globalThis;
     });
+    await page.coverage.startJSCoverage({ resetOnNavigation: false });
     await page.goto('http://localhost');
     await page.exposeFunction('postMessage', (data: any) => msgHandler(data));
 
@@ -113,6 +115,11 @@ export class WebviewPagePool {
     });
 
     return page;
+  }
+
+  /** Return all live pages (for coverage collection). */
+  getPages(): Page[] {
+    return [...this._slots.values()].map(s => s.page);
   }
 
   async close() {

--- a/packages/vscode/tests/playwright/playwright.config.ts
+++ b/packages/vscode/tests/playwright/playwright.config.ts
@@ -14,9 +14,22 @@
  * limitations under the License.
  */
 import { defineConfig } from '@playwright/test';
+import type { NextcovConfig } from 'nextcov';
 import { WorkerOptions } from './utils';
 
+// Nextcov configuration — client-side coverage from webview pages
+export const nextcov: NextcovConfig = {
+  outputDir: 'coverage/e2e',
+  sourceRoot: './src',
+  collectServer: false,
+  include: ['src/**/*.ts'],
+  exclude: ['src/upstream/**'],
+  reporters: ['html', 'lcov', 'json', 'text-summary'],
+};
+
 export default defineConfig<WorkerOptions>({
+  globalSetup: './global-setup.ts',
+  globalTeardown: './global-teardown.ts',
   testDir: '.',
   outputDir: './test-results/inner',
   fullyParallel: true,

--- a/packages/vscode/tests/playwright/utils.ts
+++ b/packages/vscode/tests/playwright/utils.ts
@@ -15,6 +15,7 @@
  */
 
 import { expect as baseExpect, test as baseTest, Browser, BrowserContextOptions, chromium, Page } from '@playwright/test';
+import { filterAppCoverage, saveClientCoverage } from 'nextcov/playwright';
 // @ts-ignore
 import { Extension } from '../../dist/extension';
 import { TestController, VSCode, WebviewPagePool, WorkspaceFolder, TestRun, TestItem } from './mock/vscode';
@@ -22,6 +23,16 @@ import { TestController, VSCode, WebviewPagePool, WorkspaceFolder, TestRun, Test
 import crypto from 'crypto';
 import fs from 'fs';
 import path from 'path';
+import { pathToFileURL } from 'url';
+
+const EXTENSION_DIR = path.resolve(__dirname, '../..');
+
+/** Map http://localhost/dist/foo.js → file:///…/packages/vscode/dist/foo.js */
+function transformUrl(url: string): string {
+  if (!url.startsWith('http://localhost/')) return url;
+  const suffix = url.substring('http://localhost/'.length);
+  return pathToFileURL(path.join(EXTENSION_DIR, suffix)).href;
+}
 
 process.env.PW_DEBUG_CONTROLLER_HEADLESS = '1';
 // the x-pw-highlight element has otherwise a closed shadow root.
@@ -40,6 +51,7 @@ type Latch = {
 };
 
 type TestFixtures = {
+  _collectCoverage: void;
   vscode: VSCode,
   activate: (files: { [key: string]: string }, options?: { rootDir?: string, workspaceFolders?: [string, any][], env?: Record<string, any>, runGlobalSetupOnEachRun?: boolean }) => Promise<ActivateResult>;
   createLatch: () => Latch;
@@ -131,6 +143,27 @@ export const test = baseTest.extend<TestFixtures, WorkerOptions & WorkerFixtures
     await use(pool);
     await pool.close();
   }, { scope: 'worker' }],
+
+  // Auto-fixture: collect client-side JS coverage from webview pages after each test.
+  _collectCoverage: [async ({ webviewPool }, use, testInfo) => {
+    await use();
+
+    // Stop coverage on all pool pages and save via nextcov
+    const pages = webviewPool.getPages();
+    for (const page of pages) {
+      try {
+        const jsCoverage = await page.coverage.stopJSCoverage();
+        const entries = jsCoverage.map(e => ({ ...e, url: transformUrl(e.url) }));
+        const appCoverage = filterAppCoverage(entries);
+        if (appCoverage.length > 0) {
+          const testId = `${testInfo.workerIndex}-${testInfo.testId.replace(/[^a-zA-Z0-9]/g, '-')}`;
+          await saveClientCoverage(testId, appCoverage);
+        }
+      } catch {
+        // Page may not have coverage started (e.g. test didn't create webviews)
+      }
+    }
+  }, { auto: true }],
 
   vscode: async ({ browser, webviewPool, vsCodeVersion }, use) => {
     const vscode = new VSCode(vsCodeVersion, path.resolve(__dirname, '../..'), browser, webviewPool);

--- a/packages/vscode/types.d.ts
+++ b/packages/vscode/types.d.ts
@@ -1,0 +1,29 @@
+// ─── nextcov (no published types) ────────────────────────────────────────────
+
+declare module "nextcov/playwright" {
+  import type { Page, TestInfo } from '@playwright/test';
+  export function collectClientCoverage(
+    page: Page,
+    testInfo: TestInfo,
+    use: () => Promise<void>,
+    config?: { transformUrl?: (url: string) => string; [key: string]: unknown },
+  ): Promise<void>;
+  export function saveClientCoverage(testId: string, coverage: unknown[]): Promise<void>;
+  export function filterAppCoverage(entries: unknown[]): unknown[];
+  export function initCoverage(config: unknown): Promise<void>;
+  export function finalizeCoverage(config: unknown): Promise<void>;
+  export function loadNextcovConfig(configPath?: string): Promise<unknown>;
+}
+
+declare module "nextcov" {
+  export interface NextcovConfig {
+    outputDir?: string;
+    sourceRoot?: string;
+    collectServer?: boolean;
+    collectClient?: boolean;
+    include?: string[];
+    exclude?: string[];
+    reporters?: string[];
+    [key: string]: unknown;
+  }
+}

--- a/packages/vscode/vitest.config.ts
+++ b/packages/vscode/vitest.config.ts
@@ -4,6 +4,14 @@ import path from 'path';
 export default defineConfig({
   test: {
     include: ['tests/unit/**/*.test.ts'],
+    coverage: {
+      enabled: true,
+      provider: 'v8',
+      reportsDirectory: './coverage/unit',
+      include: ['src/**/*.ts'],
+      exclude: ['src/upstream/**'],
+      reporter: ['text', 'json', 'lcov', 'html'],
+    },
   },
   resolve: {
     alias: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -304,6 +304,9 @@ importers:
       minimatch:
         specifier: ^10.2.4
         version: 10.2.4
+      nextcov:
+        specifier: ^1.2.1
+        version: 1.2.1(@playwright/test@1.59.1)(@types/node@18.19.130)(jiti@2.6.1)(lightningcss@1.31.1)
       stack-utils:
         specifier: ^2.0.6
         version: 2.0.6
@@ -4357,6 +4360,15 @@ snapshots:
 
   '@inquirer/ansi@2.0.3': {}
 
+  '@inquirer/checkbox@5.1.0(@types/node@18.19.130)':
+    dependencies:
+      '@inquirer/ansi': 2.0.3
+      '@inquirer/core': 11.1.5(@types/node@18.19.130)
+      '@inquirer/figures': 2.0.3
+      '@inquirer/type': 4.0.3(@types/node@18.19.130)
+    optionalDependencies:
+      '@types/node': 18.19.130
+
   '@inquirer/checkbox@5.1.0(@types/node@25.3.3)':
     dependencies:
       '@inquirer/ansi': 2.0.3
@@ -4366,12 +4378,31 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.3.3
 
+  '@inquirer/confirm@6.0.8(@types/node@18.19.130)':
+    dependencies:
+      '@inquirer/core': 11.1.5(@types/node@18.19.130)
+      '@inquirer/type': 4.0.3(@types/node@18.19.130)
+    optionalDependencies:
+      '@types/node': 18.19.130
+
   '@inquirer/confirm@6.0.8(@types/node@25.3.3)':
     dependencies:
       '@inquirer/core': 11.1.5(@types/node@25.3.3)
       '@inquirer/type': 4.0.3(@types/node@25.3.3)
     optionalDependencies:
       '@types/node': 25.3.3
+
+  '@inquirer/core@11.1.5(@types/node@18.19.130)':
+    dependencies:
+      '@inquirer/ansi': 2.0.3
+      '@inquirer/figures': 2.0.3
+      '@inquirer/type': 4.0.3(@types/node@18.19.130)
+      cli-width: 4.1.0
+      fast-wrap-ansi: 0.2.0
+      mute-stream: 3.0.0
+      signal-exit: 4.1.0
+    optionalDependencies:
+      '@types/node': 18.19.130
 
   '@inquirer/core@11.1.5(@types/node@25.3.3)':
     dependencies:
@@ -4385,6 +4416,14 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.3.3
 
+  '@inquirer/editor@5.0.8(@types/node@18.19.130)':
+    dependencies:
+      '@inquirer/core': 11.1.5(@types/node@18.19.130)
+      '@inquirer/external-editor': 2.0.3(@types/node@18.19.130)
+      '@inquirer/type': 4.0.3(@types/node@18.19.130)
+    optionalDependencies:
+      '@types/node': 18.19.130
+
   '@inquirer/editor@5.0.8(@types/node@25.3.3)':
     dependencies:
       '@inquirer/core': 11.1.5(@types/node@25.3.3)
@@ -4393,12 +4432,26 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.3.3
 
+  '@inquirer/expand@5.0.8(@types/node@18.19.130)':
+    dependencies:
+      '@inquirer/core': 11.1.5(@types/node@18.19.130)
+      '@inquirer/type': 4.0.3(@types/node@18.19.130)
+    optionalDependencies:
+      '@types/node': 18.19.130
+
   '@inquirer/expand@5.0.8(@types/node@25.3.3)':
     dependencies:
       '@inquirer/core': 11.1.5(@types/node@25.3.3)
       '@inquirer/type': 4.0.3(@types/node@25.3.3)
     optionalDependencies:
       '@types/node': 25.3.3
+
+  '@inquirer/external-editor@2.0.3(@types/node@18.19.130)':
+    dependencies:
+      chardet: 2.1.1
+      iconv-lite: 0.7.2
+    optionalDependencies:
+      '@types/node': 18.19.130
 
   '@inquirer/external-editor@2.0.3(@types/node@25.3.3)':
     dependencies:
@@ -4409,12 +4462,26 @@ snapshots:
 
   '@inquirer/figures@2.0.3': {}
 
+  '@inquirer/input@5.0.8(@types/node@18.19.130)':
+    dependencies:
+      '@inquirer/core': 11.1.5(@types/node@18.19.130)
+      '@inquirer/type': 4.0.3(@types/node@18.19.130)
+    optionalDependencies:
+      '@types/node': 18.19.130
+
   '@inquirer/input@5.0.8(@types/node@25.3.3)':
     dependencies:
       '@inquirer/core': 11.1.5(@types/node@25.3.3)
       '@inquirer/type': 4.0.3(@types/node@25.3.3)
     optionalDependencies:
       '@types/node': 25.3.3
+
+  '@inquirer/number@4.0.8(@types/node@18.19.130)':
+    dependencies:
+      '@inquirer/core': 11.1.5(@types/node@18.19.130)
+      '@inquirer/type': 4.0.3(@types/node@18.19.130)
+    optionalDependencies:
+      '@types/node': 18.19.130
 
   '@inquirer/number@4.0.8(@types/node@25.3.3)':
     dependencies:
@@ -4423,6 +4490,14 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.3.3
 
+  '@inquirer/password@5.0.8(@types/node@18.19.130)':
+    dependencies:
+      '@inquirer/ansi': 2.0.3
+      '@inquirer/core': 11.1.5(@types/node@18.19.130)
+      '@inquirer/type': 4.0.3(@types/node@18.19.130)
+    optionalDependencies:
+      '@types/node': 18.19.130
+
   '@inquirer/password@5.0.8(@types/node@25.3.3)':
     dependencies:
       '@inquirer/ansi': 2.0.3
@@ -4430,6 +4505,21 @@ snapshots:
       '@inquirer/type': 4.0.3(@types/node@25.3.3)
     optionalDependencies:
       '@types/node': 25.3.3
+
+  '@inquirer/prompts@8.3.0(@types/node@18.19.130)':
+    dependencies:
+      '@inquirer/checkbox': 5.1.0(@types/node@18.19.130)
+      '@inquirer/confirm': 6.0.8(@types/node@18.19.130)
+      '@inquirer/editor': 5.0.8(@types/node@18.19.130)
+      '@inquirer/expand': 5.0.8(@types/node@18.19.130)
+      '@inquirer/input': 5.0.8(@types/node@18.19.130)
+      '@inquirer/number': 4.0.8(@types/node@18.19.130)
+      '@inquirer/password': 5.0.8(@types/node@18.19.130)
+      '@inquirer/rawlist': 5.2.4(@types/node@18.19.130)
+      '@inquirer/search': 4.1.4(@types/node@18.19.130)
+      '@inquirer/select': 5.1.0(@types/node@18.19.130)
+    optionalDependencies:
+      '@types/node': 18.19.130
 
   '@inquirer/prompts@8.3.0(@types/node@25.3.3)':
     dependencies:
@@ -4446,12 +4536,27 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.3.3
 
+  '@inquirer/rawlist@5.2.4(@types/node@18.19.130)':
+    dependencies:
+      '@inquirer/core': 11.1.5(@types/node@18.19.130)
+      '@inquirer/type': 4.0.3(@types/node@18.19.130)
+    optionalDependencies:
+      '@types/node': 18.19.130
+
   '@inquirer/rawlist@5.2.4(@types/node@25.3.3)':
     dependencies:
       '@inquirer/core': 11.1.5(@types/node@25.3.3)
       '@inquirer/type': 4.0.3(@types/node@25.3.3)
     optionalDependencies:
       '@types/node': 25.3.3
+
+  '@inquirer/search@4.1.4(@types/node@18.19.130)':
+    dependencies:
+      '@inquirer/core': 11.1.5(@types/node@18.19.130)
+      '@inquirer/figures': 2.0.3
+      '@inquirer/type': 4.0.3(@types/node@18.19.130)
+    optionalDependencies:
+      '@types/node': 18.19.130
 
   '@inquirer/search@4.1.4(@types/node@25.3.3)':
     dependencies:
@@ -4461,6 +4566,15 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.3.3
 
+  '@inquirer/select@5.1.0(@types/node@18.19.130)':
+    dependencies:
+      '@inquirer/ansi': 2.0.3
+      '@inquirer/core': 11.1.5(@types/node@18.19.130)
+      '@inquirer/figures': 2.0.3
+      '@inquirer/type': 4.0.3(@types/node@18.19.130)
+    optionalDependencies:
+      '@types/node': 18.19.130
+
   '@inquirer/select@5.1.0(@types/node@25.3.3)':
     dependencies:
       '@inquirer/ansi': 2.0.3
@@ -4469,6 +4583,10 @@ snapshots:
       '@inquirer/type': 4.0.3(@types/node@25.3.3)
     optionalDependencies:
       '@types/node': 25.3.3
+
+  '@inquirer/type@4.0.3(@types/node@18.19.130)':
+    optionalDependencies:
+      '@types/node': 18.19.130
 
   '@inquirer/type@4.0.3(@types/node@25.3.3)':
     optionalDependencies:
@@ -6472,6 +6590,38 @@ snapshots:
 
   negotiator@1.0.0: {}
 
+  nextcov@1.2.1(@playwright/test@1.59.1)(@types/node@18.19.130)(jiti@2.6.1)(lightningcss@1.31.1):
+    dependencies:
+      '@babel/parser': 7.29.0
+      '@babel/traverse': 7.29.0
+      '@bcoe/v8-coverage': 1.0.2
+      '@inquirer/prompts': 8.3.0(@types/node@18.19.130)
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@playwright/test': 1.59.1
+      ast-v8-to-istanbul: 0.3.12
+      chalk: 4.1.2
+      convert-source-map: 2.0.0
+      glob: 11.1.0
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-lib-source-maps: 5.0.6
+      istanbul-reports: 3.2.0
+      monocart-coverage-reports: 2.12.9
+      vite: 6.4.1(@types/node@18.19.130)(jiti@2.6.1)(lightningcss@1.31.1)
+    transitivePeerDependencies:
+      - '@types/node'
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
   nextcov@1.2.1(@playwright/test@1.59.1)(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1):
     dependencies:
       '@babel/parser': 7.29.0
@@ -7187,6 +7337,20 @@ snapshots:
   vary@1.1.2: {}
 
   version-range@4.15.0: {}
+
+  vite@6.4.1(@types/node@18.19.130)(jiti@2.6.1)(lightningcss@1.31.1):
+    dependencies:
+      esbuild: 0.25.12
+      fdir: 6.5.0(picomatch@4.0.3)
+      picomatch: 4.0.3
+      postcss: 8.5.8
+      rollup: 4.59.0
+      tinyglobby: 0.2.15
+    optionalDependencies:
+      '@types/node': 18.19.130
+      fsevents: 2.3.3
+      jiti: 2.6.1
+      lightningcss: 1.31.1
 
   vite@6.4.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1):
     dependencies:


### PR DESCRIPTION
Add coverage collection for vscode package:
- Vitest unit tests: V8 coverage → coverage/unit/
- Playwright mock tests: nextcov client-side coverage from webview pages → coverage/e2e/
- Merge: nextcov merge → coverage/merged/

Changes:
- vitest.config.ts: add V8 coverage provider
- build-test.mjs: build webview scripts with sourcemaps for coverage
- playwright.config.ts: add nextcov config, globalSetup/globalTeardown
- mock/vscode.ts: startJSCoverage in WebviewPagePool, add getPages()
- utils.ts: add _collectCoverage auto-fixture with URL transform
- package.json: add nextcov dep, coverage scripts
- types.d.ts: nextcov type declarations