### PR TITLE
feat: add clear, filter, search toolbar to REPL view (#690)

### DIFF
--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -135,8 +135,45 @@
         "category": "Playwright REPL",
         "command": "playwright-repl.assertBuilder",
         "title": "Assert Builder"
+      },
+      {
+        "category": "Playwright REPL",
+        "command": "playwright-repl.repl.clear",
+        "icon": "$(clear-all)",
+        "title": "Clear REPL"
+      },
+      {
+        "category": "Playwright REPL",
+        "command": "playwright-repl.repl.toggleFilter",
+        "icon": "$(filter)",
+        "title": "Filter Output"
+      },
+      {
+        "category": "Playwright REPL",
+        "command": "playwright-repl.repl.find",
+        "icon": "$(search)",
+        "title": "Find in REPL"
       }
     ],
+    "menus": {
+      "view/title": [
+        {
+          "command": "playwright-repl.repl.clear",
+          "group": "navigation@1",
+          "when": "view == playwright-repl.replView"
+        },
+        {
+          "command": "playwright-repl.repl.toggleFilter",
+          "group": "navigation@2",
+          "when": "view == playwright-repl.replView"
+        },
+        {
+          "command": "playwright-repl.repl.find",
+          "group": "navigation@3",
+          "when": "view == playwright-repl.replView"
+        }
+      ]
+    },
     "configuration": {
       "title": "Playwright REPL",
       "properties": {

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -350,6 +350,15 @@ export class Extension implements RunHooks {
           this._logger.error('Assert builder error:', (e as Error).message);
         }
       }),
+      vscode.commands.registerCommand('playwright-repl.repl.clear', () => {
+        this._replView.clear();
+      }),
+      vscode.commands.registerCommand('playwright-repl.repl.toggleFilter', () => {
+        this._replView.toggleFilter();
+      }),
+      vscode.commands.registerCommand('playwright-repl.repl.find', () => {
+        this._replView.toggleSearch();
+      }),
     ];
 
     const configObserver = new WorkspaceObserver(this._vscode, () => this._scheduleRebuildModels(), this._isUnderTest);

