### PR TITLE
feat: add HTTP server to MCP for fast --command reuse (#697)

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -57,6 +57,31 @@ The extension connects automatically — no need to open the side panel.
 
 > Requires the [Dramaturg Chrome extension](../extension/README.md).
 
+### HTTP Mode
+
+Add `--http` to any mode to start an HTTP server alongside the REPL. This lets other processes send commands without starting a new browser session — ideal for AI tools, scripts, and CI.
+
+```bash
+# Terminal 1: Start REPL with HTTP server
+playwright-repl --http                        # standalone + HTTP (port 9223)
+playwright-repl --bridge --http               # bridge + HTTP
+playwright-repl --http --http-port 9224       # custom port
+
+# Terminal 2: Send commands via HTTP (fast — reuses existing session)
+playwright-repl --http --command "snapshot"
+playwright-repl --http --command "click e5"
+```
+
+The HTTP server exposes:
+- `GET /health` — check if server is alive
+- `POST /run` — run a command: `{"command": "snapshot"}`
+- `POST /run-script` — run a multi-line script: `{"script": "...", "language": "pw"}`
+
+Works with `curl` too:
+```bash
+curl -X POST http://localhost:9223/run -d '{"command":"snapshot"}'
+```
+
 ## Usage
 
 ```bash
@@ -101,6 +126,8 @@ Both modes auto-detect keyword commands and JavaScript expressions. For DOM acce
 | `--headless` | Run browser in headless mode (default: headed) |
 | `--bridge` | Connect to existing Chrome via WebSocket bridge |
 | `--bridge-port <port>` | Bridge server port (default: `9876`) |
+| `--http` | Start HTTP server for external command access (port `9223`) |
+| `--http-port <port>` | HTTP server port (default: `9223`) |
 | `--command <cmd>` | Run a single command, print output, and exit |
 | `--config <file>` | Path to config file |
 | `--replay <files...>` | Replay `.pw` or `.js` file(s) or folder(s) |

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -278,6 +278,32 @@ Each agent has access to `run_command` and `run_script` via the MCP server and r
 - **Prefer keyword commands** for common actions — they're shorter and more reliable than raw Playwright API
 - **Fall back to Playwright API** when keyword commands are ambiguous (e.g. two elements match the same text) — use `exact: true` or scope with a locator chain
 
+## HTTP Server
+
+The MCP server also starts an HTTP server on port `9223` for fast CLI command access. When the MCP server is running, you can send commands from the terminal without MCP protocol overhead:
+
+```bash
+# Send commands to the running MCP server via HTTP
+playwright-repl --http --command "snapshot"
+playwright-repl --http --command "click e5"
+
+# Or directly with curl
+curl -X POST http://localhost:9223/run -d '{"command":"snapshot"}'
+```
+
+Custom HTTP port:
+
+```json
+{
+  "mcpServers": {
+    "playwright-repl": {
+      "command": "playwright-repl-mcp",
+      "args": ["--http-port", "9224"]
+    }
+  }
+}
+```
+
 ## Custom port
 
 By default the MCP server listens on port `9876`. To use a different port:

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -2,12 +2,14 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { z } from 'zod';
+import http from 'node:http';
 import { COMMANDS, CATEGORIES } from '@playwright-repl/core';
 import pkg from '../package.json' with { type: 'json' };
 import { createBridgeRunner } from './bridge.js';
 import { createEvaluateRunner } from './evaluate.js';
 import { createStandaloneRunner } from './standalone.js';
 import { logStartup, logEvent, logToolCall, logToolResult, logError, LOG_FILE } from './logger.js';
+import type { Runner } from './types.js';
 // ─── Process exit handlers — log why the process dies ───────────────────────
 
 process.on('uncaughtException', (err) => {
@@ -54,6 +56,70 @@ if (standalone) {
 const { runner, descriptions } = runnerModule;
 
 logStartup(standalone ? 'standalone' : 'bridge', `log → ${LOG_FILE}`);
+
+// ─── HTTP server for --command --http piggybacking ──────────────────────────
+
+const httpPort = (() => {
+    const idx = argv.indexOf('--http-port');
+    if (idx !== -1 && argv[idx + 1]) return parseInt(argv[idx + 1], 10);
+    return 9223;
+})();
+
+startHttpServer(httpPort, runner);
+
+function startHttpServer(port: number, r: Runner) {
+    const server = http.createServer(async (req: http.IncomingMessage, res: http.ServerResponse) => {
+        res.setHeader('Access-Control-Allow-Origin', '*');
+        if (req.method === 'GET' && req.url === '/health') {
+            res.writeHead(200, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({ status: 'ok' }));
+            return;
+        }
+        if (req.method === 'POST' && req.url === '/run') {
+            try {
+                const body = await readBody(req);
+                const { command } = JSON.parse(body);
+                const result = await r.runCommand(command);
+                res.writeHead(200, { 'Content-Type': 'application/json' });
+                res.end(JSON.stringify(result));
+            } catch (e: unknown) {
+                res.writeHead(500, { 'Content-Type': 'application/json' });
+                res.end(JSON.stringify({ text: (e as Error).message, isError: true }));
+            }
+            return;
+        }
+        if (req.method === 'POST' && req.url === '/run-script') {
+            try {
+                const body = await readBody(req);
+                const { script, language } = JSON.parse(body);
+                const result = await r.runScript(script, language || 'pw');
+                res.writeHead(200, { 'Content-Type': 'application/json' });
+                res.end(JSON.stringify(result));
+            } catch (e: unknown) {
+                res.writeHead(500, { 'Content-Type': 'application/json' });
+                res.end(JSON.stringify({ text: (e as Error).message, isError: true }));
+            }
+            return;
+        }
+        res.writeHead(404);
+        res.end('Not found');
+    });
+    server.listen(port, () => {
+        logEvent(`HTTP server on port ${port}`);
+    });
+    server.on('error', (e: Error) => {
+        logEvent(`HTTP server failed: ${e.message}`);
+    });
+}
+
+function readBody(req: http.IncomingMessage): Promise<string> {
+    return new Promise((resolve, reject) => {
+        let data = '';
+        req.on('data', (chunk: string) => data += chunk);
+        req.on('end', () => resolve(data));
+        req.on('error', reject);
+    });
+}
 
 // ─── MCP server ──────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- MCP server automatically starts HTTP server on port 9223 (configurable via `--http-port`)
- Enables `playwright-repl --http --command "snapshot"` to piggyback on running MCP server
- Same `/health`, `/run`, `/run-script` endpoints as CLI `--http` mode
- Updated CLI and MCP READMEs with `--http` documentation

## Test plan
- [x] MCP server builds successfully
- [x] CLI `--http --command` works against running MCP server
- [ ] Manual: start MCP via Claude Desktop, send `--http --command` from terminal

Closes #697

🤖 Generated with [Claude Code](https://claude.com/claude-code)