### PR TITLE
fix: dedupe concurrent browser launches in VS Code extension

### DIFF
--- a/packages/vscode/src/browserController.ts
+++ b/packages/vscode/src/browserController.ts
@@ -37,6 +37,7 @@ export class BrowserController {
   private _vscode: vscodeTypes.VSCode;
   private _logger: vscodeTypes.LogOutputChannel;
   private _browserManager?: BrowserManager;
+  private _launchPromise?: Promise<void>;
   private _recorder?: Recorder;
   private _picker?: Picker;
   private _lastCdpUrl: string | undefined;
@@ -92,14 +93,23 @@ export class BrowserController {
       this._browserManager = this._createBrowserManager(this._logger);
     if (this._browserManager.isRunning())
       return;
+    if (this._launchPromise)
+      return this._launchPromise;
     const resolvedFolder = workspaceFolder
       || this._vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
-    await this._browserManager.launch({
-      browser: 'chromium',
-      headless: false,
-      workspaceFolder: resolvedFolder,
-    });
-    this._notifyViewsConnected();
+    this._launchPromise = (async () => {
+      try {
+        await this._browserManager!.launch({
+          browser: 'chromium',
+          headless: false,
+          workspaceFolder: resolvedFolder,
+        });
+        this._notifyViewsConnected();
+      } finally {
+        this._launchPromise = undefined;
+      }
+    })();
+    return this._launchPromise;
   }
 
   async stop() {


### PR DESCRIPTION
## Summary
- Fixes #710 — on Mac (and other slow-startup machines), running Playwright tests with "Show browser" enabled would launch a second browser instead of reusing the first.
- Root cause: `BrowserController.ensureLaunched()` had no guard against concurrent calls. During the ~7s launch window, `isRunning()` returns `false`, so a second call triggers another `launch()`.
- Fix: cache the in-flight launch promise so concurrent callers await the same launch.

## Test plan
- [x] Check "Show browser", click "Launch browser", immediately click "Run tests" — only one browser opens.
- [ ] Verify existing test run flow still works when browser is already fully launched.
- [ ] Verify behavior is unchanged when "Show browser" is off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)