--- a/packages/vscode/src/replView.script.ts
+++ b/packages/vscode/src/replView.script.ts
@@ -180,6 +180,10 @@ window.addEventListener('message', event => {
     output.scrollTop = output.scrollHeight;
   } else if (method === 'clear') {
     output.textContent = '';
+  } else if (method === 'toggleFilter') {
+    toggleFilterBar();
+  } else if (method === 'toggleSearch') {
+    toggleSearchBar();
   } else if (method === 'processing') {
     input.disabled = params.processing;
     if (!params.processing) input.focus();
@@ -304,6 +308,124 @@ function renderCollapsible<T>(
   });
 
   return details;
+}
+
+// ─── Filter ──────────────────────────────────────────────────────────────
+
+const filterBar = document.getElementById('filter-bar')!;
+let activeFilter = 'all';
+
+function toggleFilterBar() {
+  const showing = filterBar.style.display === 'none' || filterBar.style.display === '';
+  filterBar.style.display = showing ? 'flex' : 'none';
+  if (!showing)
+    applyFilter('all');
+}
+
+filterBar.addEventListener('click', (e) => {
+  const btn = (e.target as HTMLElement).closest('.filter-btn') as HTMLElement | null;
+  if (!btn || !btn.dataset.filter) return;
+  applyFilter(btn.dataset.filter);
+});
+
+function applyFilter(filter: string) {
+  activeFilter = filter;
+  // Update active button
+  for (const btn of filterBar.querySelectorAll('.filter-btn'))
+    btn.classList.toggle('active', (btn as HTMLElement).dataset.filter === filter);
+  // Show/hide lines
+  for (const line of output.querySelectorAll('.line')) {
+    const el = line as HTMLElement;
+    if (filter === 'all') {
+      el.style.display = '';
+    } else {
+      el.style.display = el.classList.contains(`line-${filter}`) ? '' : 'none';
+    }
+  }
+}
+
+// ─── Search ──────────────────────────────────────────────────────────────
+
+const searchBar = document.getElementById('search-bar')!;
+const searchInput = document.getElementById('search-input') as HTMLInputElement;
+const searchCount = document.getElementById('search-count')!;
+let searchMatches: HTMLElement[] = [];
+let searchIndex = -1;
+
+function toggleSearchBar() {
+  const showing = searchBar.style.display === 'none' || searchBar.style.display === '';
+  searchBar.style.display = showing ? 'flex' : 'none';
+  if (showing) {
+    searchInput.focus();
+    searchInput.select();
+  } else {
+    clearSearchHighlights();
+  }
+}
+
+searchInput.addEventListener('input', () => {
+  performSearch(searchInput.value);
+});
+
+searchInput.addEventListener('keydown', (e) => {
+  if (e.key === 'Enter') {
+    e.preventDefault();
+    if (e.shiftKey) navigateSearch(-1);
+    else navigateSearch(1);
+  }
+  if (e.key === 'Escape') {
+    e.preventDefault();
+    toggleSearchBar();
+  }
+});
+
+document.getElementById('search-prev')!.addEventListener('click', () => navigateSearch(-1));
+document.getElementById('search-next')!.addEventListener('click', () => navigateSearch(1));
+document.getElementById('search-close')!.addEventListener('click', () => toggleSearchBar());
+
+function performSearch(query: string) {
+  clearSearchHighlights();
+  if (!query) {
+    searchCount.textContent = '';
+    return;
+  }
+
+  const lower = query.toLowerCase();
+  const lines = output.querySelectorAll('.line');
+  for (const line of lines) {
+    const el = line as HTMLElement;
+    const text = el.textContent || '';
+    if (text.toLowerCase().includes(lower)) {
+      el.classList.add('search-highlight');
+      searchMatches.push(el);
+    }
+  }
+
+  if (searchMatches.length > 0) {
+    searchIndex = 0;
+    searchMatches[0].classList.add('search-highlight-current');
+    searchMatches[0].scrollIntoView({ block: 'nearest' });
+    searchCount.textContent = `1/${searchMatches.length}`;
+  } else {
+    searchCount.textContent = 'No results';
+  }
+}
+
+function navigateSearch(direction: number) {
+  if (searchMatches.length === 0) return;
+  searchMatches[searchIndex].classList.remove('search-highlight-current');
+  searchIndex = (searchIndex + direction + searchMatches.length) % searchMatches.length;
+  searchMatches[searchIndex].classList.add('search-highlight-current');
+  searchMatches[searchIndex].scrollIntoView({ block: 'nearest' });
+  searchCount.textContent = `${searchIndex + 1}/${searchMatches.length}`;
+}
+
+function clearSearchHighlights() {
+  for (const el of searchMatches) {
+    el.classList.remove('search-highlight', 'search-highlight-current');
+  }
+  searchMatches = [];
+  searchIndex = -1;
 }
 
 // Request history on load

--- a/packages/vscode/src/replView.ts
+++ b/packages/vscode/src/replView.ts
@@ -109,6 +109,65 @@ export class ReplView extends WebviewBase {
         .obj-number { color: var(--vscode-debugTokenExpression-number, #b5cea8); }
         .obj-boolean { color: var(--vscode-debugTokenExpression-boolean, #569cd6); }
         .obj-null { color: var(--vscode-descriptionForeground); font-style: italic; }
+        /* Filter bar */
+        #filter-bar {
+          display: none;
+          padding: 2px 8px;
+          border-bottom: 1px solid var(--vscode-panel-border);
+          gap: 4px;
+          align-items: center;
+        }
+        .filter-btn {
+          background: transparent;
+          border: 1px solid transparent;
+          color: var(--vscode-descriptionForeground);
+          font-family: inherit;
+          font-size: 0.9em;
+          padding: 1px 6px;
+          border-radius: 3px;
+          cursor: pointer;
+        }
+        .filter-btn:hover {
+          background: var(--vscode-toolbar-hoverBackground);
+        }
+        .filter-btn.active {
+          color: var(--vscode-editor-foreground);
+          border-color: var(--vscode-focusBorder);
+          background: var(--vscode-toolbar-activeBackground, rgba(127,127,127,0.1));
+        }
+        /* Search bar */
+        #search-bar {
+          display: none;
+          padding: 2px 8px;
+          border-bottom: 1px solid var(--vscode-panel-border);
+          align-items: center;
+          gap: 4px;
+        }
+        #search-input {
+          flex: 1;
+          border: 1px solid var(--vscode-input-border, var(--vscode-panel-border));
+          background: var(--vscode-input-background);
+          color: var(--vscode-input-foreground);
+          font-family: inherit;
+          font-size: inherit;
+          padding: 2px 4px;
+          border-radius: 2px;
+          outline: none;
+        }
+        #search-input:focus {
+          border-color: var(--vscode-focusBorder);
+        }
+        #search-count {
+          color: var(--vscode-descriptionForeground);
+          font-size: 0.9em;
+          white-space: nowrap;
+        }
+        .search-highlight {
+          background: var(--vscode-editor-findMatchHighlightBackground, rgba(234,92,0,0.33));
+        }
+        .search-highlight-current {
+          background: var(--vscode-editor-findMatchBackground, rgba(161,121,0,0.4));
+        }
         #input-row {
           position: relative;
         }
