### PR TITLE
feat: add --http mode for fast --command reuse (#688)

### DIFF
--- a/packages/cli/src/playwright-repl.ts
+++ b/packages/cli/src/playwright-repl.ts
@@ -17,8 +17,8 @@ import { minimist } from '@playwright-repl/core';
 import { startRepl } from './repl.js';
 
 const args = minimist(process.argv.slice(2), {
-  boolean: ['headed', 'headless', 'persistent', 'help', 'step', 'silent', 'spawn', 'bridge', 'engine', 'include-snapshot', 'verbose'],
-  string: ['session', 'browser', 'profile', 'config', 'replay', 'record', 'connect', 'port', 'cdp-port', 'bridge-port', 'command'],
+  boolean: ['headed', 'headless', 'persistent', 'help', 'step', 'silent', 'spawn', 'bridge', 'engine', 'include-snapshot', 'verbose', 'http'],
+  string: ['session', 'browser', 'profile', 'config', 'replay', 'record', 'connect', 'port', 'cdp-port', 'bridge-port', 'command', 'http-port'],
   alias: { s: 'session', h: 'help', b: 'browser', q: 'silent' },
   default: { session: 'default' },
 });
@@ -47,6 +47,8 @@ Options:
   --cdp-port <number>    Chrome CDP port (default: 9222)
   --include-snapshot     Include snapshot in update command responses
   --verbose              Show raw response headers (### Result, ### Snapshot, etc.)
+  --http                 Start HTTP server for external command access (port 9223)
+  --http-port <port>     HTTP server port (default: 9223)
   --command <cmd>        Run a single command, print output, and exit
   --config <file>        Path to config file
   --replay <files...>   Replay .pw file(s) or folder(s)
@@ -111,6 +113,8 @@ startRepl({
   step: args.step as boolean,
   bridge: args.bridge as boolean,
   engine: args.engine as boolean,
+  http: args.http as boolean,
+  httpPort: args['http-port'] ? parseInt(args['http-port'] as string, 10) : undefined,
   bridgePort: args['bridge-port'] ? parseInt(args['bridge-port'] as string, 10) : undefined,
   includeSnapshot: args['include-snapshot'] as boolean,
   verbose: args.verbose as boolean,

--- a/packages/cli/src/repl.ts
+++ b/packages/cli/src/repl.ts
@@ -8,6 +8,7 @@ import readline from 'node:readline';
 import path from 'node:path';
 import fs from 'node:fs';
 import os from 'node:os';
+import http from 'node:http';
 import {
   replVersion, parseInput, ALIASES, ALL_COMMANDS, buildCompletionItems, c, prettyJson,
   BridgeServer, COMMANDS, CATEGORIES, JS_CATEGORIES,
@@ -30,6 +31,8 @@ export interface ReplOpts extends EngineOpts {
   bridge?: boolean;
   bridgePort?: number;
   engine?: boolean;
+  http?: boolean;
+  httpPort?: number;
   includeSnapshot?: boolean;
   verbose?: boolean;
 }
@@ -953,11 +956,114 @@ async function startBridgeLoop(opts: ReplOpts, srv: BridgeServer): Promise<void>
   });
 }
 
+// ─── HTTP server for --http mode ─────────────────────────────────────────────
+
+const DEFAULT_HTTP_PORT = 9223;
+
+interface CommandRunner {
+  run(command: string, opts?: { includeSnapshot?: boolean }): Promise<{ text?: string; isError?: boolean }>;
+  runScript?(script: string, language: string): Promise<{ text?: string; isError?: boolean }>;
+}
+
+function startHttpServer(port: number, runner: CommandRunner, log: (...args: unknown[]) => void): Promise<http.Server> {
+  return new Promise((resolve, reject) => {
+    const server = http.createServer(async (req, res) => {
+      res.setHeader('Access-Control-Allow-Origin', '*');
+
+      if (req.method === 'GET' && req.url === '/health') {
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ status: 'ok' }));
+        return;
+      }
+
+      if (req.method === 'POST' && req.url === '/run') {
+        try {
+          const body = await readBody(req);
+          const { command } = JSON.parse(body);
+          const result = await runner.run(command);
+          res.writeHead(200, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify(result));
+        } catch (e: unknown) {
+          res.writeHead(500, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ text: (e as Error).message, isError: true }));
+        }
+        return;
+      }
+
+      if (req.method === 'POST' && req.url === '/run-script') {
+        try {
+          const body = await readBody(req);
+          const { script, language } = JSON.parse(body);
+          const result = runner.runScript
+            ? await runner.runScript(script, language || 'javascript')
+            : await runner.run(script);
+          res.writeHead(200, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify(result));
+        } catch (e: unknown) {
+          res.writeHead(500, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ text: (e as Error).message, isError: true }));
+        }
+        return;
+      }
+
+      res.writeHead(404);
+      res.end('Not found');
+    });
+
+    server.listen(port, () => {
+      log(`${c.green}✓${c.reset} HTTP server on port ${port}`);
+      resolve(server);
+    });
+    server.on('error', reject);
+  });
+}
+
+function readBody(req: http.IncomingMessage): Promise<string> {
+  return new Promise((resolve, reject) => {
+    let data = '';
+    req.on('data', (chunk: Buffer) => data += chunk);
+    req.on('end', () => resolve(data));
+    req.on('error', reject);
+  });
+}
+
+/** Try to send --command via HTTP to an already-running --http server. */
+async function tryHttpCommand(command: string, port: number): Promise<boolean> {
+  try {
+    const result = await new Promise<{ text?: string; isError?: boolean }>((resolve, reject) => {
+      const body = JSON.stringify({ command });
+      const req = http.request({ hostname: '127.0.0.1', port, path: '/run', method: 'POST', headers: { 'Content-Type': 'application/json', 'Content-Length': Buffer.byteLength(body) }, timeout: 3000 }, res => {
+        let data = '';
+        res.on('data', (chunk: string) => data += chunk);
+        res.on('end', () => { try { resolve(JSON.parse(data)); } catch { reject(new Error('Invalid response')); } });
+      });
+      req.on('error', reject);
+      req.on('timeout', () => { req.destroy(); reject(new Error('timeout')); });
+      req.write(body);
+      req.end();
+    });
+    process.stdout.write((result.text ?? '') + '\n');
+    process.exit(result.isError ? 1 : 0);
+  } catch {
+    return false; // Server not running, fall back
+  }
+  return false; // unreachable
+}
+
 // ─── REPL ────────────────────────────────────────────────────────────────────
 
 export async function startRepl(opts: ReplOpts = {}): Promise<void> {
   const silent = opts.silent || false;
   const log = (...args: unknown[]) => { if (!silent) console.log(...args); };
+
+  // ─── --command --http: send via HTTP to running server ──────────
+  if (opts.command && opts.http) {
+    const httpPort = opts.httpPort ?? DEFAULT_HTTP_PORT;
+    const sent = await tryHttpCommand(opts.command, httpPort);
+    if (sent) return;
+    console.error(`Could not connect to HTTP server on port ${httpPort}. Is playwright-repl --http running?`);
+    process.exit(1);
+  }
 
   log(`${c.bold}${c.magenta}🎭 Playwright REPL${c.reset} ${c.dim}v${replVersion}${c.reset}`);
 
@@ -979,6 +1085,14 @@ export async function startRepl(opts: ReplOpts = {}): Promise<void> {
           process.stdout.write((result.text ?? '') + '\n');
           await conn.close();
           process.exit(result.isError ? 1 : 0);
+        }
+        // Start HTTP server if --http
+        if (opts.http) {
+          try {
+            await startHttpServer(opts.httpPort ?? DEFAULT_HTTP_PORT, conn as CommandRunner, log);
+          } catch (e: unknown) {
+            log(`${c.yellow}⚠${c.reset} HTTP server failed: ${(e as Error).message}`);
+          }
         }
         log(`${c.dim}Type .help for commands, JavaScript supported${c.reset}\n`);
         if (opts.replay && opts.replay.length > 0) {
@@ -1007,6 +1121,14 @@ export async function startRepl(opts: ReplOpts = {}): Promise<void> {
       process.stdout.write((result.text ?? '') + '\n');
       srv.close();
       process.exit(result.isError ? 1 : 0);
+    }
+    // Start HTTP server if --http
+    if (opts.http) {
+      try {
+        await startHttpServer(opts.httpPort ?? DEFAULT_HTTP_PORT, srv as CommandRunner, log);
+      } catch (e: unknown) {
+        log(`${c.yellow}⚠${c.reset} HTTP server failed: ${(e as Error).message}`);
+      }
     }
     if (opts.replay && opts.replay.length > 0) {
       await runBridgeReplayMode(opts, srv);


### PR DESCRIPTION
## Summary
- Add `--http` flag to start an HTTP server alongside the REPL (port 9223, configurable via `--http-port`)
- `--command --http` sends commands to the running HTTP server (milliseconds vs seconds)
- Works with standalone (`--http`) and bridge (`--bridge --http`) modes
- Clear error if `--command --http` is used without a running server
- HTTP server error doesn't break REPL startup

## Endpoints
- `GET /health` — check if server is alive
- `POST /run` — run a single command
- `POST /run-script` — run a multi-line script

## Test plan
- [x] `playwright-repl --http` launches browser + HTTP server
- [x] `playwright-repl --bridge --http` starts bridge + HTTP server
- [x] `playwright-repl --http --command "1+1"` returns result via HTTP (fast)
- [x] `playwright-repl --command "1+1"` still works without HTTP (slow fallback)
- [x] Existing --replay tests pass

Closes #688

🤖 Generated with [Claude Code](https://claude.com/claude-code)