### PR TITLE
feat: Polish with AI command (#723)

### DIFF
--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -153,9 +153,29 @@
         "command": "playwright-repl.repl.find",
         "icon": "$(search)",
         "title": "Find in REPL"
+      },
+      {
+        "category": "Playwright REPL",
+        "command": "playwright-repl.polishWithAI",
+        "icon": "$(sparkle)",
+        "title": "Polish with AI"
       }
     ],
     "menus": {
+      "editor/title": [
+        {
+          "command": "playwright-repl.polishWithAI",
+          "when": "resourceFilename =~ /\\.(spec|test)\\.[tj]sx?$/",
+          "group": "navigation"
+        }
+      ],
+      "editor/context": [
+        {
+          "command": "playwright-repl.polishWithAI",
+          "when": "editorHasSelection && resourceFilename =~ /\\.(spec|test)\\.[tj]sx?$/",
+          "group": "1_modification@99"
+        }
+      ],
       "view/title": [
         {
           "command": "playwright-repl.repl.clear",

--- a/packages/vscode/src/ai/polish.ts
+++ b/packages/vscode/src/ai/polish.ts
@@ -1,0 +1,125 @@
+/**
+ * Polish with AI — improves recorded test code in one AI pass.
+ *
+ * Handles range detection, code replacement, and snapshot/revert logic.
+ */
+
+import type * as vscodeTypes from '../vscodeTypes';
+import type { AIProvider } from './provider';
+import type { IBrowserManager } from '../browser';
+
+// ─── Test Detection ─────────────────────────────────────────────────────────
+
+/**
+ * Detect the full range of the test() call enclosing the cursor.
+ * Includes the test declaration line through the closing `});`.
+ */
+export function detectTestRange(
+  vscode: vscodeTypes.VSCode,
+  editor: vscodeTypes.TextEditor,
+): vscodeTypes.Range | undefined {
+  const doc = editor.document;
+  const cursorLine = editor.selection.active.line;
+
+  // Walk backward to find test( opening
+  let braceDepth = 0;
+  let testOpenLine = -1;
+  for (let i = cursorLine; i >= 0; i--) {
+    const line = doc.lineAt(i).text;
+    for (let j = line.length - 1; j >= 0; j--) {
+      if (line[j] === '}') braceDepth++;
+      if (line[j] === '{') braceDepth--;
+    }
+    if (braceDepth < 0 && /(?:^|\s)test\s*\(/.test(line)) {
+      testOpenLine = i;
+      break;
+    }
+  }
+  if (testOpenLine < 0) return undefined;
+
+  // Find the arrow function body opening brace: look for `=> {`
+  let bodyStart = -1;
+  for (let i = testOpenLine; i < doc.lineCount; i++) {
+    const line = doc.lineAt(i).text;
+    if (line.match(/=>\s*\{/)) {
+      bodyStart = i + 1;
+      break;
+    }
+  }
+  if (bodyStart < 0) return undefined;
+
+  // Walk forward to find matching closing `});`
+  braceDepth = 1;
+  for (let i = bodyStart; i < doc.lineCount; i++) {
+    const line = doc.lineAt(i).text;
+    for (const ch of line) {
+      if (ch === '{') braceDepth++;
+      if (ch === '}') braceDepth--;
+      if (braceDepth === 0) {
+        // Include through the end of the closing line (the `});` line)
+        return new vscode.Range(
+          new vscode.Position(testOpenLine, 0),
+          new vscode.Position(i, doc.lineAt(i).text.length),
+        );
+      }
+    }
+  }
+  return undefined;
+}
+
+// ─── Main Entry Point ───────────────────────────────────────────────────────
+
+export async function polishWithAI(
+  vscode: vscodeTypes.VSCode,
+  aiProvider: AIProvider,
+  editor: vscodeTypes.TextEditor,
+  browserManager?: IBrowserManager,
+  range?: vscodeTypes.Range,
+): Promise<void> {
+  // Determine range
+  const targetRange = range || detectTestRange(vscode, editor);
+  if (!targetRange) {
+    vscode.window.showWarningMessage('Place your cursor inside a test() function, or select code to polish.');
+    return;
+  }
+
+  const originalText = editor.document.getText(targetRange);
+  if (!originalText.trim()) {
+    vscode.window.showWarningMessage('No code to polish.');
+    return;
+  }
+
+  // Opportunistic page snapshot
+  let pageSnapshot: string | undefined;
+  if (browserManager?.isRunning()) {
+    try {
+      const result = await browserManager.runCommand('snapshot');
+      if (!result.isError && result.text) pageSnapshot = result.text;
+    } catch { /* ignore — snapshot is optional */ }
+  }
+
+  // Call AI with progress
+  let polished: string;
+  try {
+    polished = await vscode.window.withProgress(
+      { location: 15 /* ProgressLocation.Notification */, title: 'Polishing with AI...' },
+      () => aiProvider.polishCode(originalText, pageSnapshot),
+    );
+  } catch (e: unknown) {
+    vscode.window.showErrorMessage(`Polish failed: ${(e as Error).message}`);
+    return;
+  }
+
+
+  // If AI returned the same code, nothing to do
+  if (polished.trim() === originalText.trim()) {
+    vscode.window.showInformationMessage('Code looks good — no changes needed.');
+    return;
+  }
+
+  // Replace code (user can Ctrl+Z to revert)
+  await editor.edit(editBuilder => {
+    editBuilder.replace(targetRange, polished);
+  });
+}
+

--- a/packages/vscode/src/ai/provider.ts
+++ b/packages/vscode/src/ai/provider.ts
@@ -35,6 +35,7 @@ export interface AIProvider {
     ariaSnapshot: string,
     locator: string,
   ): Promise<AssertionSuggestion[]>;
+  polishCode(code: string, pageSnapshot?: string): Promise<string>;
 }
 
 export class NoModelsAvailableError extends Error {
@@ -95,9 +96,30 @@ export class VSCodeLMProvider implements AIProvider {
 
     return parseSuggestions(fullText);
   }
+
+  async polishCode(code: string, pageSnapshot?: string): Promise<string> {
+    const lm = (this._vscode as any).lm;
+    if (!lm?.selectChatModels)
+      throw new NoModelsAvailableError();
+
+    const models = await lm.selectChatModels();
+    if (!models.length) throw new NoModelsAvailableError();
+    const model = models[0];
+
+    const messages = [
+      this._vscode.LanguageModelChatMessage.User(buildPolishSystemPrompt()),
+      this._vscode.LanguageModelChatMessage.User(buildPolishUserPrompt(code, pageSnapshot)),
+    ];
+
+    const response = await model.sendRequest(messages, {}, new this._vscode.CancellationTokenSource().token);
+    let fullText = '';
+    for await (const chunk of response.text) fullText += chunk;
+
+    return parsePolishResponse(fullText, code);
+  }
 }
 
-// ─── Prompt construction ────────────────────────────────────────────────────
+// ─── Assertion prompt construction ─────────────────────────────────────────
 
 export function buildSystemPrompt(): string {
   return `You are a Playwright test expert helping developers write meaningful assertions.
@@ -172,4 +194,54 @@ export function parseSuggestions(responseText: string): AssertionSuggestion[] {
     result.push(suggestion);
   }
   return result.slice(0, 5); // Cap at 5 suggestions
+}
+
+// ─── Polish prompt construction ────────────────────────────────────────────
+
+export function buildPolishSystemPrompt(): string {
+  return `You are a Playwright test expert. Given test body code, improve it while preserving its intent.
+
+CRITICAL RULES:
+- Return ONLY the improved code. No prose, no explanation, no code fences.
+- PRESERVE the test's intent — do NOT change what the test verifies or add unrelated actions.
+- Return EXACTLY the same structure as the input — if the input is a full test() block, return a full test() block. If the input is just a code fragment, return just the improved fragment.
+- Do NOT add imports, describe() wrappers, or test() wrappers that weren't in the input.
+- If the code is already clean and idiomatic, return it EXACTLY unchanged.
+- Preserve the EXACT original indentation — every line must have the same leading whitespace as the input.
+
+Improvements (apply only when beneficial):
+1. LOCATORS: Replace fragile CSS selectors with semantic locators.
+   Prefer: getByRole() > getByText() > getByTestId() > getByLabel() > CSS.
+2. ASSERTIONS: Add assertions only when clearly missing after state-changing actions.
+3. REDUNDANCY: Remove duplicate or unnecessary steps.
+4. COMMENTS: Add brief comments only for complex multi-step flows (3+ actions).
+
+Do NOT:
+- Rewrite simple tests that are already correct.
+- Add navigation steps the original code doesn't have.
+- Change assertion targets or values.
+- Add comments to single-line test bodies.`;
+}
+
+export function buildPolishUserPrompt(code: string, pageSnapshot?: string): string {
+  const parts: string[] = [];
+  parts.push('Code to polish:', code);
+  if (pageSnapshot) {
+    parts.push('', 'Current page state (may not reflect the code being polished — use as optional context only):');
+    parts.push(pageSnapshot.slice(0, 3000));
+  }
+  return parts.join('\n');
+}
+
+// ─── Polish response parsing ───────────────────────────────────────────────
+
+export function parsePolishResponse(responseText: string, originalCode: string): string {
+  let code = responseText.trim();
+  // Strip code fences if the model wrapped the response
+  const fenceMatch = code.match(/^```(?:typescript|ts|javascript|js)?\s*\n([\s\S]*?)\n```$/);
+  if (fenceMatch) code = fenceMatch[1].trim();
+  // If response is empty or looks like prose, return original
+  if (!code || /^(Here|I |The |This |Sure|Let me)/i.test(code))
+    return originalCode;
+  return code;
 }

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -38,6 +38,7 @@ import { createRequire } from 'node:module';
 import { ReplView } from './replView';
 import { AssertView } from './assertView';
 import { VSCodeLMProvider } from './ai/provider';
+import { polishWithAI } from './ai/polish';
 import { BrowserController } from './browserController';
 
 const stackUtils = new StackUtils({
@@ -370,6 +371,18 @@ export class Extension implements RunHooks {
       }),
       vscode.commands.registerCommand('playwright-repl.repl.find', () => {
         this._replView.toggleSearch();
+      }),
+      vscode.commands.registerCommand('playwright-repl.polishWithAI', async () => {
+        const editor = vscode.window.activeTextEditor;
+        if (!editor) return;
+        const aiProvider = new VSCodeLMProvider(vscode);
+        if (!await aiProvider.isAvailable()) {
+          vscode.window.showWarningMessage('No AI model available. Install GitHub Copilot or another LLM extension.');
+          return;
+        }
+        const selection = editor.selection;
+        const range = selection.isEmpty ? undefined : new vscode.Range(selection.start, selection.end);
+        await polishWithAI(vscode, aiProvider, editor, this._browserController.browserManager, range);
       }),
     ];
 


### PR DESCRIPTION
## Summary
- Add "Polish with AI" sparkle button in editor title bar for `.spec.ts` / `.test.ts` files
- Right-click context menu "Polish with AI" when code is selected
- Uses `vscode.lm` API to improve test code: locator normalization, redundancy removal, assertion additions, comment grouping
- Preserves test intent and structure — returns code unchanged if already clean
- Supports both full test block (auto-detected from cursor) and selected code fragments

## Test plan
- [ ] Open a `.spec.ts` file — sparkle icon appears in editor title bar
- [ ] Place cursor inside a `test()` and click sparkle — polishes the test
- [ ] Select code fragment, right-click → "Polish with AI" — polishes selection
- [ ] Test with clean code — should return unchanged ("Code looks good")
- [ ] Test with fragile CSS selectors — should normalize to role-based locators
- [ ] Ctrl+Z reverts the polish

Closes #723

🤖 Generated with [Claude Code](https://claude.com/claude-code)