@@ -150,6 +209,20 @@ export class ReplView extends WebviewBase {
           white-space: nowrap;
         }
       </style>
+      <div id="filter-bar">
+        <button class="filter-btn active" data-filter="all">All</button>
+        <button class="filter-btn" data-filter="command">Commands</button>
+        <button class="filter-btn" data-filter="output">Output</button>
+        <button class="filter-btn" data-filter="error">Errors</button>
+        <button class="filter-btn" data-filter="info">Info</button>
+      </div>
+      <div id="search-bar">
+        <input id="search-input" type="text" placeholder="Find…" />
+        <span id="search-count"></span>
+        <button class="filter-btn" id="search-prev" title="Previous">&#x2191;</button>
+        <button class="filter-btn" id="search-next" title="Next">&#x2193;</button>
+        <button class="filter-btn" id="search-close" title="Close">&#x2715;</button>
+      </div>
       <div id="output"></div>
       <div id="input-row">
         <div id="autocomplete-dropdown"></div>
@@ -347,5 +420,17 @@ export class ReplView extends WebviewBase {
 
   private _setProcessing(processing: boolean) {
     this.postMessage('processing', { processing });
+  }
+
+  clear() {
+    this.postMessage('clear');
+  }
+
+  toggleFilter() {
+    this.postMessage('toggleFilter');
+  }
+
+  toggleSearch() {
+    this.postMessage('toggleSearch');
   }
 }

