### PR TITLE
feat: add AI skill for playwright-repl CLI (#701)

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -25,6 +25,27 @@ npm install -g playwright-repl
 npx playwright install chromium
 ```
 
+## AI Skills
+
+playwright-repl includes an AI skill file that teaches agents (Claude Code, Cursor, etc.) how to use `pw-cli` via Bash — no MCP needed.
+
+### Claude Code
+
+```bash
+# Copy the skill to your project
+mkdir -p .claude/skills
+cp node_modules/playwright-repl/skills/SKILL.md .claude/skills/playwright-repl.md
+```
+
+### Cursor
+
+```bash
+mkdir -p .cursor/skills
+cp node_modules/playwright-repl/skills/SKILL.md .cursor/skills/playwright-repl.md
+```
+
+The skill defines `allowed-tools: Bash(pw-cli:*)` so the agent can run browser commands directly.
+
 ## Connection Modes
 
 | Mode | Flag | How it works |

--- a/packages/cli/skills/SKILL.md
+++ b/packages/cli/skills/SKILL.md
@@ -1,0 +1,272 @@
+---
+name: playwright-repl
+description: Automate browser interactions using playwright-repl keyword commands and JavaScript.
+allowed-tools: Bash(pw-cli:*) Bash(playwright-repl:*)
+---
+
+# Browser Automation with playwright-repl
+
+## Quick start
+
+```bash
+# Start the HTTP server (keeps browser session alive)
+playwright-repl --http
+
+# In another terminal, send commands via pw-cli:
+pw-cli "goto https://example.com"
+pw-cli snapshot
+pw-cli "click e15"
+pw-cli "fill e5 user@example.com"
+pw-cli screenshot
+```
+
+## Prerequisites
+
+The `pw-cli` shorthand sends commands via HTTP to a running playwright-repl session. Start one first:
+
+```bash
+# Option 1: Standalone — launches Chromium with extension
+playwright-repl --http
+
+# Option 2: Standalone headless — no visible browser
+playwright-repl --http --headless
+
+# Option 3: Bridge — uses your real Chrome with Dramaturg extension
+playwright-repl --bridge --http
+
+# Option 4: Custom port (default: 9223)
+playwright-repl --http --http-port 9224
+playwright-repl --bridge --http --http-port 9224
+
+# Option 5: MCP server — HTTP starts automatically on port 9223
+# Launched by Claude Desktop / Claude Code via MCP config
+```
+
+When using a custom port, pass it to pw-cli:
+```bash
+pw-cli --http-port 9224 "snapshot"
+```
+
+## Commands
+
+### Core
+
+```bash
+pw-cli "goto https://example.com"
+pw-cli snapshot
+pw-cli "click e3"
+pw-cli "click Submit"
+pw-cli "dblclick e7"
+pw-cli "fill e5 user@example.com"
+pw-cli "type search query"
+pw-cli "press Enter"
+pw-cli "hover e4"
+pw-cli "select e9 option-value"
+pw-cli "check e12"
+pw-cli "uncheck e12"
+pw-cli "drag e2 e8"
+pw-cli "upload e10 ./document.pdf"
+pw-cli screenshot
+pw-cli "pdf"
+pw-cli "close"
+```
+
+### Navigation
+
+```bash
+pw-cli "goto https://example.com"
+pw-cli "go-back"
+pw-cli "go-forward"
+pw-cli "reload"
+```
+
+### Keyboard
+
+```bash
+pw-cli "press Enter"
+pw-cli "press Tab"
+pw-cli "press Escape"
+pw-cli "press ArrowDown"
+```
+
+### Inspection
+
+```bash
+pw-cli snapshot
+pw-cli screenshot
+pw-cli "highlight Submit"
+pw-cli "eval document.title"
+pw-cli "eval el => el.textContent e5"
+pw-cli "console"
+pw-cli "network"
+pw-cli "locator e5"
+```
+
+### Assertions
+
+```bash
+pw-cli "verify-text Welcome"
+pw-cli "verify-no-text Error"
+pw-cli "verify-element button Submit"
+pw-cli "verify-value e5 user@example.com"
+pw-cli "verify-list e10 Item 1, Item 2"
+pw-cli "verify-title My Page"
+pw-cli "verify-url /dashboard"
+```
+
+### Tabs
+
+```bash
+pw-cli "tab-list"
+pw-cli "tab-new https://example.com"
+pw-cli "tab-select 0"
+pw-cli "tab-close"
+```
+
+### Storage
+
+```bash
+# Cookies
+pw-cli "cookie-list"
+pw-cli "cookie-get session_id"
+pw-cli "cookie-set session_id abc123"
+pw-cli "cookie-delete session_id"
+pw-cli "cookie-clear"
+
+# localStorage
+pw-cli "localstorage-list"
+pw-cli "localstorage-get theme"
+pw-cli "localstorage-set theme dark"
+pw-cli "localstorage-delete theme"
+pw-cli "localstorage-clear"
+
+# sessionStorage
+pw-cli "sessionstorage-list"
+pw-cli "sessionstorage-get step"
+pw-cli "sessionstorage-set step 3"
+pw-cli "sessionstorage-delete step"
+pw-cli "sessionstorage-clear"
+
+# Auth state
+pw-cli "state-save auth.json"
+pw-cli "state-load auth.json"
+```
+
+### Network
+
+```bash
+pw-cli "route **/*.jpg --status 404"
+pw-cli "route-list"
+pw-cli "unroute **/*.jpg"
+pw-cli "unroute"
+```
+
+### Video Recording
+
+```bash
+pw-cli "video-start"
+pw-cli "video-chapter Login flow"
+pw-cli "video-stop"
+```
+
+### DevTools
+
+```bash
+pw-cli "console"
+pw-cli "network"
+pw-cli "tracing-start"
+pw-cli "tracing-stop"
+```
+
+### Layout
+
+```bash
+pw-cli "resize 1920 1080"
+pw-cli "dialog-accept"
+pw-cli "dialog-dismiss"
+```
+
+## Playwright JavaScript
+
+For complex interactions, use the full Playwright API:
+
+```bash
+pw-cli "await page.url()"
+pw-cli "await page.title()"
+pw-cli "await page.locator('button').count()"
+pw-cli "await page.getByRole('link', { name: 'Get started' }).click()"
+pw-cli "await page.evaluate(() => document.title)"
+pw-cli "await expect(page.getByText('Welcome')).toBeVisible()"
+```
+
+## Targeting elements
+
+Use refs from the snapshot to interact with elements:
+
+```bash
+# Get snapshot with refs
+pw-cli snapshot
+# Output includes refs like e1, e5, e15...
+
+# Interact using a ref
+pw-cli "click e15"
+pw-cli "fill e5 hello"
+```
+
+Or use text/label matching:
+
+```bash
+pw-cli "click Submit"
+pw-cli "fill Email user@example.com"
+pw-cli "click Submit --nth 0"
+pw-cli "click Submit --exact"
+```
+
+## Screenshots
+
+Screenshots are automatically saved to `~/pw-screenshots/` and the file path is returned:
+
+```bash
+pw-cli screenshot
+# → Screenshot saved to /home/user/pw-screenshots/pw-screenshot-1712876400000.png
+```
+
+## Best practices
+
+1. **Always snapshot first** to understand page structure before interacting
+2. **Use refs from snapshot** for precise element targeting
+3. **Verify after actions** with `verify-text` or `screenshot` to confirm state
+4. **Use keyword commands** for common actions — shorter and more reliable
+5. **Fall back to JavaScript** when keywords are ambiguous (e.g., multiple matching elements)
+
+## Example: Form submission
+
+```bash
+pw-cli "goto https://example.com/form"
+pw-cli snapshot
+pw-cli "fill e1 user@example.com"
+pw-cli "fill e2 password123"
+pw-cli "click e3"
+pw-cli "verify-text Welcome"
+```
+
+## Example: Navigate and verify
+
+```bash
+pw-cli "goto https://demo.playwright.dev/todomvc/"
+pw-cli "fill \"What needs to be done?\" Buy groceries"
+pw-cli "press Enter"
+pw-cli "verify-text Buy groceries"
+pw-cli "verify-text 1 item left"
+pw-cli screenshot
+```
+
+## Example: Multi-tab workflow
+
+```bash
+pw-cli "goto https://example.com"
+pw-cli "tab-new https://example.com/other"
+pw-cli "tab-list"
+pw-cli "tab-select 0"
+pw-cli snapshot
+```

--- a/packages/cli/src/repl.ts
+++ b/packages/cli/src/repl.ts
@@ -700,7 +700,7 @@ function isComplete(code: string): boolean {
 
 // ─── Bridge shared helpers ───────────────────────────────────────────────────
 
-function displayBridgeResult(result: EngineResult, silent: boolean, command?: string): void {
+function displayBridgeResult(result: EngineResult, silent: boolean): void {
   if (result.image) {
     const isPdf = result.image.startsWith('data:application/pdf');
     const outDir = path.join(os.homedir(), isPdf ? 'pw-pdfs' : 'pw-screenshots');
@@ -720,15 +720,6 @@ function displayBridgeResult(result: EngineResult, silent: boolean, command?: st
     }
   }
 
-  // Save snapshot to file when command is snapshot (or includes snapshot output)
-  const cmd = command?.trim().toLowerCase() ?? '';
-  if (!result.isError && result.text && (cmd === 'snapshot' || cmd === 's')) {
-    const outDir = path.join(os.homedir(), 'pw-snapshots');
-    fs.mkdirSync(outDir, { recursive: true });
-    const outPath = path.join(outDir, `pw-snapshot-${Date.now()}.yaml`);
-    fs.writeFileSync(outPath, result.text);
-    if (!silent) console.log(`${c.dim}Snapshot saved to ${outPath}${c.reset}`);
-  }
 }
 
 // ─── Bridge replay mode ──────────────────────────────────────────────────────
@@ -769,7 +760,7 @@ async function runSingleBridgeFile(
 
     const result = await srv.run(cmd);
     const elapsed = (performance.now() - startTime).toFixed(0);
-    displayBridgeResult(result, silent, cmd);
+    displayBridgeResult(result, silent);
     log(`${c.dim}(${elapsed}ms)${c.reset}`);
 
     if (result.isError) {
@@ -928,7 +919,7 @@ async function startBridgeLoop(opts: ReplOpts, srv: BridgeServer): Promise<void>
     const runOpts = opts.includeSnapshot ? { includeSnapshot: true } : undefined;
     const result = await srv.run(command, runOpts);
     const elapsed = (performance.now() - startTime).toFixed(0);
-    displayBridgeResult(result, silent, command);
+    displayBridgeResult(result, silent);
     log(`${c.dim}(${elapsed}ms)${c.reset}`);
   }
 
@@ -1132,7 +1123,7 @@ export async function startRepl(opts: ReplOpts = {}): Promise<void> {
         log(`${c.green}✓${c.reset} Browser ready (with extension)`);
         if (opts.command) {
           const result = await conn.run(opts.command);
-          displayBridgeResult(result, silent, opts.command);
+          displayBridgeResult(result, silent);
           await conn.close();
           process.exit(result.isError ? 1 : 0);
         }
@@ -1175,7 +1166,7 @@ export async function startRepl(opts: ReplOpts = {}): Promise<void> {
     if (opts.command) {
       await srv.waitForConnection(30000);
       const result = await srv.run(opts.command);
-      displayBridgeResult(result, silent, opts.command);
+      displayBridgeResult(result, silent);
       srv.close();
       process.exit(result.isError ? 1 : 0);
     }
@@ -1223,7 +1214,7 @@ export async function startRepl(opts: ReplOpts = {}): Promise<void> {
       return; // unreachable, but satisfies TS control-flow
     }
     const result = await conn.run(parsed);
-    displayBridgeResult(result, silent, opts.command);
+    displayBridgeResult(result, silent);
     conn.close();
     process.exit(result.isError ? 1 : 0);
   }

--- a/packages/cli/src/repl.ts
+++ b/packages/cli/src/repl.ts
@@ -1123,7 +1123,7 @@ export async function startRepl(opts: ReplOpts = {}): Promise<void> {
         log(`${c.green}✓${c.reset} Browser ready (with extension)`);
         if (opts.command) {
           const result = await conn.run(opts.command);
-          displayBridgeResult(result, silent);
+          process.stdout.write((result.text ?? '') + '\n');
           await conn.close();
           process.exit(result.isError ? 1 : 0);
         }
@@ -1166,7 +1166,7 @@ export async function startRepl(opts: ReplOpts = {}): Promise<void> {
     if (opts.command) {
       await srv.waitForConnection(30000);
       const result = await srv.run(opts.command);
-      displayBridgeResult(result, silent);
+      process.stdout.write((result.text ?? '') + '\n');
       srv.close();
       process.exit(result.isError ? 1 : 0);
     }
@@ -1214,7 +1214,7 @@ export async function startRepl(opts: ReplOpts = {}): Promise<void> {
       return; // unreachable, but satisfies TS control-flow
     }
     const result = await conn.run(parsed);
-    displayBridgeResult(result, silent);
+    process.stdout.write((result.text ?? '') + '\n');
     conn.close();
     process.exit(result.isError ? 1 : 0);
   }

--- a/packages/cli/src/repl.ts
+++ b/packages/cli/src/repl.ts
@@ -700,7 +700,7 @@ function isComplete(code: string): boolean {
 
 // ─── Bridge shared helpers ───────────────────────────────────────────────────
 
-function displayBridgeResult(result: EngineResult, silent: boolean): void {
+function displayBridgeResult(result: EngineResult, silent: boolean, command?: string): void {
   if (result.image) {
     const isPdf = result.image.startsWith('data:application/pdf');
     const outDir = path.join(os.homedir(), isPdf ? 'pw-pdfs' : 'pw-screenshots');
@@ -718,6 +718,16 @@ function displayBridgeResult(result: EngineResult, silent: boolean): void {
     } else {
       console.log(result.isError ? `${c.red}${result.text}${c.reset}` : result.text);
     }
+  }
+
+  // Save snapshot to file when command is snapshot (or includes snapshot output)
+  const cmd = command?.trim().toLowerCase() ?? '';
+  if (!result.isError && result.text && (cmd === 'snapshot' || cmd === 's')) {
+    const outDir = path.join(os.homedir(), 'pw-snapshots');
+    fs.mkdirSync(outDir, { recursive: true });
+    const outPath = path.join(outDir, `pw-snapshot-${Date.now()}.yaml`);
+    fs.writeFileSync(outPath, result.text);
+    if (!silent) console.log(`${c.dim}Snapshot saved to ${outPath}${c.reset}`);
   }
 }
 
@@ -759,7 +769,7 @@ async function runSingleBridgeFile(
 
     const result = await srv.run(cmd);
     const elapsed = (performance.now() - startTime).toFixed(0);
-    displayBridgeResult(result, silent);
+    displayBridgeResult(result, silent, cmd);
     log(`${c.dim}(${elapsed}ms)${c.reset}`);
 
     if (result.isError) {
@@ -918,7 +928,7 @@ async function startBridgeLoop(opts: ReplOpts, srv: BridgeServer): Promise<void>
     const runOpts = opts.includeSnapshot ? { includeSnapshot: true } : undefined;
     const result = await srv.run(command, runOpts);
     const elapsed = (performance.now() - startTime).toFixed(0);
-    displayBridgeResult(result, silent);
+    displayBridgeResult(result, silent, command);
     log(`${c.dim}(${elapsed}ms)${c.reset}`);
   }
 
@@ -1122,7 +1132,7 @@ export async function startRepl(opts: ReplOpts = {}): Promise<void> {
         log(`${c.green}✓${c.reset} Browser ready (with extension)`);
         if (opts.command) {
           const result = await conn.run(opts.command);
-          process.stdout.write((result.text ?? '') + '\n');
+          displayBridgeResult(result, silent, opts.command);
           await conn.close();
           process.exit(result.isError ? 1 : 0);
         }
@@ -1165,7 +1175,7 @@ export async function startRepl(opts: ReplOpts = {}): Promise<void> {
     if (opts.command) {
       await srv.waitForConnection(30000);
       const result = await srv.run(opts.command);
-      process.stdout.write((result.text ?? '') + '\n');
+      displayBridgeResult(result, silent, opts.command);
       srv.close();
       process.exit(result.isError ? 1 : 0);
     }
@@ -1213,7 +1223,7 @@ export async function startRepl(opts: ReplOpts = {}): Promise<void> {
       return; // unreachable, but satisfies TS control-flow
     }
     const result = await conn.run(parsed);
-    process.stdout.write((result.text ?? '') + '\n');
+    displayBridgeResult(result, silent, opts.command);
     conn.close();
     process.exit(result.isError ? 1 : 0);
   }


### PR DESCRIPTION
## Summary
- Add `packages/cli/skills/SKILL.md` — AI skill teaching agents to use `pw-cli` via Bash
- Covers all commands: core, navigation, keyboard, inspection, assertions, tabs, storage, network, video, devtools
- Includes workflow examples and best practices
- Update CLI README with install instructions for Claude Code and Cursor

## Install
```bash
mkdir -p .claude/skills
cp node_modules/playwright-repl/skills/SKILL.md .claude/skills/playwright-repl.md
```

## Test plan
- [ ] Manual: install skill, verify agent can use pw-cli commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)