### PR TITLE
fix: remove in-page REC overlay from video capture

### DIFF
--- a/packages/extension/src/background.ts
+++ b/packages/extension/src/background.ts
@@ -294,45 +294,10 @@ chrome.tabs.onRemoved.addListener((tabId) => {
   }
 });
 
-// ─── Recording Overlay ──────────────────────────────────────────────────────
-
-function injectRecordingOverlay(tabId: number) {
-  chrome.scripting.executeScript({
-    target: { tabId },
-    func: () => {
-      if (document.getElementById('__pw_rec_overlay')) return;
-      const el = document.createElement('div');
-      el.id = '__pw_rec_overlay';
-      el.textContent = '● REC';
-      const style = document.createElement('style');
-      style.id = '__pw_rec_style';
-      style.textContent = `@keyframes __pw_rec_dot { 0%,100%{opacity:1} 50%{opacity:0.2} }`;
-      document.documentElement.appendChild(style);
-      el.innerHTML = '<span style="color:#ff4444;animation:__pw_rec_dot 1.5s ease-in-out infinite;display:inline-block;font-size:16px;vertical-align:middle;line-height:1">●</span> REC';
-      Object.assign(el.style, {
-        position: 'fixed', top: '8px', right: '8px', zIndex: '2147483647',
-        background: 'rgba(0,0,0,0.75)', color: '#ffffff',
-        padding: '4px 10px', borderRadius: '4px',
-        fontSize: '12px', fontFamily: 'monospace', fontWeight: 'bold',
-        pointerEvents: 'none', userSelect: 'none',
-      });
-      document.documentElement.appendChild(el);
-    },
-  }).catch(e => console.debug('[pw-repl] overlay inject:', e));
-}
-
-function removeRecordingOverlay(tabId: number) {
-  chrome.scripting.executeScript({
-    target: { tabId },
-    func: () => { document.getElementById('__pw_rec_overlay')?.remove(); document.getElementById('__pw_rec_style')?.remove(); },
-  }).catch(e => console.debug('[pw-repl] overlay remove:', e));
-}
-
 // ─── Video Capture ──────────────────────────────────────────────────────────
 
 let videoRecording = false;
 let videoStartTime = 0;
-let videoTabId: number | null = null;
 
 async function startVideoCapture(): Promise<{ ok: boolean; error?: string }> {
   if (videoRecording) return { ok: false, error: 'Already recording' };
@@ -353,8 +318,6 @@ async function startVideoCapture(): Promise<{ ok: boolean; error?: string }> {
     if (result?.ok) {
       videoRecording = true;
       videoStartTime = Date.now();
-      videoTabId = tabId;
-      injectRecordingOverlay(tabId);
     }
     return result ?? { ok: false, error: 'No response from offscreen document' };
   } catch (e) {
@@ -368,8 +331,6 @@ async function stopVideoCapture(): Promise<{ ok: boolean; error?: string; blobUr
   const duration = Math.round((Date.now() - videoStartTime) / 1000);
   const result = await chrome.runtime.sendMessage({ type: 'video-capture-stop' });
   videoRecording = false;
-  if (videoTabId) removeRecordingOverlay(videoTabId);
-  videoTabId = null;
 
   if (result?.ok && result.blobUrl) {
     return { ok: true, blobUrl: result.blobUrl, duration, size: result.size };


### PR DESCRIPTION
## Summary
- Removes the in-page REC overlay that was being captured in video recordings
- The toolbar video button already provides recording feedback (state + elapsed time)

Closes #708

## Test plan
- [ ] Record a video in Dramaturg and verify no REC indicator appears in the output
- [ ] Verify the toolbar still shows video recording state and elapsed time

🤖 Generated with [Claude Code](https://claude.com/claude-code)