### PR TITLE
fix: apply paren-depth tokenizer fix to extension (#726)

### DIFF
--- a/packages/extension/src/panel/lib/commands.ts
+++ b/packages/extension/src/panel/lib/commands.ts
@@ -197,18 +197,31 @@ function tokenize(line: string): string[] {
   const tokens: string[] = [];
   let current = '';
   let inQuote: string | null = null;
+  // Track parenthesis depth — inside parens, whitespace and quotes are preserved
+  // so CSS locators like `div:has-text("RFCP")` stay as a single token.
+  let parenDepth = 0;
 
   for (let i = 0; i < line.length; i++) {
     const ch = line[i];
     if (inQuote) {
       if (ch === inQuote) {
         inQuote = null;
+        // Quotes inside parens are part of the CSS syntax — keep them
+        if (parenDepth > 0) current += ch;
       } else {
         current += ch;
       }
     } else if (ch === '"' || ch === "'") {
       inQuote = ch;
-    } else if (ch === ' ' || ch === '\t') {
+      // Quotes inside parens are part of the CSS syntax — keep them
+      if (parenDepth > 0) current += ch;
+    } else if (ch === '(') {
+      parenDepth++;
+      current += ch;
+    } else if (ch === ')') {
+      parenDepth = Math.max(0, parenDepth - 1);
+      current += ch;
+    } else if ((ch === ' ' || ch === '\t') && parenDepth === 0) {
       if (current) {
         tokens.push(current);
         current = '';

--- a/packages/extension/test/lib/commands.test.ts
+++ b/packages/extension/test/lib/commands.test.ts
@@ -182,6 +182,24 @@ describe("highlight", () => {
     const { jsExpr } = direct("highlight --clear");
     expect(jsExpr).toContain('clearHighlight');
   });
+
+  it("preserves quotes inside :has-text() CSS pseudo-class", () => {
+    const { jsExpr } = direct('highlight div:has-text("RFCP")');
+    expect(jsExpr).toContain('highlightBySelector');
+    expect(jsExpr).toContain('has-text(\\"RFCP\\")');
+  });
+
+  it("preserves single quotes inside :has-text()", () => {
+    const { jsExpr } = direct("highlight div:has-text('RFCP')");
+    expect(jsExpr).toContain('highlightBySelector');
+    expect(jsExpr).toContain("has-text('RFCP')");
+  });
+
+  it("preserves spaces inside :has-text()", () => {
+    const { jsExpr } = direct('highlight div:has-text("Hello World")');
+    expect(jsExpr).toContain('highlightBySelector');
+    expect(jsExpr).toContain('has-text(\\"Hello World\\")');
+  });
 });
 
 describe("press", () => {


### PR DESCRIPTION
## Summary
- The previous fix (c2f0801 / #727) only patched the tokenizer in `packages/core/src/parser.ts` but missed the **duplicate tokenizer** in `packages/extension/src/panel/lib/commands.ts`
- CSS pseudo-class locators like `highlight div:has-text("RFCP")` still broke in the extension because quotes inside parentheses were being stripped
- Applied the same paren-depth tracking fix to the extension's tokenizer

## Test plan
- [x] Added 3 test cases for CSS pseudo-class locators (double quotes, single quotes, spaces inside `:has-text()`)
- [x] All 60 tests pass (32 core parser + 28 extension commands)
- [ ] @mardukbp to verify `highlight div:has-text("RFCP")` works in the extension

🤖 Generated with [Claude Code](https://claude.com/claude-code)