### PR TITLE
feat: add object tree rendering to VS Code REPL (#690)

### DIFF
--- a/packages/vscode/src/replView.script.ts
+++ b/packages/vscode/src/replView.script.ts
@@ -187,6 +187,9 @@ window.addEventListener('message', event => {
     commandHistory = params.history;
   } else if (method === 'completionItems') {
     completionItems = params.items;
+  } else if (method === 'structuredOutput') {
+    output.appendChild(renderValue(params.data, true));
+    output.scrollTop = output.scrollHeight;
   }
 });
 
@@ -201,6 +204,106 @@ function appendLine(text: string, type: 'command' | 'output' | 'error' | 'info')
     output.appendChild(el);
   }
   output.scrollTop = output.scrollHeight;
+}
+
+// ─── Object tree rendering ───────────────────────────────────────────────
+
+function renderValue(value: unknown, topLevel = false): HTMLElement {
+  if (value === null) {
+    const span = document.createElement('span');
+    span.className = 'obj-null';
+    span.textContent = 'null';
+    return span;
+  }
+  if (value === undefined) {
+    const span = document.createElement('span');
+    span.className = 'obj-null';
+    span.textContent = 'undefined';
+    return span;
+  }
+  if (typeof value === 'string') {
+    const span = document.createElement('span');
+    span.className = 'obj-string';
+    span.textContent = `"${value}"`;
+    return span;
+  }
+  if (typeof value === 'number') {
+    const span = document.createElement('span');
+    span.className = 'obj-number';
+    span.textContent = String(value);
+    return span;
+  }
+  if (typeof value === 'boolean') {
+    const span = document.createElement('span');
+    span.className = 'obj-boolean';
+    span.textContent = String(value);
+    return span;
+  }
+  if (Array.isArray(value)) {
+    return renderCollapsible(`Array(${value.length})`, value, topLevel, (v, container) => {
+      for (let i = 0; i < v.length; i++) {
+        const row = document.createElement('div');
+        row.className = 'obj-row';
+        const key = document.createElement('span');
+        key.className = 'obj-key';
+        key.textContent = `${i}: `;
+        row.appendChild(key);
+        row.appendChild(renderValue(v[i]));
+        container.appendChild(row);
+      }
+    });
+  }
+  if (typeof value === 'object') {
+    const keys = Object.keys(value as Record<string, unknown>);
+    const preview = keys.slice(0, 3).map(k => `${k}: …`).join(', ');
+    const label = `{${preview}${keys.length > 3 ? ', …' : ''}}`;
+    return renderCollapsible(label, value as Record<string, unknown>, topLevel, (v, container) => {
+      for (const k of Object.keys(v)) {
+        const row = document.createElement('div');
+        row.className = 'obj-row';
+        const key = document.createElement('span');
+        key.className = 'obj-key';
+        key.textContent = `${k}: `;
+        row.appendChild(key);
+        row.appendChild(renderValue((v as Record<string, unknown>)[k]));
+        container.appendChild(row);
+      }
+    });
+  }
+  // Fallback
+  const span = document.createElement('span');
+  span.textContent = String(value);
+  return span;
+}
+
+function renderCollapsible<T>(
+  label: string,
+  data: T,
+  open: boolean,
+  populate: (data: T, container: HTMLElement) => void,
+): HTMLElement {
+  const details = document.createElement('details');
+  details.className = 'obj-tree line';
+  if (open) details.open = true;
+
+  const summary = document.createElement('summary');
+  summary.textContent = label;
+  details.appendChild(summary);
+
+  // Lazy: populate children on first open
+  let populated = false;
+  if (open) {
+    populate(data, details);
+    populated = true;
+  }
+  details.addEventListener('toggle', () => {
+    if (details.open && !populated) {
+      populate(data, details);
+      populated = true;
+    }
+  });
+
+  return details;
 }
 
 // Request history on load

--- a/packages/vscode/src/replView.ts
+++ b/packages/vscode/src/replView.ts
@@ -93,6 +93,22 @@ export class ReplView extends WebviewBase {
         #command-input:disabled {
           opacity: 0.5;
         }
