### PR TITLE
feat: add pw-cli shorthand for fast HTTP commands

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -82,6 +82,27 @@ Works with `curl` too:
 curl -X POST http://localhost:9223/run -d '{"command":"snapshot"}'
 ```
 
+## pw-cli — Quick Command Shorthand
+
+`pw-cli` is a shorthand for `playwright-repl --http --command`. When given arguments, it sends the command via HTTP to a running session (REPL, MCP, or VS Code):
+
+```bash
+pw-cli "snapshot"                # → playwright-repl --http --command "snapshot"
+pw-cli "click e5"                # → playwright-repl --http --command "click e5"
+pw-cli "await page.title()"     # JavaScript works too
+pw-cli                           # no args → starts interactive REPL
+```
+
+Requires a running `--http` server (or MCP server) on port 9223. Start one first:
+
+```bash
+# Option 1: REPL with HTTP
+playwright-repl --http
+
+# Option 2: MCP server (HTTP starts automatically)
+# (launched by Claude Desktop / Claude Code)
+```
+
 ## Usage
 
 ```bash

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -4,7 +4,8 @@
   "description": "Interactive REPL for Playwright — keyword commands, recording, and replay",
   "type": "module",
   "bin": {
-    "playwright-repl": "./dist/playwright-repl.js"
+    "playwright-repl": "./dist/playwright-repl.js",
+    "pw-cli": "./dist/pw-cli.js"
   },
   "main": "./dist/index.js",
   "exports": {

--- a/packages/cli/src/pw-cli.ts
+++ b/packages/cli/src/pw-cli.ts
@@ -1,0 +1,66 @@
+#!/usr/bin/env node
+
+/**
+ * pw-cli — shorthand for playwright-repl --http --command.
+ *
+ * Usage:
+ *   pw-cli "snapshot"           # → --http --command "snapshot"
+ *   pw-cli "click e5"           # → --http --command "click e5"
+ *   pw-cli                      # → starts interactive REPL (same as playwright-repl)
+ *   pw-cli --bridge             # → passes flags through to playwright-repl
+ */
+
+import { startRepl } from './repl.js';
+import { minimist } from '@playwright-repl/core';
+
+const args = minimist(process.argv.slice(2), {
+  boolean: ['headed', 'headless', 'bridge', 'http', 'help'],
+  string: ['http-port', 'bridge-port', 'command'],
+  alias: { h: 'help' },
+});
+
+if (args.help) {
+  console.log(`
+pw-cli — shorthand for playwright-repl
+
+Usage:
+  pw-cli "snapshot"              # send command via HTTP (fast)
+  pw-cli "click e5"              # send command via HTTP
+  pw-cli                         # start interactive REPL
+  pw-cli --bridge                # start bridge mode REPL
+  pw-cli --http                  # start REPL with HTTP server
+
+Examples:
+  pw-cli "goto https://example.com"
+  pw-cli "await page.title()"
+  pw-cli "screenshot"
+`);
+  process.exit(0);
+}
+
+// If positional args given, treat as --http --command
+const positional = args._ as string[];
+if (positional.length > 0) {
+  const command = positional.join(' ');
+  startRepl({
+    command,
+    http: true,
+    httpPort: args['http-port'] ? parseInt(args['http-port'] as string, 10) : undefined,
+    silent: true,
+  }).catch((err: Error) => {
+    console.error(err.message);
+    process.exit(1);
+  });
+} else {
+  // No args — start interactive REPL, pass through flags
+  startRepl({
+    bridge: args.bridge as boolean,
+    http: args.http as boolean,
+    httpPort: args['http-port'] ? parseInt(args['http-port'] as string, 10) : undefined,
+    bridgePort: args['bridge-port'] ? parseInt(args['bridge-port'] as string, 10) : undefined,
+    headed: args.headless ? false : args.headed ? true : undefined,
+  }).catch((err: Error) => {
+    console.error(`Fatal: ${err.message}`);
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
## Summary
- Add `pw-cli` binary as shorthand for `playwright-repl --http --command`
- `pw-cli "snapshot"` sends command via HTTP to running server (fast)
- `pw-cli` with no args starts interactive REPL
- Passes through `--bridge`, `--http`, `--headed` flags

## Usage
```bash
pw-cli "snapshot"           # fast HTTP command
pw-cli "click e5"           # fast HTTP command
pw-cli                      # interactive REPL
pw-cli --bridge --http      # bridge + HTTP server
```

## Test plan
- [x] `pw-cli --help` shows usage
- [x] Builds successfully
- [ ] Manual: `pw-cli "1+1"` with running HTTP server

🤖 Generated with [Claude Code](https://claude.com/claude-code)