### PR TITLE
feat: iframe support — record and replay with --frame flag

### DIFF
--- a/packages/core/src/parser.ts
+++ b/packages/core/src/parser.ts
@@ -193,6 +193,7 @@ type PageScriptFn = (...args: unknown[]) => Promise<void>;
  */
 export function resolveArgs(args: ParsedArgs): ParsedArgs {
   const cmdName = args._[0];
+  const frameSel = args.frame ? String(args.frame) : undefined;
 
   // ── Unified verify command → run-code translation ──────────
   if (cmdName === 'verify') {
@@ -316,6 +317,13 @@ export function resolveArgs(args: ParsedArgs): ParsedArgs {
       ? `return await ${args._[1]}`
       : args._[1];
     args = { _: ['run-code', `async (page) => { ${body} }`] };
+  }
+
+  // ── --frame: wrap run-code to operate inside an iframe ──
+  if (frameSel && args._[0] === 'run-code' && args._[1]) {
+    const inner = args._[1];
+    // Wrap: resolve the frame, then call the inner function with the frame as "page"
+    args = { _: ['run-code', `async (page) => { const __frame = await page.locator(${JSON.stringify(frameSel)}).contentFrame(); return await (${inner})(__frame); }`] };
   }
 
   return args;

--- a/packages/core/test/parser.test.ts
+++ b/packages/core/test/parser.test.ts
@@ -1,6 +1,6 @@
 // @ts-nocheck
 import { describe, it, expect } from 'vitest';
-import { parseInput, ALIASES, ALL_COMMANDS, booleanOptions } from '../src/parser.js';
+import { parseInput, resolveArgs, ALIASES, ALL_COMMANDS, booleanOptions } from '../src/parser.js';
 
 describe('parseInput', () => {
   it('parses a basic command', () => {
@@ -184,6 +184,29 @@ describe('--in option', () => {
     // minimist treats --in as a string option with value "dialog"
     expect(args.in).toBe('dialog');
     expect(args).not.toHaveProperty('in-role');
+  });
+});
+
+describe('--frame flag', () => {
+  it('parses --frame as a string option', () => {
+    const args = parseInput('click "Bis 45 km/h" --frame "#oevd-iframe"');
+    expect(args.frame).toBe('#oevd-iframe');
+    expect(args._).toEqual(['click', 'Bis 45 km/h']);
+  });
+
+  it('wraps run-code with frame resolution in resolveArgs', () => {
+    const args = parseInput('click "Submit" --frame "#myframe"');
+    const resolved = resolveArgs(args);
+    expect(resolved._[0]).toBe('run-code');
+    expect(resolved._[1]).toContain('page.locator("#myframe").contentFrame()');
+    expect(resolved.frame).toBeUndefined();
+  });
+
+  it('does not wrap when --frame is absent', () => {
+    const args = parseInput('click "Submit"');
+    const resolved = resolveArgs(args);
+    expect(resolved._[0]).toBe('run-code');
+    expect(resolved._[1]).not.toContain('contentFrame');
   });
 });
 

--- a/packages/extension/src/background.ts
+++ b/packages/extension/src/background.ts
@@ -260,7 +260,7 @@ async function startRecording(): Promise<{ ok: boolean; url?: string; error?: st
     const tabId = await getActiveTabId();
     if (!tabId) return { ok: false, error: 'No active tab' };
     const tab = await chrome.tabs.get(tabId);
-    await chrome.scripting.executeScript({ target: { tabId }, files: ['content/recorder.js'] });
+    await chrome.scripting.executeScript({ target: { tabId, allFrames: true }, files: ['content/recorder.js'] });
     recordingTabId = tabId;
     return { ok: true, url: tab.url ?? '' };
   } catch (e) {
@@ -279,7 +279,7 @@ async function stopRecording(): Promise<{ ok: boolean }> {
 // Re-inject recorder after navigation (page reload / SPA navigation)
 chrome.tabs.onUpdated.addListener((tabId, changeInfo) => {
   if (tabId === recordingTabId && changeInfo.status === 'complete') {
-    chrome.scripting.executeScript({ target: { tabId }, files: ['content/recorder.js'] }).catch(e => console.debug('[pw-repl] recorder re-inject:', e));
+    chrome.scripting.executeScript({ target: { tabId, allFrames: true }, files: ['content/recorder.js'] }).catch(e => console.debug('[pw-repl] recorder re-inject:', e));
   }
 });
 

--- a/packages/extension/src/content/recorder.ts
+++ b/packages/extension/src/content/recorder.ts
@@ -16,6 +16,68 @@ export const SPECIAL_KEYS = new Set([
     'F1', 'F2', 'F3', 'F4', 'F5', 'F6', 'F7', 'F8', 'F9', 'F10', 'F11', 'F12',
 ]);
 
+// ─── Frame detection ─────────────────────────────────────────────────────
+
+/**
+ * Detect if we're inside an iframe and compute a CSS selector for it.
+ * Returns null if we're in the top frame.
+ *
+ * For same-origin iframes, `window.frameElement` gives us the <iframe> element
+ * in the parent document. For cross-origin iframes, `window.frameElement` is null
+ * due to security restrictions — we fall back to using the frame's src URL.
+ */
+function detectFrameSelector(): string | null {
+    if (window === window.top) return null;
+
+    try {
+        // Same-origin: window.frameElement is accessible
+        const frame = window.frameElement;
+        if (frame) {
+            // Prefer id selector
+            if (frame.id) return `#${CSS.escape(frame.id)}`;
+            // Prefer name attribute
+            const name = frame.getAttribute('name');
+            if (name) return `iframe[name="${name}"]`;
+            // Prefer src attribute
+            const src = frame.getAttribute('src');
+            if (src) return `iframe[src="${src}"]`;
+            // Fall back to tag + nth-of-type
+            const parent = frame.parentElement;
+            if (parent) {
+                const siblings = Array.from(parent.querySelectorAll(':scope > iframe'));
+                const idx = siblings.indexOf(frame);
+                if (siblings.length === 1) return 'iframe';
+                return `iframe:nth-of-type(${idx + 1})`;
+            }
+            return 'iframe';
+        }
+    } catch { /* cross-origin — frameElement throws */ }
+
+    // Cross-origin fallback: use location to build a src-based selector
+    // This is a best-effort approach
+    try {
+        const src = window.location.href;
+        if (src && src !== 'about:blank') return `iframe[src="${src}"]`;
+    } catch { /* cannot access location */ }
+
+    return 'iframe';
+}
+
+/** Cached frame selector — computed once on init */
+let frameSelector: string | null = null;
+
+/**
+ * Wrap recorded commands with frame context if we're inside an iframe.
+ * Prepends --frame flag to PW and .contentFrame() to JS.
+ */
+function wrapWithFrameContext(cmds: { pw: string; js: string }): { pw: string; js: string } {
+    if (!frameSelector) return cmds;
+    return {
+        pw: `${cmds.pw} --frame "${frameSelector}"`,
+        js: `await page.locator(${JSON.stringify(frameSelector)}).contentFrame().${cmds.js.replace(/^await page\./, '')}`,
+    };
+}
+
 // ─── Fill buffering state machine ─────────────────────────────────────────
 
 export let pendingFill: { el: Element; value: string } | null = null;
@@ -46,14 +108,14 @@ export function onClickCapture(e: MouseEvent) {
         if (hoverTarget) {
             const hoverCmds = buildCommands('hover', hoverTarget);
             if (hoverCmds) {
-                chrome.runtime.sendMessage({ type: 'recorded-action', action: hoverCmds });
+                chrome.runtime.sendMessage({ type: 'recorded-action', action: wrapWithFrameContext(hoverCmds) });
             }
         }
     }
 
     const cmds = buildCommands('click', target);
     if (cmds) {
-        chrome.runtime.sendMessage({ type: 'recorded-action', action: cmds });
+        chrome.runtime.sendMessage({ type: 'recorded-action', action: wrapWithFrameContext(cmds) });
     }
 }
 
@@ -68,7 +130,7 @@ export function onInputCapture(e: Event) {
         pendingFill.value = value;
         const cmds = buildCommands('fill', target, { value });
         if (cmds) {
-            chrome.runtime.sendMessage({ type: 'recorded-fill-update', action: cmds });
+            chrome.runtime.sendMessage({ type: 'recorded-fill-update', action: wrapWithFrameContext(cmds) });
         }
     } else {
         // Different element or first input — flush old, start new
@@ -76,7 +138,7 @@ export function onInputCapture(e: Event) {
         pendingFill = { el: target, value };
         const cmds = buildCommands('fill', target, { value });
         if (cmds) {
-            chrome.runtime.sendMessage({ type: 'recorded-action', action: cmds });
+            chrome.runtime.sendMessage({ type: 'recorded-action', action: wrapWithFrameContext(cmds) });
         }
     }
 }
@@ -91,7 +153,7 @@ export function onChangeCapture(e: Event) {
         const checked = (target as HTMLInputElement).checked;
         const cmds = buildCommands(checked ? 'check' : 'uncheck', target);
         if (cmds) {
-            chrome.runtime.sendMessage({ type: 'recorded-action', action: cmds });
+            chrome.runtime.sendMessage({ type: 'recorded-action', action: wrapWithFrameContext(cmds) });
         }
         return;
     }
@@ -102,7 +164,7 @@ export function onChangeCapture(e: Event) {
         const option = target.value;
         const cmds = buildCommands('select', target, { option });
         if (cmds) {
-            chrome.runtime.sendMessage({ type: 'recorded-action', action: cmds });
+            chrome.runtime.sendMessage({ type: 'recorded-action', action: wrapWithFrameContext(cmds) });
         }
         return;
     }
@@ -127,7 +189,7 @@ export function onKeyDownCapture(e: KeyboardEvent) {
         ? buildCommands('press', target, { key: e.key })
         : { pw: `press ${e.key}`, js: `await page.keyboard.press(${escapeString(e.key)});` };
     if (cmds) {
-        chrome.runtime.sendMessage({ type: 'recorded-action', action: cmds });
+        chrome.runtime.sendMessage({ type: 'recorded-action', action: wrapWithFrameContext(cmds) });
     }
 }
 
@@ -160,6 +222,9 @@ export function init() {
     // Guard against double-injection
     if ((window as any).__pw_recorder_active) return;
     (window as any).__pw_recorder_active = true;
+
+    // Detect iframe context once on init
+    frameSelector = detectFrameSelector();
 
     chrome.runtime.onMessage.addListener(onMessage);
     document.addEventListener('click', onClickCapture, true);

--- a/packages/extension/src/panel/lib/commands.ts
+++ b/packages/extension/src/panel/lib/commands.ts
@@ -654,8 +654,17 @@ export function parseReplCommand(input: string): ParseResult {
   // Resolve to DirectExecution, TabOperation, or unrecognised ParsedArgs
   const resolved = resolveArgs(args);
 
-  // DirectExecution
-  if (isDirect(resolved)) return resolved;
+  // DirectExecution — wrap with frame context if --frame was specified
+  if (isDirect(resolved)) {
+    const frameSel = args.frame;
+    if (frameSel && typeof frameSel === 'string') {
+      // Temporarily shadow `page` with the frame so all page-script functions
+      // operate inside the iframe. The original `page` is used to locate the frame.
+      const frameExpr = `await page.locator(${ser(frameSel)}).contentFrame()`;
+      return { jsExpr: `await (async (__page) => { const page = __page; return ${resolved.jsExpr}; })(${frameExpr})` };
+    }
+    return resolved;
+  }
 
   // Unknown command
   const cmdName = args._[0];

--- a/packages/extension/test/background.test.ts
+++ b/packages/extension/test/background.test.ts
@@ -206,7 +206,7 @@ describe("background.ts message handlers", () => {
   it("record-start injects recorder content script and returns url", async () => {
     const result = await sendMessage({ type: 'record-start' });
     expect(chrome.scripting.executeScript).toHaveBeenCalledWith(
-      expect.objectContaining({ target: { tabId: 42 }, files: ['content/recorder.js'] })
+      expect.objectContaining({ target: { tabId: 42, allFrames: true }, files: ['content/recorder.js'] })
     );
     expect(result).toEqual({ ok: true, url: 'https://example.com' });
   });

--- a/packages/extension/test/lib/commands.test.ts
+++ b/packages/extension/test/lib/commands.test.ts
@@ -202,6 +202,40 @@ describe("highlight", () => {
   });
 });
 
+// ─── --frame flag ───────────────────────────────────────────────────────────
+
+describe("--frame flag", () => {
+  it("wraps click with frame context", () => {
+    const { jsExpr } = direct('click "Bis 45 km/h" --frame "#oevd-iframe"');
+    expect(jsExpr).toContain('page.locator("#oevd-iframe").contentFrame()');
+    expect(jsExpr).toContain('"Bis 45 km/h"');
+  });
+
+  it("wraps highlight with frame context", () => {
+    const { jsExpr } = direct('highlight "Submit" --frame "#myframe"');
+    expect(jsExpr).toContain('page.locator("#myframe").contentFrame()');
+    expect(jsExpr).toContain('highlightByText');
+  });
+
+  it("wraps check with frame context", () => {
+    const { jsExpr } = direct('check radio "Accept" --frame "#oevd-iframe"');
+    expect(jsExpr).toContain('page.locator("#oevd-iframe").contentFrame()');
+    expect(jsExpr).toContain('"Accept"');
+  });
+
+  it("wraps fill with frame context", () => {
+    const { jsExpr } = direct('fill "Email" "test@example.com" --frame "#form-frame"');
+    expect(jsExpr).toContain('page.locator("#form-frame").contentFrame()');
+    expect(jsExpr).toContain('"Email"');
+    expect(jsExpr).toContain('"test@example.com"');
+  });
+
+  it("does not wrap when --frame is absent", () => {
+    const { jsExpr } = direct('click "Submit"');
+    expect(jsExpr).not.toContain('contentFrame');
+  });
+});
+
 describe("press", () => {
   it("routes role+name+key to pressKeyByRole", () => {
     const { jsExpr } = direct('press textbox "What needs to be done?" Enter');

--- a/packages/extension/types.d.ts
+++ b/packages/extension/types.d.ts
@@ -32,7 +32,7 @@ declare namespace chrome {
 
   namespace scripting {
     interface ScriptInjection {
-      target: { tabId: number };
+      target: { tabId: number; allFrames?: boolean };
       files?: string[];
       func?: () => void;
     }


### PR DESCRIPTION
## Summary
- Inject recorder content script into all frames (`allFrames: true`) so actions inside iframes are captured (#735)
- Recorder detects iframe context and appends `--frame` flag to PW commands and `.contentFrame()` to JS expressions
- Extension command resolver and core parser handle `--frame` flag for replay (#736)

### Example output for an element inside `#oevd-iframe`:
```
pw: check radio "Bis 45 km/h" --frame "#oevd-iframe"
js: await page.locator("#oevd-iframe").contentFrame().getByRole('radio', { name: 'Bis 45 km/h' }).check();
```

### Files changed
| File | Change |
|------|--------|
| `background.ts` | `allFrames: true` in both `executeScript` calls |
| `recorder.ts` | Frame detection + wraps commands with `--frame` / `.contentFrame()` |
| `commands.ts` | Handles `--frame` by shadowing `page` with frame context |
| `parser.ts` | `--frame` wrapping for CLI run-code path |
| `types.d.ts` | Added `allFrames` to `ScriptInjection.target` type |

## Test plan
- [x] 5 new tests for `--frame` in extension commands
- [x] 3 new tests for `--frame` in core parser
- [x] All 68 tests pass
- [x] Manual test: record click/check inside iframe on provinzial.de — both PW and JS include frame context
- [x] Manual test: replay `click "text" --frame "#oevd-iframe"` works

🤖 Generated with [Claude Code](https://claude.com/claude-code)