### PR TITLE
fix: route pick locator and recording through BrowserController (#712)

### DIFF
--- a/packages/vscode/src/browserController.ts
+++ b/packages/vscode/src/browserController.ts
@@ -127,8 +127,9 @@ export class BrowserController {
   // ─── Recording ──────────────────────────────────────────────────────────
 
   async startRecording() {
+    await this.ensureLaunched();
     if (!this._browserManager?.isRunning()) {
-      this._vscode.window.showWarningMessage('Launch browser first.');
+      this._vscode.window.showWarningMessage('Could not launch browser.');
       return;
     }
     if (!this._recorder)
@@ -145,8 +146,9 @@ export class BrowserController {
   // ─── Picker ─────────────────────────────────────────────────────────────
 
   async pickLocator() {
+    await this.ensureLaunched();
     if (!this._browserManager?.isRunning()) {
-      this._vscode.window.showWarningMessage('Launch browser first.');
+      this._vscode.window.showWarningMessage('Could not launch browser.');
       return;
     }
     this._ensurePicker();

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -232,7 +232,10 @@ export class Extension implements RunHooks {
           await vscode.window.showWarningMessage(messageNoPlaywrightTestsFound);
           return;
         }
-        await this._reusedBrowser.inspect(this._models);
+        if (this._settingsModel.showBrowser.get())
+          await this._browserController.pickLocator();
+        else
+          await this._reusedBrowser.inspect(this._models);
       }),
       vscode.commands.registerCommand('playwright-repl.closeBrowsers', () => {
         this._reusedBrowser.closeAllBrowsers();
@@ -254,7 +257,10 @@ export class Extension implements RunHooks {
         try {
           await this._settingsModel.showBrowser.set(true);
           await this._showBrowserForRecording(file, project);
-          await this._reusedBrowser.record(model, project.project);
+          if (showBrowser)
+            await this._browserController.startRecording();
+          else
+            await this._reusedBrowser.record(model, project.project);
         } finally {
           await this._settingsModel.showBrowser.set(showBrowser);
         }
@@ -263,9 +269,13 @@ export class Extension implements RunHooks {
         const model = this._models.selectedModel();
         if (!model)
           return vscode.window.showWarningMessage(messageNoPlaywrightTestsFound);
-        const openTestCase = this._testUnderDebug?.testCase ?? (this._settingsModel.showBrowser.get() ? this._lastBeganTest : undefined);
-        const project = openTestCase ? ancestorProject(openTestCase) : model.enabledProjects()[0]?.project;
-        await this._reusedBrowser.record(model, project);
+        if (this._settingsModel.showBrowser.get()) {
+          await this._browserController.startRecording();
+        } else {
+          const openTestCase = this._testUnderDebug?.testCase ?? undefined;
+          const project = openTestCase ? ancestorProject(openTestCase) : model.enabledProjects()[0]?.project;
+          await this._reusedBrowser.record(model, project);
+        }
       }),
       vscode.commands.registerCommand('playwright-repl.toggleModels', async () => {
         this._settingsView.toggleModels();

--- a/packages/vscode/tests/unit/browser-controller.test.ts
+++ b/packages/vscode/tests/unit/browser-controller.test.ts
@@ -130,9 +130,10 @@ describe('BrowserController', () => {
     expect(views.replView.notifyBrowserDisconnected).toHaveBeenCalled();
   });
 
-  it('startRecording should warn when browser not running', async () => {
+  it('startRecording should auto-launch and warn if launch fails', async () => {
     await controller.startRecording();
-    expect(vscode.window.showWarningMessage).toHaveBeenCalledWith('Launch browser first.');
+    expect(mockBm.launch).toHaveBeenCalled();
+    expect(vscode.window.showWarningMessage).toHaveBeenCalledWith('Could not launch browser.');
   });
 
   it('stopRecording should update settingsView', () => {
@@ -140,9 +141,10 @@ describe('BrowserController', () => {
     expect(views.settingsView.setRecording).toHaveBeenCalledWith(false);
   });
 
-  it('pickLocator should warn when browser not running', async () => {
+  it('pickLocator should auto-launch and warn if launch fails', async () => {
     await controller.pickLocator();
-    expect(vscode.window.showWarningMessage).toHaveBeenCalledWith('Launch browser first.');
+    expect(mockBm.launch).toHaveBeenCalled();
+    expect(vscode.window.showWarningMessage).toHaveBeenCalledWith('Could not launch browser.');
   });
 
   it('onWillRunTests should return connection info when browser is running with CDP', async () => {


### PR DESCRIPTION
## Summary
- `pickLocator()` and `startRecording()` in `BrowserController` now `await ensureLaunched()` first, participating in the shared launch promise instead of bailing during the ~7s launch window
- `inspect`, `recordNew`, and `recordAtCursor` commands route through `BrowserController` when `showBrowser` is on, falling back to `ReusedBrowser` only for headless/debug mode
- Updated unit tests to reflect new auto-launch behavior

## Test plan
- [x] Unit tests pass (91/91)
- [ ] Enable "Show browser" → click "Launch browser" → within launch window, click "Pick locator" → should wait for launch, not open a second browser
- [ ] Enable "Show browser" → "Pick locator" without launching → should auto-launch then pick
- [ ] Enable "Show browser" → "Record at cursor" → should record via BrowserController
- [ ] Disable "Show browser" → "Pick locator" → should use ReusedBrowser as before

Closes #712

🤖 Generated with [Claude Code](https://claude.com/claude-code)