--- a/packages/vscode/tests/playwright/repl-view.spec.ts
+++ b/packages/vscode/tests/playwright/repl-view.spec.ts
@@ -24,6 +24,20 @@ const replHtml = `<!DOCTYPE html>
 <html lang="en">
 <head><meta charset="UTF-8"></head>
 <body class="repl-view">
+  <div id="filter-bar" style="display:none">
+    <button class="filter-btn active" data-filter="all">All</button>
+    <button class="filter-btn" data-filter="command">Commands</button>
+    <button class="filter-btn" data-filter="output">Output</button>
+    <button class="filter-btn" data-filter="error">Errors</button>
+    <button class="filter-btn" data-filter="info">Info</button>
+  </div>
+  <div id="search-bar" style="display:none">
+    <input id="search-input" type="text" placeholder="Find…" />
+    <span id="search-count"></span>
+    <button class="filter-btn" id="search-prev">&#x2191;</button>
+    <button class="filter-btn" id="search-next">&#x2193;</button>
+    <button class="filter-btn" id="search-close">&#x2715;</button>
+  </div>
   <div id="output"></div>
   <div id="input-row">
     <div id="autocomplete-dropdown"></div>
@@ -181,4 +195,107 @@ test('should restore history from extension', async ({ replPage }) => {
   await input.press('Home');
   await input.press('ArrowUp');
   await expect(input).toHaveValue('old2');
+});
+
+// ─── Filter tests ────────────────────────────────────────────────────────
+
+test('should toggle filter bar visibility', async ({ replPage }) => {
+  const filterBar = replPage.locator('#filter-bar');
+  await expect(filterBar).not.toBeVisible();
+
+  await postToWebview(replPage, 'toggleFilter');
+  await expect(filterBar).toBeVisible();
+
+  await postToWebview(replPage, 'toggleFilter');
+  await expect(filterBar).not.toBeVisible();
+});
+
+test('should filter output by type', async ({ replPage }) => {
+  // Add lines of different types
+  await typeCommand(replPage, 'test command');
+  await postToWebview(replPage, 'output', { text: 'some output', type: 'output' });
+  await postToWebview(replPage, 'output', { text: 'an error', type: 'error' });
+  await postToWebview(replPage, 'output', { text: 'info note', type: 'info' });
+
+  // Show filter bar and filter to errors only
+  await postToWebview(replPage, 'toggleFilter');
+  await replPage.locator('.filter-btn[data-filter="error"]').click();
+
+  // Error line visible, others hidden
+  await expect(replPage.locator('.line-error')).toBeVisible();
+  await expect(replPage.locator('.line-command')).toBeHidden();
+  await expect(replPage.locator('.line-output')).toBeHidden();
+  await expect(replPage.locator('.line-info')).toBeHidden();
+
+  // Switch back to all
+  await replPage.locator('.filter-btn[data-filter="all"]').click();
+  await expect(replPage.locator('.line-command')).toBeVisible();
+  await expect(replPage.locator('.line-output')).toBeVisible();
+  await expect(replPage.locator('.line-error')).toBeVisible();
+  await expect(replPage.locator('.line-info')).toBeVisible();
+});
+
+// ─── Search tests ────────────────────────────────────────────────────────
+
+test('should toggle search bar visibility', async ({ replPage }) => {
+  const searchBar = replPage.locator('#search-bar');
+  await expect(searchBar).not.toBeVisible();
+
+  await postToWebview(replPage, 'toggleSearch');
+  await expect(searchBar).toBeVisible();
+  await expect(replPage.locator('#search-input')).toBeFocused();
+
+  await postToWebview(replPage, 'toggleSearch');
+  await expect(searchBar).not.toBeVisible();
+});
+
+test('should highlight matching lines on search', async ({ replPage }) => {
+  await postToWebview(replPage, 'output', { text: 'hello world', type: 'output' });
+  await postToWebview(replPage, 'output', { text: 'goodbye world', type: 'output' });
+  await postToWebview(replPage, 'output', { text: 'hello again', type: 'output' });
+
+  await postToWebview(replPage, 'toggleSearch');
+  await replPage.locator('#search-input').fill('hello');
+
+  // Two lines should be highlighted
+  await expect(replPage.locator('.search-highlight')).toHaveCount(2);
+  await expect(replPage.locator('#search-count')).toHaveText('1/2');
+});
+
+test('should navigate search results', async ({ replPage }) => {
+  await postToWebview(replPage, 'output', { text: 'apple pie', type: 'output' });
+  await postToWebview(replPage, 'output', { text: 'banana split', type: 'output' });
+  await postToWebview(replPage, 'output', { text: 'apple sauce', type: 'output' });
+
+  await postToWebview(replPage, 'toggleSearch');
+  await replPage.locator('#search-input').fill('apple');
+
+  await expect(replPage.locator('#search-count')).toHaveText('1/2');
+
+  // Navigate to next
+  await replPage.locator('#search-next').click();
+  await expect(replPage.locator('#search-count')).toHaveText('2/2');
+
+  // Navigate to previous (wraps around)
+  await replPage.locator('#search-prev').click();
+  await expect(replPage.locator('#search-count')).toHaveText('1/2');
+});
+
+test('should close search with Escape', async ({ replPage }) => {
+  await postToWebview(replPage, 'toggleSearch');
+  await replPage.locator('#search-input').fill('test');
+  await replPage.locator('#search-input').press('Escape');
+
+  await expect(replPage.locator('#search-bar')).not.toBeVisible();
+});
+
+// ─── Clear test ──────────────────────────────────────────────────────────
+
+test('should clear output via clear message', async ({ replPage }) => {
+  await postToWebview(replPage, 'output', { text: 'line 1', type: 'output' });
+  await postToWebview(replPage, 'output', { text: 'line 2', type: 'output' });
+  await expect(replPage.locator('#output .line')).toHaveCount(2);
+
+  await postToWebview(replPage, 'clear');
+  await expect(replPage.locator('#output')).toBeEmpty();
 });


### PR DESCRIPTION
## Summary
- Add native VS Code toolbar icons (clear-all, filter, search) to REPL panel title bar
- Filter bar: All/Commands/Output/Errors/Info tabs to show/hide output by type
- Search bar: text search with highlighting, prev/next navigation, Escape to close
- Clear: clears all output

## Test plan
- [x] 178 tests pass (7 new repl-view tests)
- [ ] Manual: verify toolbar icons appear, filter/search/clear work

Phase 4 of #690

🤖 Generated with [Claude Code](https://claude.com/claude-code)