### PR TITLE
fix: preserve quotes inside parens for CSS pseudo-class locators

### DIFF
--- a/packages/core/src/parser.ts
+++ b/packages/core/src/parser.ts
@@ -87,18 +87,31 @@ function tokenize(line: string): string[] {
   const tokens: string[] = [];
   let current = '';
   let inQuote: string | null = null;
+  // Track parenthesis depth — inside parens, whitespace and quotes are preserved
+  // so CSS locators like `div:has-text("RFCP")` stay as a single token.
+  let parenDepth = 0;
 
   for (let i = 0; i < line.length; i++) {
     const ch = line[i];
     if (inQuote) {
       if (ch === inQuote) {
         inQuote = null;
+        // Quotes inside parens are part of the CSS syntax — keep them
+        if (parenDepth > 0) current += ch;
       } else {
         current += ch;
       }
     } else if (ch === '"' || ch === "'") {
       inQuote = ch;
-    } else if (ch === ' ' || ch === '\t') {
+      // Quotes inside parens are part of the CSS syntax — keep them
+      if (parenDepth > 0) current += ch;
+    } else if (ch === '(') {
+      parenDepth++;
+      current += ch;
+    } else if (ch === ')') {
+      parenDepth = Math.max(0, parenDepth - 1);
+      current += ch;
+    } else if ((ch === ' ' || ch === '\t') && parenDepth === 0) {
       if (current) {
         tokens.push(current);
         current = '';

--- a/packages/core/test/parser.test.ts
+++ b/packages/core/test/parser.test.ts
@@ -101,6 +101,57 @@ describe('parseInput', () => {
   });
 });
 
+// ─── CSS locator pseudo-classes (Playwright non-standard CSS) ───────────────
+
+describe('CSS locator pseudo-classes', () => {
+  it('preserves quotes inside :has-text() — double quotes', () => {
+    const args = parseInput('highlight div:has-text("RFCP")');
+    expect(args._).toEqual(['highlight', 'div:has-text("RFCP")']);
+  });
+
+  it('preserves quotes inside :has-text() — single quotes', () => {
+    const args = parseInput("highlight div:has-text('RFCP')");
+    expect(args._).toEqual(['highlight', "div:has-text('RFCP')"]);
+  });
+
+  it('preserves spaces inside :has-text()', () => {
+    const args = parseInput('highlight div:has-text("Hello World")');
+    expect(args._).toEqual(['highlight', 'div:has-text("Hello World")']);
+  });
+
+  it('preserves quotes inside :text()', () => {
+    const args = parseInput('highlight button:text("Submit")');
+    expect(args._).toEqual(['highlight', 'button:text("Submit")']);
+  });
+
+  it('preserves quotes inside :text-is()', () => {
+    const args = parseInput('highlight span:text-is("Exact")');
+    expect(args._).toEqual(['highlight', 'span:text-is("Exact")']);
+  });
+
+  it('preserves quotes inside :text-matches() with regex', () => {
+    const args = parseInput('highlight div:text-matches("^RFCP$")');
+    expect(args._).toEqual(['highlight', 'div:text-matches("^RFCP$")']);
+  });
+
+  it('handles nested parens in :has()', () => {
+    const args = parseInput('highlight div:has(button:has-text("OK"))');
+    expect(args._).toEqual(['highlight', 'div:has(button:has-text("OK"))']);
+  });
+
+  it('still tokenizes normally outside parens', () => {
+    const args = parseInput('click "Submit" --force');
+    expect(args._).toEqual(['click', 'Submit']);
+    expect(args.force).toBe(true);
+  });
+
+  it('handles CSS locator followed by normal flag', () => {
+    const args = parseInput('highlight div:has-text("RFCP") --clear');
+    expect(args._).toEqual(['highlight', 'div:has-text("RFCP")']);
+    expect(args.clear).toBe(true);
+  });
+});
+
 describe('ALIASES', () => {
   it('maps most aliases to known commands', () => {
     // verify-* aliases map to commands handled as knownExtras in repl.ts,


### PR DESCRIPTION
## Summary

Playwright's non-standard CSS pseudo-class locators (`:has-text("foo")`, `:text()`, `:text-is()`, `:text-matches()`, `:has()`) require quoted string arguments. The REPL tokenizer was stripping quotes during parsing, which broke these locators.

**Before:**
```
pw> highlight div:has-text("RFCP")
Error: "has-text" engine expects a single string
```

**After:**
```
pw> highlight div:has-text("RFCP")
Highlighted
```

## Fix

Track parenthesis depth in the tokenizer. Inside parens, preserve whitespace and quotes so CSS locator syntax stays intact as a single token.

## Test coverage

Added 9 tests in `packages/core/test/parser.test.ts` covering:
- `:has-text()` with single and double quotes
- `:has-text()` with spaces in the string
- `:text()`, `:text-is()`, `:text-matches()` variants
- Nested pseudo-classes: `div:has(button:has-text("OK"))`
- Normal tokenization still works outside parens
- CSS locator followed by a flag

All 124 core tests pass.

Closes #726

## Test plan
- [x] `pnpm --filter @playwright-repl/core run test` — 124 passed
- [x] `pnpm run build` passes
- [ ] Manual: run `highlight div:has-text("RFCP")` in the REPL and confirm it highlights instead of erroring

🤖 Generated with [Claude Code](https://claude.com/claude-code)