### PR TITLE
fix: bridge mode single test marked as skipped (#692)

### DIFF
--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -826,6 +826,7 @@ export class Extension implements RunHooks {
       needsNode: (filePath: string) => boolean;
       compile: (filePath: string) => Promise<string>;
       parseAllResults: (text: string) => { status: string; duration: number; errors: { message: string }[] }[];
+      findResultByName: (lines: string[], testName: string) => { status: string; duration: number; errors: { message: string }[] };
     };
 
     // Collect test items — only use direct bridge for leaf test items (not folders)
@@ -924,24 +925,25 @@ export class Extension implements RunHooks {
       const result = await bridge.runScript(script, 'javascript');
       const outputText = result.text || '';
       testRun.appendOutput(outputText.replace(/\n/g, '\r\n'));
-      const results = bridgeUtils.parseAllResults(outputText);
-
-      // Map results back to test items
+      // Map results back to test items by name (not index — results include
+      // skipped tests from grep filtering, so indices don't match testItems)
+      const outputLines = outputText.split('\n');
       for (let i = 0; i < testItems.length; i++) {
         const testItem = testItems[i];
-        const testResult = results[i];
 
-        if (!testResult || result.isError) {
+        if (result.isError) {
           testRun.failed(testItem, [{ message: result.text || 'Bridge execution failed' }], 0);
           continue;
         }
+
+        const testResult = bridgeUtils.findResultByName(outputLines, fullNames[i]);
 
         if (testResult.status === 'passed')
           testRun.passed(testItem, testResult.duration);
         else if (testResult.status === 'skipped')
           testRun.skipped(testItem);
         else
-          testRun.failed(testItem, testResult.errors.map(e => ({ message: e.message })), testResult.duration);
+          testRun.failed(testItem, testResult.errors.map((e: { message: string }) => ({ message: e.message })), testResult.duration);
       }
     }
 

--- a/packages/vscode/tests/unit/bridge-results.test.ts
+++ b/packages/vscode/tests/unit/bridge-results.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest';
+
+// Import bridge-utils directly (CJS module)
+const bridgeUtils = require('@playwright-repl/runner/dist/bridge-utils.cjs') as {
+  parseAllResults: (text: string) => { status: string; duration: number; errors: { message: string }[] }[];
+  findResultByName: (lines: string[], testName: string) => { status: string; duration: number; errors: { message: string }[] };
+};
+
+describe('parseAllResults', () => {
+  it('should parse passed, failed, and skipped tests', () => {
+    const output = [
+      '  ✓ should add todo (12ms)',
+      '  ✗ should delete todo (5ms)',
+      '    Expected true, got false',
+      '  - should edit todo (skipped)',
+    ].join('\n');
+
+    const results = bridgeUtils.parseAllResults(output);
+    expect(results).toHaveLength(3);
+    expect(results[0]).toEqual({ status: 'passed', duration: 12, errors: [] });
+    expect(results[1]).toEqual({ status: 'failed', duration: 5, errors: [{ message: 'Expected true, got false' }] });
+    expect(results[2]).toEqual({ status: 'skipped', duration: 0, errors: [] });
+  });
+
+  it('should return empty array for no results', () => {
+    const results = bridgeUtils.parseAllResults('some random output\nno tests here');
+    expect(results).toEqual([]);
+  });
+});
+
+describe('findResultByName', () => {
+  const output = [
+    '  - should add todo (skipped)',
+    '  ✓ should delete todo (8ms)',
+    '  - should edit todo (skipped)',
+  ];
+
+  it('should find passed test by name', () => {
+    const result = bridgeUtils.findResultByName(output, 'should delete todo');
+    expect(result.status).toBe('passed');
+    expect(result.duration).toBe(8);
+  });
+
+  it('should find skipped test by name', () => {
+    const result = bridgeUtils.findResultByName(output, 'should add todo');
+    expect(result.status).toBe('skipped');
+  });
+
+  it('should return failed for unknown test name', () => {
+    const result = bridgeUtils.findResultByName(output, 'nonexistent test');
+    expect(result.status).toBe('failed');
+    expect(result.errors[0].message).toContain('not found');
+  });
+
+  it('should not confuse index with name — the bug scenario', () => {
+    // Bug: when clicking "should delete todo" (the 2nd test), index-based
+    // mapping returns results[0] which is "should add todo (skipped)".
+    // Name-based mapping correctly returns the passed result.
+
+    const allResults = bridgeUtils.parseAllResults(output.join('\n'));
+
+    // Index-based (WRONG): testItems[0] maps to results[0] = skipped
+    expect(allResults[0].status).toBe('skipped'); // this is the bug
+
+    // Name-based (CORRECT): find by name returns passed
+    const result = bridgeUtils.findResultByName(output, 'should delete todo');
+    expect(result.status).toBe('passed');
+  });
+});


### PR DESCRIPTION
## Summary
- Fix index-based result mapping in `_tryDirectBridge()` — `results[i]` mapped to wrong test when grep filter skips earlier tests
- Use `findResultByName()` to match results by test name instead of array index
- Add 6 unit tests covering `parseAllResults`, `findResultByName`, and the specific bug scenario

## Test plan
- [x] Unit tests pass (`vitest run bridge-results.test.ts`)
- [ ] Manual: click single test in Test Explorer with bridge mode — should pass, not skip

Closes #692

🤖 Generated with [Claude Code](https://claude.com/claude-code)