### PR TITLE
fix: use close instead of exit to prevent truncated child process output

### DIFF
--- a/packages/vscode/src/utils.ts
+++ b/packages/vscode/src/utils.ts
@@ -50,7 +50,7 @@ export async function spawnAsync(executable: string, args: string[], cwd?: strin
   childProcess.stdout.on('data', data => output += data.toString());
   return new Promise<string>((f, r) => {
     childProcess.on('error', error => r(error));
-    childProcess.on('exit', () => f(output));
+    childProcess.on('close', () => f(output));
   });
 }
 

--- a/packages/vscode/tests/playwright/mock/vscode.ts
+++ b/packages/vscode/tests/playwright/mock/vscode.ts
@@ -904,7 +904,7 @@ class Debug {
       });
     });
     this._debuggerProcess.stderr.on('data', data => this.output += data.toString());
-    this._debuggerProcess.on('exit', () => this._didTerminateDebugSession.fire(session));
+    this._debuggerProcess.on('close', () => this._didTerminateDebugSession.fire(session));
     return true;
   }
 


### PR DESCRIPTION
## Summary
- `spawnAsync` in `utils.ts` used `exit` instead of `close`, causing truncated stdout on macOS CI under load
- Mock debug session in `vscode.ts` had the same `exit` → `close` bug, causing flaky debug tests
- Node.js `exit` fires before stdio pipes drain; `close` waits for full flush

## Root cause of #714
`playwrightFinder` output was truncated → `JSON.parse` threw `Unexpected end of JSON input` → extension skipped config activation → tests produced empty results

## Test plan
- [x] All 178 Playwright mock tests pass locally
- [ ] CI passes on macOS (the environment where failures occurred)

Closes #714

🤖 Generated with [Claude Code](https://claude.com/claude-code)