+        /* Object tree */
+        details.obj-tree { margin: 2px 0; }
+        details.obj-tree > summary {
+          cursor: pointer;
+          list-style: revert;
+          color: var(--vscode-editor-foreground);
+        }
+        details.obj-tree > summary:hover {
+          background: var(--vscode-list-hoverBackground);
+        }
+        .obj-row { padding-left: 16px; line-height: 1.4; }
+        .obj-key { color: var(--vscode-debugTokenExpression-name, #9cdcfe); }
+        .obj-string { color: var(--vscode-debugTokenExpression-string, #ce9178); }
+        .obj-number { color: var(--vscode-debugTokenExpression-number, #b5cea8); }
+        .obj-boolean { color: var(--vscode-debugTokenExpression-boolean, #569cd6); }
+        .obj-null { color: var(--vscode-descriptionForeground); font-style: italic; }
         #input-row {
           position: relative;
         }
@@ -176,31 +192,6 @@ export class ReplView extends WebviewBase {
       return;
     }
 
-    // Intercept 'page' — show useful page info instead of raw object
-    if (command.trim() === 'page') {
-      this._setProcessing(true);
-      try {
-        const result = await this._browserManager.runCommand('await JSON.stringify({ url: page.url(), title: await page.title(), viewport: await page.evaluate(() => ({ width: document.documentElement.clientWidth, height: document.documentElement.clientHeight, dpr: window.devicePixelRatio })) })');
-        if (result.text && !result.isError) {
-          const info = JSON.parse(result.text);
-          const vp = info.viewport ? `${info.viewport.width}x${info.viewport.height}` : 'auto';
-          const dpr = info.viewport?.dpr && info.viewport.dpr !== 1 ? ` @${info.viewport.dpr}x` : '';
-          this._appendOutput(
-            `URL:      ${info.url}\n` +
-            `Title:    ${info.title}\n` +
-            `Viewport: ${vp}${dpr}`,
-            'output',
-          );
-        } else {
-          this._appendOutput(result.text || 'Could not get page info', 'error');
-        }
-      } catch (e: unknown) {
-        this._appendOutput(`Error: ${(e as Error).message}`, 'error');
-      }
-      this._setProcessing(false);
-      return;
-    }
-
     this._setProcessing(true);
     this._commandCount++;
     const start = Date.now();
@@ -218,7 +209,13 @@ export class ReplView extends WebviewBase {
       if (result.text) {
         // Strip markdown section headers
         const text = result.text.replace(/^### \w[\w ]*\n/gm, '');
-        this._appendOutput(text, result.isError ? 'error' : 'output');
+
+        // Try to render as object tree if it's JSON
+        const structured = result.isError ? null : this._tryParseStructured(text);
+        if (structured !== null)
+          this.postMessage('structuredOutput', { data: structured });
+        else
+          this._appendOutput(text, result.isError ? 'error' : 'output');
       }
       if (!result.text && !result.image) {
         this._appendOutput('Done.', 'info');
@@ -310,6 +307,17 @@ export class ReplView extends WebviewBase {
     }
 
     return false;
+  }
+
+  /** Try to parse text as a JSON object or array. Returns null for primitives/strings/failures. */
+  private _tryParseStructured(text: string): unknown {
+    const trimmed = text.trim();
+    if (!trimmed.startsWith('{') && !trimmed.startsWith('[')) return null;
+    try {
+      const parsed = JSON.parse(trimmed);
+      if (typeof parsed === 'object' && parsed !== null) return parsed;
+    } catch {}
+    return null;
   }
 
   private _appendOutput(text: string, type: 'output' | 'error' | 'info') {


### PR DESCRIPTION
## Summary
- Render JSON objects/arrays as expandable `<details>/<summary>` trees
- Lazy child population — only builds DOM on first expand
- Primitives colored with `--vscode-debugTokenExpression-*` variables
- Remove custom `page` intercept — let CDP preview handle it naturally

## Test plan
- [x] All 171 tests pass
- [x] `await page.evaluate(() => ({...}))` renders as expandable tree
- [x] Non-JSON output (snapshot, click, etc.) renders as plain text
- [ ] Manual: verify tree expand/collapse, nested objects, arrays

Phase 2 of #690

🤖 Generated with [Claude Code](https://claude.com/claude-code)