### PR TITLE
fix: add timeouts to prevent silent hangs in bridge, SW, and HTTP endpoints

### DIFF
--- a/packages/cli/src/engine.ts
+++ b/packages/cli/src/engine.ts
@@ -96,7 +96,10 @@ export class Engine {
     // Launch/connect mode.
     {
       // Launch/connect mode: eagerly create context for immediate feedback.
-      const browser = await deps.createBrowser(config, clientInfo);
+      const browser = await Promise.race([
+        deps.createBrowser(config, clientInfo),
+        new Promise<never>((_, reject) => setTimeout(() => reject(new Error('Browser launch timed out after 30s')), 30000)),
+      ]);
       const browserContext = browser.contexts()[0] || await browser.newContext();
       this._browserContext = browserContext;
       this._close = () => browser.close();
@@ -316,7 +319,7 @@ export class Engine {
       }
 
       try {
-        const res = await fetch(`${cdpUrl}/json/version`);
+        const res = await fetch(`${cdpUrl}/json/version`, { signal: AbortSignal.timeout(5000) });
         if (!res.ok) {
           console.warn(`Reconnect attempt ${attempt}: CDP responded with status ${res.status}`);
           continue;

--- a/packages/core/src/bridge-server.ts
+++ b/packages/core/src/bridge-server.ts
@@ -71,7 +71,13 @@ export class BridgeServer {
 
             ws.on('pong', () => { (ws as any)._alive = true; });
             ws.on('message', (data) => {
-                const msg = JSON.parse(String(data));
+                let msg;
+                try {
+                    msg = JSON.parse(String(data));
+                } catch (e) {
+                    console.error(`[bridge ${ts()}] malformed message: ${(e as Error).message}`);
+                    return;
+                }
                 // Events from extension (recording, picker) — no request ID
                 if (msg._event) {
                     this._onEvent?.(msg);
@@ -106,28 +112,38 @@ export class BridgeServer {
         }, 30000);
     }
 
-    async run(command: string, opts?: { includeSnapshot?: boolean }): Promise<EngineResult> {
+    async run(command: string, opts?: { includeSnapshot?: boolean; timeout?: number }): Promise<EngineResult> {
         if (!this.connected) {
             try { await this.waitForConnection(10000); }
             catch { return { text: 'Extension not connected', isError: true }; }
         }
         const id = Math.random().toString(36).slice(2);
+        const timeoutMs = opts?.timeout ?? 30000;
         return new Promise((resolve) => {
-            this.pending.set(id, resolve);
+            const timer = setTimeout(() => {
+                this.pending.delete(id);
+                resolve({ text: `Command timed out after ${timeoutMs}ms: ${command}`, isError: true });
+            }, timeoutMs);
+            this.pending.set(id, (result) => { clearTimeout(timer); resolve(result); });
             const msg: Record<string, unknown> = { id, command, type: 'command' };
             if (opts?.includeSnapshot) msg.includeSnapshot = true;
             this.socket!.send(JSON.stringify(msg));
         });
     }
 
-    async runScript(script: string, language: 'pw' | 'javascript' = 'pw'): Promise<EngineResult> {
+    async runScript(script: string, language: 'pw' | 'javascript' = 'pw', opts?: { timeout?: number }): Promise<EngineResult> {
         if (!this.connected) {
             try { await this.waitForConnection(10000); }
             catch { return { text: 'Extension not connected', isError: true }; }
         }
         const id = Math.random().toString(36).slice(2);
+        const timeoutMs = opts?.timeout ?? 30000;
         return new Promise((resolve) => {
-            this.pending.set(id, resolve);
+            const timer = setTimeout(() => {
+                this.pending.delete(id);
+                resolve({ text: `Script timed out after ${timeoutMs}ms`, isError: true });
+            }, timeoutMs);
+            this.pending.set(id, (result) => { clearTimeout(timer); resolve(result); });
             this.socket!.send(JSON.stringify({ id, command: script, type: 'script', language }));
         });
     }

--- a/packages/core/src/evaluate-connection.ts
+++ b/packages/core/src/evaluate-connection.ts
@@ -88,16 +88,18 @@ export class EvaluateConnection {
 
     // Get the extension's service worker
     let sw = this._context.serviceWorkers()[0];
-    if (!sw) sw = await this._context.waitForEvent('serviceworker');
+    if (!sw) sw = await this._context.waitForEvent('serviceworker', { timeout: 10000 });
     this._sw = sw;
 
     // Wait for handleBridgeCommand to be available
-    await sw.evaluate(async () => {
+    const ready = await sw.evaluate(async () => {
       for (let i = 0; i < 50; i++) {
-        if ((self as any).handleBridgeCommand) return;
+        if ((self as any).handleBridgeCommand) return true;
         await new Promise(r => setTimeout(r, 100));
       }
+      return false;
     });
+    if (!ready) throw new Error('Service worker handleBridgeCommand not available after 5s');
 
     // Navigate to blank page so the extension can attach to a tab
     const page = this._context.pages()[0] || await this._context.newPage();

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -82,7 +82,7 @@ function startHttpServer(port: number, r: Runner) {
                 const body = await readBody(req);
                 ({ command } = JSON.parse(body));
                 logHttp(`→ ${command}`);
-                const result = await r.runCommand(command);
+                const result = await withTimeout(r.runCommand(command), 30000, `Command timed out after 30s: ${command}`);
                 const ms = Date.now() - t0;
                 logHttp(`${result.isError ? '✗' : '✓'} ${command} (${ms}ms)`);
                 res.writeHead(200, { 'Content-Type': 'application/json' });
@@ -104,7 +104,7 @@ function startHttpServer(port: number, r: Runner) {
                 language = parsed.language || 'pw';
                 const preview = script.split('\n')[0].slice(0, 60);
                 logHttp(`→ [${language}] ${preview}${script.length > preview.length ? '…' : ''}`);
-                const result = await r.runScript(script, language as 'pw' | 'javascript');
+                const result = await withTimeout(r.runScript(script, language as 'pw' | 'javascript'), 30000, `Script timed out after 30s`);
                 const ms = Date.now() - t0;
                 logHttp(`${result.isError ? '✗' : '✓'} [${language}] (${ms}ms)`);
                 res.writeHead(200, { 'Content-Type': 'application/json' });
@@ -127,12 +127,26 @@ function startHttpServer(port: number, r: Runner) {
     });
 }
 
-function readBody(req: http.IncomingMessage): Promise<string> {
+function withTimeout<T>(promise: Promise<T>, ms: number, message: string): Promise<T> {
+    return new Promise((resolve, reject) => {
+        const timer = setTimeout(() => reject(new Error(message)), ms);
+        promise.then(
+            (v) => { clearTimeout(timer); resolve(v); },
+            (e) => { clearTimeout(timer); reject(e); },
+        );
+    });
+}
+
+function readBody(req: http.IncomingMessage, timeoutMs = 5000): Promise<string> {
     return new Promise((resolve, reject) => {
         let data = '';
+        const timer = setTimeout(() => {
+            req.destroy();
+            reject(new Error(`Request body read timed out after ${timeoutMs}ms`));
+        }, timeoutMs);
         req.on('data', (chunk: string) => data += chunk);
-        req.on('end', () => resolve(data));
-        req.on('error', reject);
+        req.on('end', () => { clearTimeout(timer); resolve(data); });
+        req.on('error', (e: Error) => { clearTimeout(timer); reject(e); });
     });
 }
 

--- a/packages/vscode/src/browser.ts
+++ b/packages/vscode/src/browser.ts
@@ -110,11 +110,12 @@ export class BrowserManager implements IBrowserManager {
     try {
       const http = await import('node:http');
       const versionData = await new Promise<any>((resolve, reject) => {
-        http.get(`http://127.0.0.1:${cdpPort}/json/version`, res => {
+        const timer = setTimeout(() => { req.destroy(); reject(new Error('CDP discovery timed out')); }, 5000);
+        const req = http.get(`http://127.0.0.1:${cdpPort}/json/version`, res => {
           let data = '';
           res.on('data', (chunk: string) => data += chunk);
-          res.on('end', () => { try { resolve(JSON.parse(data)); } catch (e) { reject(e); } });
-        }).on('error', reject);
+          res.on('end', () => { clearTimeout(timer); try { resolve(JSON.parse(data)); } catch (e) { reject(e); } });
+        }).on('error', (e) => { clearTimeout(timer); reject(e); });
       });
       if (versionData.webSocketDebuggerUrl) {
         this._cdpUrl = versionData.webSocketDebuggerUrl;


### PR DESCRIPTION
## Summary
- Add timeouts to 6 async operations that could hang indefinitely
- Wrap unguarded `JSON.parse` in bridge WebSocket handler with try-catch
- Prerequisite for AI integration (#703) where rapid command loops need fast failure

## Changes
| Location | Timeout | What it prevents |
|----------|---------|-----------------|
| `evaluate-connection.ts` waitForEvent | 10s | Hang waiting for service worker |
| `evaluate-connection.ts` SW readiness | 5s | Silent undefined on timeout |
| `bridge-server.ts` JSON.parse | — | Crash on malformed WS message |
| `bridge-server.ts` run/runScript | 30s | Hang on unresponsive extension |
| `mcp/index.ts` readBody + runner calls | 5s/30s | HTTP endpoint hangs |
| `engine.ts` createBrowser | 30s | Indefinite browser launch |
| `engine.ts` CDP reconnect fetch | 5s | Hung fetch during reconnect |
| `browser.ts` CDP discovery | 5s | Hung http.get to CDP port |

## Test plan
- [x] All 1054 unit tests pass across core, cli, extension, vscode
- [ ] CI green

Closes #704

🤖 Generated with [Claude Code](https://claude.com/claude-code)