### PR TITLE
fix: --http runs as a console with logged requests, not an interactive REPL

### DIFF
--- a/packages/cli/src/playwright-repl.ts
+++ b/packages/cli/src/playwright-repl.ts
@@ -17,7 +17,7 @@ import { minimist } from '@playwright-repl/core';
 import { startRepl } from './repl.js';
 
 const args = minimist(process.argv.slice(2), {
-  boolean: ['headed', 'headless', 'persistent', 'help', 'step', 'silent', 'spawn', 'bridge', 'engine', 'include-snapshot', 'verbose', 'http'],
+  boolean: ['headed', 'headless', 'persistent', 'help', 'step', 'silent', 'spawn', 'bridge', 'engine', 'include-snapshot', 'verbose', 'http', 'interactive'],
   string: ['session', 'browser', 'profile', 'config', 'replay', 'record', 'connect', 'port', 'cdp-port', 'bridge-port', 'command', 'http-port'],
   alias: { s: 'session', h: 'help', b: 'browser', q: 'silent' },
   default: { session: 'default' },
@@ -47,8 +47,11 @@ Options:
   --cdp-port <number>    Chrome CDP port (default: 9222)
   --include-snapshot     Include snapshot in update command responses
   --verbose              Show raw response headers (### Result, ### Snapshot, etc.)
-  --http                 Start HTTP server for external command access (port 9223)
+  --http                 Start HTTP server for external command access (port 9223).
+                         Runs as a console (no interactive prompt) — pair with --interactive
+                         to also get a readline REPL.
   --http-port <port>     HTTP server port (default: 9223)
+  --interactive          Force interactive readline prompt even when --http is set
   --command <cmd>        Run a single command, print output, and exit
   --config <file>        Path to config file
   --replay <files...>   Replay .pw file(s) or folder(s)
@@ -115,6 +118,7 @@ startRepl({
   engine: args.engine as boolean,
   http: args.http as boolean,
   httpPort: args['http-port'] ? parseInt(args['http-port'] as string, 10) : undefined,
+  interactive: args.interactive as boolean,
   bridgePort: args['bridge-port'] ? parseInt(args['bridge-port'] as string, 10) : undefined,
   includeSnapshot: args['include-snapshot'] as boolean,
   verbose: args.verbose as boolean,

--- a/packages/cli/src/pw-cli.ts
+++ b/packages/cli/src/pw-cli.ts
@@ -14,7 +14,7 @@ import { startRepl } from './repl.js';
 import { minimist } from '@playwright-repl/core';
 
 const args = minimist(process.argv.slice(2), {
-  boolean: ['headed', 'headless', 'bridge', 'http', 'help'],
+  boolean: ['headed', 'headless', 'bridge', 'http', 'interactive', 'help'],
   string: ['http-port', 'bridge-port', 'command'],
   alias: { h: 'help' },
 });
@@ -58,6 +58,7 @@ if (positional.length > 0) {
     http: args.http as boolean,
     httpPort: args['http-port'] ? parseInt(args['http-port'] as string, 10) : undefined,
     bridgePort: args['bridge-port'] ? parseInt(args['bridge-port'] as string, 10) : undefined,
+    interactive: args.interactive as boolean,
     headed: args.headless ? false : args.headed ? true : undefined,
   }).catch((err: Error) => {
     console.error(`Fatal: ${err.message}`);

--- a/packages/cli/src/repl.ts
+++ b/packages/cli/src/repl.ts
@@ -33,6 +33,7 @@ export interface ReplOpts extends EngineOpts {
   engine?: boolean;
   http?: boolean;
   httpPort?: number;
+  interactive?: boolean;
   includeSnapshot?: boolean;
   verbose?: boolean;
 }
@@ -965,6 +966,12 @@ interface CommandRunner {
   runScript?(script: string, language: string): Promise<{ text?: string; isError?: boolean }>;
 }
 
+function httpTs(): string {
+  const d = new Date();
+  const pad = (n: number) => n.toString().padStart(2, '0');
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}`;
+}
+
 function startHttpServer(port: number, runner: CommandRunner, log: (...args: unknown[]) => void): Promise<http.Server> {
   return new Promise((resolve, reject) => {
     const server = http.createServer(async (req, res) => {
@@ -977,13 +984,20 @@ function startHttpServer(port: number, runner: CommandRunner, log: (...args: unk
       }
 
       if (req.method === 'POST' && req.url === '/run') {
+        const t0 = Date.now();
+        let command = '';
         try {
           const body = await readBody(req);
-          const { command } = JSON.parse(body);
+          ({ command } = JSON.parse(body));
+          log(`${c.dim}[${httpTs()}] →${c.reset} ${command}`);
           const result = await runner.run(command);
+          const ms = Date.now() - t0;
+          const mark = result.isError ? `${c.red}✗${c.reset}` : `${c.green}✓${c.reset}`;
+          log(`${c.dim}[${httpTs()}]${c.reset} ${mark} ${command} ${c.dim}(${ms}ms)${c.reset}`);
           res.writeHead(200, { 'Content-Type': 'application/json' });
           res.end(JSON.stringify(result));
         } catch (e: unknown) {
+          log(`${c.dim}[${httpTs()}]${c.reset} ${c.red}✗${c.reset} ${command} ${c.dim}— ${(e as Error).message}${c.reset}`);
           res.writeHead(500, { 'Content-Type': 'application/json' });
           res.end(JSON.stringify({ text: (e as Error).message, isError: true }));
         }
@@ -991,15 +1005,25 @@ function startHttpServer(port: number, runner: CommandRunner, log: (...args: unk
       }
 
       if (req.method === 'POST' && req.url === '/run-script') {
+        const t0 = Date.now();
+        let language = 'javascript';
         try {
           const body = await readBody(req);
-          const { script, language } = JSON.parse(body);
+          const parsed = JSON.parse(body);
+          const script = parsed.script;
+          language = parsed.language || 'javascript';
+          const preview = String(script).split('\n')[0].slice(0, 60);
+          log(`${c.dim}[${httpTs()}] → [${language}]${c.reset} ${preview}${String(script).length > preview.length ? '…' : ''}`);
           const result = runner.runScript
-            ? await runner.runScript(script, language || 'javascript')
+            ? await runner.runScript(script, language)
             : await runner.run(script);
+          const ms = Date.now() - t0;
+          const mark = result.isError ? `${c.red}✗${c.reset}` : `${c.green}✓${c.reset}`;
+          log(`${c.dim}[${httpTs()}]${c.reset} ${mark} [${language}] ${c.dim}(${ms}ms)${c.reset}`);
           res.writeHead(200, { 'Content-Type': 'application/json' });
           res.end(JSON.stringify(result));
         } catch (e: unknown) {
+          log(`${c.dim}[${httpTs()}]${c.reset} ${c.red}✗${c.reset} [${language}] ${c.dim}— ${(e as Error).message}${c.reset}`);
           res.writeHead(500, { 'Content-Type': 'application/json' });
           res.end(JSON.stringify({ text: (e as Error).message, isError: true }));
         }
@@ -1027,25 +1051,41 @@ function readBody(req: http.IncomingMessage): Promise<string> {
   });
 }
 
+/** Block until SIGINT/SIGTERM. Used by --http console mode (no readline loop). */
+function waitForShutdown(log: (...args: unknown[]) => void): Promise<void> {
+  return new Promise<void>((resolve) => {
+    const onSignal = (sig: string) => {
+      log(`${c.dim}Received ${sig}, shutting down...${c.reset}`);
+      resolve();
+    };
+    process.once('SIGINT', () => onSignal('SIGINT'));
+    process.once('SIGTERM', () => onSignal('SIGTERM'));
+  });
+}
+
 /** Try to send --command via HTTP to an already-running --http server. */
 async function tryHttpCommand(command: string, port: number): Promise<boolean> {
   try {
     const result = await new Promise<{ text?: string; isError?: boolean }>((resolve, reject) => {
       const body = JSON.stringify({ command });
-      const req = http.request({ hostname: '127.0.0.1', port, path: '/run', method: 'POST', headers: { 'Content-Type': 'application/json', 'Content-Length': Buffer.byteLength(body) }, timeout: 3000 }, res => {
+      const req = http.request({ hostname: '127.0.0.1', port, path: '/run', method: 'POST', headers: { 'Content-Type': 'application/json', 'Content-Length': Buffer.byteLength(body) } }, res => {
         let data = '';
         res.on('data', (chunk: string) => data += chunk);
         res.on('end', () => { try { resolve(JSON.parse(data)); } catch { reject(new Error('Invalid response')); } });
       });
       req.on('error', reject);
-      req.on('timeout', () => { req.destroy(); reject(new Error('timeout')); });
       req.write(body);
       req.end();
     });
-    process.stdout.write((result.text ?? '') + '\n');
+    const text = (result.text ?? '').replace(/^\s*\n+|\n+\s*$/g, '');
+    if (text) process.stdout.write(text + '\n');
     process.exit(result.isError ? 1 : 0);
-  } catch {
-    return false; // Server not running, fall back
+  } catch (e: unknown) {
+    const code = (e as NodeJS.ErrnoException).code;
+    if (code === 'ECONNREFUSED' || code === 'ENOTFOUND') return false; // Server not running, fall back
+    // Server is running but request errored — surface the real error, don't pretend the server is down
+    console.error(`HTTP request failed: ${(e as Error).message}`);
+    process.exit(1);
   }
   return false; // unreachable
 }
@@ -1094,6 +1134,13 @@ export async function startRepl(opts: ReplOpts = {}): Promise<void> {
             log(`${c.yellow}⚠${c.reset} HTTP server failed: ${(e as Error).message}`);
           }
         }
+        // --http runs as a console (no readline) unless --interactive is also set
+        if (opts.http && !opts.interactive && !(opts.replay && opts.replay.length > 0)) {
+          log(`${c.dim}Console mode — send commands via HTTP. Ctrl+C to exit.${c.reset}\n`);
+          await waitForShutdown(log);
+          await conn.close();
+          process.exit(0);
+        }
         log(`${c.dim}Type .help for commands, JavaScript supported${c.reset}\n`);
         if (opts.replay && opts.replay.length > 0) {
           await runBridgeReplayMode(opts, conn as any);
@@ -1132,6 +1179,11 @@ export async function startRepl(opts: ReplOpts = {}): Promise<void> {
     }
     if (opts.replay && opts.replay.length > 0) {
       await runBridgeReplayMode(opts, srv);
+    } else if (opts.http && !opts.interactive) {
+      log(`${c.dim}Console mode — send commands via HTTP. Ctrl+C to exit.${c.reset}\n`);
+      await waitForShutdown(log);
+      srv.close();
+      process.exit(0);
     } else {
       log('Waiting for extension to connect...');
       await startBridgeLoop(opts, srv);


### PR DESCRIPTION
## Summary

Fixes a misleading "Could not connect to HTTP server" message and reshapes `--http` as a server console rather than a hybrid REPL.

- **Bug fix**: `pw-cli` had a 3s client-side timeout. Slow commands like `go-back` (page navigation) blew past it, the catch block returned `false`, and the user saw `Could not connect to HTTP server on port 9223. Is playwright-repl --http running?` even though the server was running and the command had completed. Dropped the timeout and now only `ECONNREFUSED`/`ENOTFOUND` get treated as "server not running" — other errors surface their real message instead.
- **Output cleanup**: trim leading/trailing blank lines from result text so commands that returned `\nhttps://playwright.dev/` no longer print an extra empty line.
- **Console mode**: `--http` previously started the readline prompt *and* the HTTP server, so HTTP-driven log output interleaved with the live `pw>` prompt. Now `--http` skips the readline loop and just keeps the process alive until `SIGINT`/`SIGTERM`. Added `--interactive` as an opt-in escape hatch for users who want both.
- **Request logging**: `/run` and `/run-script` now log each request with a `[YYYY-MM-DD HH:MM:SS]` timestamp, ✓/✗ status, and elapsed ms — useful when watching a long-running console.

Sample console output:
```
[bridge 20:56:29] new connection accepted
[2026-04-11 20:56:33] → snapshot
[2026-04-11 20:56:33] ✓ snapshot (30ms)
[2026-04-11 20:57:59] → go-back
[2026-04-11 20:57:59] ✓ go-back (312ms)
```

## Test plan

- [ ] `pw-cli "go-back"` against a running `--http` server — should print result without "Could not connect" error
- [ ] `pw-cli` with no running server — should still fall back gracefully (ECONNREFUSED path)
- [ ] `playwright-repl --bridge --http` — should show "Console mode" and **no** `pw>` prompt
- [ ] `playwright-repl --bridge --http --interactive` — should show both HTTP server and the readline prompt
- [ ] `playwright-repl --http --replay foo.pw` — replay still runs (HTTP coexists)
- [ ] Ctrl+C from console mode — clean shutdown
- [ ] Result text with trailing newlines no longer prints an extra blank line

🤖 Generated with [Claude Code](https://claude.com/claude-code)