### PR TITLE
feat: add autocomplete dropdown to VS Code REPL (#690)

### DIFF
--- a/packages/vscode/src/replView.script.ts
+++ b/packages/vscode/src/replView.script.ts
@@ -1,21 +1,117 @@
 /**
- * REPL webview script — handles input, output rendering, and command history.
+ * REPL webview script — handles input, output rendering, command history,
+ * and autocomplete dropdown for .pw commands.
  */
 
 import { vscode } from './common';
 
 const output = document.getElementById('output')!;
 const input = document.getElementById('command-input') as HTMLTextAreaElement;
+const dropdown = document.getElementById('autocomplete-dropdown')!;
 
 let commandHistory: string[] = [];
 let commandHistoryIndex = -1;
 let savedInput = '';
 
+// ─── Autocomplete state ──────────────────────────────────────────────────
+
+interface CompletionItem { cmd: string; desc: string; }
+
+let completionItems: CompletionItem[] = [];
+let filteredItems: CompletionItem[] = [];
+let selectedIndex = 0;
+let dropdownVisible = false;
+
+function showDropdown(items: CompletionItem[]) {
+  filteredItems = items;
+  selectedIndex = 0;
+  dropdown.innerHTML = '';
+  for (let i = 0; i < items.length; i++) {
+    const el = document.createElement('div');
+    el.className = 'ac-item' + (i === 0 ? ' ac-selected' : '');
+    el.innerHTML = `<span class="ac-cmd">${escapeHtml(items[i].cmd)}</span><span class="ac-desc">${escapeHtml(items[i].desc)}</span>`;
+    el.addEventListener('mousedown', (e) => {
+      e.preventDefault(); // prevent blur
+      acceptCompletion(i);
+    });
+    dropdown.appendChild(el);
+  }
+  dropdown.classList.add('visible');
+  dropdownVisible = true;
+}
+
+function hideDropdown() {
+  dropdown.classList.remove('visible');
+  dropdown.innerHTML = '';
+  dropdownVisible = false;
+  filteredItems = [];
+}
+
+function updateSelection(newIndex: number) {
+  const items = dropdown.querySelectorAll('.ac-item');
+  if (items[selectedIndex]) items[selectedIndex].classList.remove('ac-selected');
+  selectedIndex = Math.max(0, Math.min(newIndex, filteredItems.length - 1));
+  if (items[selectedIndex]) {
+    items[selectedIndex].classList.add('ac-selected');
+    items[selectedIndex].scrollIntoView({ block: 'nearest' });
+  }
+}
+
+function acceptCompletion(index?: number) {
+  const idx = index ?? selectedIndex;
+  if (idx < 0 || idx >= filteredItems.length) return;
+  const item = filteredItems[idx];
+  // Replace the current word with the completed command
+  const prefix = getCurrentWord();
+  const before = input.value.slice(0, input.selectionStart - prefix.length);
+  const after = input.value.slice(input.selectionStart);
+  input.value = before + item.cmd + (after || ' ');
+  input.selectionStart = input.selectionEnd = before.length + item.cmd.length + (after ? 0 : 1);
+  hideDropdown();
+  input.focus();
+}
+
+function getCurrentWord(): string {
+  const text = input.value.slice(0, input.selectionStart);
+  // Find word start (from cursor back to start or last space/newline)
+  const match = text.match(/[\w.\-]+$/);
+  return match ? match[0] : '';
+}
+
+function updateAutocomplete() {
+  const word = getCurrentWord();
+  if (word.length === 0 || input.value.includes('\n')) {
+    hideDropdown();
+    return;
+  }
+  const lower = word.toLowerCase();
+  const matches = completionItems.filter(item => item.cmd.toLowerCase().startsWith(lower) && item.cmd !== word);
+  if (matches.length === 0) {
+    hideDropdown();
+    return;
+  }
+  // Limit to 12 items to keep dropdown manageable
+  showDropdown(matches.slice(0, 12));
+}
+
+function escapeHtml(s: string): string {
+  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+
 // ─── Input handling ───────────────────────────────────────────────────────
 
 input.addEventListener('keydown', (e: KeyboardEvent) => {
+  // Autocomplete takes priority when visible
+  if (dropdownVisible) {
+    if (e.key === 'ArrowDown') { e.preventDefault(); updateSelection(selectedIndex + 1); return; }
+    if (e.key === 'ArrowUp') { e.preventDefault(); updateSelection(selectedIndex - 1); return; }
+    if (e.key === 'Tab' || (e.key === 'Enter' && !e.shiftKey)) { e.preventDefault(); acceptCompletion(); return; }
+    if (e.key === 'Escape') { e.preventDefault(); hideDropdown(); return; }
+  }
+
   if (e.key === 'Enter' && !e.shiftKey) {
     e.preventDefault();
+    hideDropdown();
     const command = input.value.trim();
     if (!command) return;
     appendLine(command, 'command');
@@ -43,6 +139,15 @@ input.addEventListener('keydown', (e: KeyboardEvent) => {
       input.value = savedInput;
     }
   }
+});
+
+input.addEventListener('input', () => {
+  updateAutocomplete();
+});
+
+input.addEventListener('blur', () => {
+  // Delay to allow mousedown on dropdown items
+  setTimeout(hideDropdown, 150);
 });
 
 function resetHeight() {
@@ -82,6 +187,8 @@ window.addEventListener('message', event => {
     if (!params.processing) input.focus();
   } else if (method === 'history') {
     commandHistory = params.history;
+  } else if (method === 'completionItems') {
+    completionItems = params.items;
   }
 });
 

--- a/packages/vscode/src/replView.script.ts
+++ b/packages/vscode/src/replView.script.ts
@@ -29,7 +29,11 @@ function showDropdown(items: CompletionItem[]) {
   for (let i = 0; i < items.length; i++) {
     const el = document.createElement('div');
     el.className = 'ac-item' + (i === 0 ? ' ac-selected' : '');
-    el.innerHTML = `<span class="ac-cmd">${escapeHtml(items[i].cmd)}</span><span class="ac-desc">${escapeHtml(items[i].desc)}</span>`;
+    const prefix = input.value.slice(0, input.selectionStart);
+    const matchLen = prefix.length;
+    const cmd = items[i].cmd;
+    const highlighted = `<b>${escapeHtml(cmd.slice(0, matchLen))}</b>${escapeHtml(cmd.slice(matchLen))}`;
+    el.innerHTML = `<span class="ac-cmd">${highlighted}</span><span class="ac-desc">${escapeHtml(items[i].desc)}</span>`;
     el.addEventListener('mousedown', (e) => {
       e.preventDefault(); // prevent blur
       acceptCompletion(i);

--- a/packages/vscode/src/replView.script.ts
+++ b/packages/vscode/src/replView.script.ts
@@ -61,31 +61,25 @@ function acceptCompletion(index?: number) {
   const idx = index ?? selectedIndex;
   if (idx < 0 || idx >= filteredItems.length) return;
   const item = filteredItems[idx];
-  // Replace the current word with the completed command
-  const prefix = getCurrentWord();
-  const before = input.value.slice(0, input.selectionStart - prefix.length);
-  const after = input.value.slice(input.selectionStart);
-  input.value = before + item.cmd + (after || ' ');
-  input.selectionStart = input.selectionEnd = before.length + item.cmd.length + (after ? 0 : 1);
+  // Replace entire input with the completed command + trailing space
+  input.value = item.cmd + ' ';
+  input.selectionStart = input.selectionEnd = input.value.length;
   hideDropdown();
   input.focus();
 }
 
-function getCurrentWord(): string {
-  const text = input.value.slice(0, input.selectionStart);
-  // Find word start (from cursor back to start or last space/newline)
-  const match = text.match(/[\w.\-]+$/);
-  return match ? match[0] : '';
-}
-
 function updateAutocomplete() {
-  const word = getCurrentWord();
-  if (word.length === 0 || input.value.includes('\n')) {
+  const text = input.value.slice(0, input.selectionStart);
+  if (text.length === 0 || input.value.includes('\n')) {
     hideDropdown();
     return;
   }
-  const lower = word.toLowerCase();
-  const matches = completionItems.filter(item => item.cmd.toLowerCase().startsWith(lower) && item.cmd !== word);
+  // Match against full input — same logic as CLI ghost completion:
+  // when input contains a space, only match commands that also contain a space
+  const candidates = text.includes(' ')
+    ? completionItems.filter(item => item.cmd.includes(' '))
+    : completionItems;
+  const matches = candidates.filter(item => item.cmd.startsWith(text) && item.cmd !== text);
   if (matches.length === 0) {
     hideDropdown();
     return;

--- a/packages/vscode/src/replView.ts
+++ b/packages/vscode/src/replView.ts
@@ -5,7 +5,7 @@
 import { WebviewBase } from './webviewBase';
 import type { IBrowserManager } from './browser';
 import * as vscodeTypes from './vscodeTypes';
-import { COMMANDS, CATEGORIES, ALIASES } from '@playwright-repl/core';
+import { COMMANDS, CATEGORIES, ALIASES, buildCompletionItems } from '@playwright-repl/core';
 
 function core() {
   return { COMMANDS, CATEGORIES, ALIASES };
@@ -93,9 +93,48 @@ export class ReplView extends WebviewBase {
         #command-input:disabled {
           opacity: 0.5;
         }
+        #input-row {
+          position: relative;
+        }
+        #autocomplete-dropdown {
+          position: absolute;
+          bottom: 100%;
+          left: 0; right: 0;
+          max-height: 200px;
+          overflow-y: auto;
+          background: var(--vscode-editorSuggestWidget-background, var(--vscode-editorWidget-background));
+          border: 1px solid var(--vscode-editorSuggestWidget-border, var(--vscode-widget-border));
+          border-radius: 3px;
+          z-index: 100;
+          display: none;
+        }
+        #autocomplete-dropdown.visible { display: block; }
+        .ac-item {
+          padding: 2px 8px;
+          display: flex;
+          justify-content: space-between;
+          cursor: pointer;
+          font-family: inherit;
+          font-size: inherit;
+        }
+        .ac-item.ac-selected, .ac-item:hover {
+          background: var(--vscode-editorSuggestWidget-selectedBackground, var(--vscode-list-activeSelectionBackground));
+          color: var(--vscode-editorSuggestWidget-selectedForeground, var(--vscode-list-activeSelectionForeground));
+        }
+        .ac-cmd { flex: none; }
+        .ac-desc {
+          color: var(--vscode-descriptionForeground);
+          margin-left: 12px;
+          font-size: 0.9em;
+          opacity: 0.8;
+          overflow: hidden;
+          text-overflow: ellipsis;
+          white-space: nowrap;
+        }
       </style>
       <div id="output"></div>
       <div id="input-row">
+        <div id="autocomplete-dropdown"></div>
         <span id="prompt">pw&gt;</span>
         <textarea id="command-input" rows="1" placeholder="Type a command..." autofocus></textarea>
       </div>
@@ -116,6 +155,7 @@ export class ReplView extends WebviewBase {
     const connected = this._browserManager?.isRunning() ?? false;
     this._appendOutput('Playwright REPL\nType commands. Use ↑↓ for history.', 'info');
     this._appendOutput(connected ? 'Connected to browser.' : 'Waiting for browser... Launch with Ctrl+Shift+P → "Launch Browser"', connected ? 'info' : 'error');
+    this.postMessage('completionItems', { items: buildCompletionItems() });
   }
 
   private async _execute(command: string) {

--- a/packages/vscode/src/replView.ts
+++ b/packages/vscode/src/replView.ts
@@ -99,7 +99,9 @@ export class ReplView extends WebviewBase {
         #autocomplete-dropdown {
           position: absolute;
           bottom: 100%;
-          left: 0; right: 0;
+          left: 8px;
+          min-width: 200px;
+          max-width: 400px;
           max-height: 200px;
           overflow-y: auto;
           background: var(--vscode-editorSuggestWidget-background, var(--vscode-editorWidget-background));

--- a/packages/vscode/tests/playwright/repl-view.spec.ts
+++ b/packages/vscode/tests/playwright/repl-view.spec.ts
@@ -26,6 +26,7 @@ const replHtml = `<!DOCTYPE html>
 <body class="repl-view">
   <div id="output"></div>
   <div id="input-row">
+    <div id="autocomplete-dropdown"></div>
     <span id="prompt">pw&gt;</span>
     <textarea id="command-input" rows="1" placeholder="Type a command..."></textarea>
   </div>


### PR DESCRIPTION
## Summary
- Add command autocomplete dropdown to REPL webview input
- Filters `.pw` commands from `completion-data.ts` as user types
- Keyboard: ArrowUp/Down navigate, Tab/Enter accept, Escape dismiss
- Styled with `--vscode-editorSuggestWidget-*` CSS variables

## Test plan
- [x] All 171 existing tests pass
- [x] repl-view.spec.ts updated with dropdown div fixture
- [ ] Manual: type partial command, verify dropdown appears and accepts

Phase 1 of #690

🤖 Generated with [Claude Code](https://claude.com/claude-code)