### PR TITLE
feat: auto-generate --in instead of --nth in recorder/picker (#742)

### DIFF
--- a/packages/extension/src/background.ts
+++ b/packages/extension/src/background.ts
@@ -372,6 +372,29 @@ async function pickElement(): Promise<{ ok: boolean; info?: any; error?: string 
       for (const attr of el.attributes) attrs[attr.name] = attr.value;
       const tag = el.tagName;
       const inputType = (attrs.type || '').toLowerCase();
+
+      // Detect nearest preceding sibling text (for --in context)
+      // Generic: finds first short leaf text, skipping buttons — works for headings, banners, labels
+      function leafText(node: Node): string {
+        for (const c of node.childNodes) {
+          if (c.nodeType === 3) { const t = (c.textContent || '').trim(); if (t && t.length >= 2 && t.length <= 50) return t; }
+          if (c.nodeType === 1) { const e = c as Element; if (e.matches('button') || e.closest('button')) continue; const t = leafText(e); if (t) return t; }
+        }
+        return '';
+      }
+      let headingContext: string | null = null;
+      let cur = el.parentElement;
+      while (cur && cur !== document.body && cur !== document.documentElement) {
+        for (const child of cur.children) {
+          if (child.contains(el)) break;
+          if (child.matches('a') || child.querySelector('a')) continue; // skip peer items with links
+          const t = leafText(child);
+          if (t) { headingContext = t; break; }
+        }
+        if (headingContext) break;
+        cur = cur.parentElement;
+      }
+
       return {
         tag,
         text: (el as HTMLElement).innerText?.slice(0, 200) ?? '',
@@ -383,6 +406,7 @@ async function pickElement(): Promise<{ ok: boolean; info?: any; error?: string 
         value: ('value' in el) ? (el as HTMLInputElement).value : undefined,
         checked: (tag === 'INPUT' && (inputType === 'checkbox' || inputType === 'radio'))
           ? (el as HTMLInputElement).checked : undefined,
+        headingContext,
       };
     }).catch(() => null);
 

--- a/packages/extension/src/content/locator.ts
+++ b/packages/extension/src/content/locator.ts
@@ -144,6 +144,67 @@ function findContainerAncestor(el: Element): { ancestor: Element; role: string }
     return null;
 }
 
+// ─── Heading-based context disambiguation ────────────────────────────────
+
+/**
+ * Find the first short leaf text in an element, skipping button content.
+ * Generic approach — works for headings, banners, labels, or any structure.
+ */
+function findLeafText(node: Node): string {
+    for (const child of node.childNodes) {
+        if (child.nodeType === Node.TEXT_NODE) {
+            const text = (child.textContent || '').trim();
+            if (text && text.length >= 2 && text.length <= 50) return text;
+        }
+        if (child.nodeType === Node.ELEMENT_NODE) {
+            const el = child as Element;
+            if (el.matches('button') || el.closest('button')) continue;
+            const text = findLeafText(el);
+            if (text) return text;
+        }
+    }
+    return '';
+}
+
+/**
+ * Walk up from el, find the nearest preceding sibling with distinctive text.
+ * Skips siblings that contain links — those are peer items, not section labels.
+ */
+function findNearestHeading(el: Element): { container: Element; text: string } | null {
+    let current = el.parentElement;
+    while (current && current !== document.body && current !== document.documentElement) {
+        for (const child of current.children) {
+            if (child.contains(el)) break; // stop at el's branch
+            // Skip peer items — section labels don't contain navigation links
+            if (child.matches('a') || child.querySelector('a')) continue;
+            const text = findLeafText(child);
+            if (text) return { container: current, text };
+        }
+        current = current.parentElement;
+    }
+    return null;
+}
+
+/**
+ * Try heading-based disambiguation: if each duplicate match has a unique
+ * nearest heading, return the heading text for the target element.
+ */
+function tryHeadingContext(el: Element, matches: Element[]): string | null {
+    const result = findNearestHeading(el);
+    if (!result) return null;
+
+    // Check uniqueness: only one match should share this heading text
+    let count = 0;
+    for (const match of matches) {
+        const mResult = findNearestHeading(match);
+        if (mResult && mResult.text === result.text) {
+            count++;
+            if (count > 1) return null;
+        }
+    }
+    return count === 1 ? result.text : null;
+}
+
 /**
  * Try to disambiguate using ancestor context.
  * Returns a chained locator like:
@@ -345,26 +406,46 @@ const ROLE_SHORTHANDS: Record<string, string> = { listitem: 'list' };
  */
 export function generateLocatorPair(el: Element): { js: string; pw: string; ancestor?: { role: string; text: string } } {
     const jsLocator = generateLocator(el);
-    if (!jsLocator.includes('.filter(')) return { js: jsLocator, pw: jsLocator };
 
-    // JS used ancestor context — extract ancestor info for PW --in flag
-    const role = getImplicitRole(el)!;
-    const name = getAccessibleName(el);
-    const container = findContainerAncestor(el);
-    const contextText = container ? getContextText(container.ancestor, el) : '';
-
-    if (container && contextText) {
-        const pwLocator = `getByRole(${escapeString(role)}, { name: ${escapeString(name)} })`;
-        const shortRole = ROLE_SHORTHANDS[container.role] ?? container.role;
-        return { js: jsLocator, pw: pwLocator, ancestor: { role: shortRole, text: contextText } };
+    // No disambiguation needed — return as-is
+    if (!jsLocator.includes('.filter(') && !jsLocator.includes('.nth(') && !jsLocator.includes('.first()')) {
+        return { js: jsLocator, pw: jsLocator };
     }
 
-    // No ancestor context — fall back to .nth()
-    const matches = findByRoleAndName(role, name);
-    const base = `getByRole(${escapeString(role)}, { name: ${escapeString(name)}, exact: true })`;
-    const idx = matches.indexOf(el);
-    const pwLocator = idx === 0 ? base + '.first()' : base + `.nth(${idx})`;
-    return { js: jsLocator, pw: pwLocator };
+    // JS used ancestor context (.filter chain) — extract ancestor info for PW --in flag
+    if (jsLocator.includes('.filter(')) {
+        const role = getImplicitRole(el)!;
+        const name = getAccessibleName(el);
+        const container = findContainerAncestor(el);
+        const contextText = container ? getContextText(container.ancestor, el) : '';
+
+        if (container && contextText) {
+            const pwLocator = `getByRole(${escapeString(role)}, { name: ${escapeString(name)} })`;
+            const shortRole = ROLE_SHORTHANDS[container.role] ?? container.role;
+            return { js: jsLocator, pw: pwLocator, ancestor: { role: shortRole, text: contextText } };
+        }
+
+        // .filter() present but no container context — fall back to .nth()
+        const matches = findByRoleAndName(role, name);
+        const base = `getByRole(${escapeString(role)}, { name: ${escapeString(name)}, exact: true })`;
+        const idx = matches.indexOf(el);
+        const pwLocator = idx === 0 ? base + '.first()' : base + `.nth(${idx})`;
+        return { js: jsLocator, pw: pwLocator };
+    }
+
+    // .nth()/.first() — try heading context for PW --in flag
+    const role = getImplicitRole(el);
+    const name = getAccessibleName(el);
+    if (role && name) {
+        const matches = findByRoleAndName(role, name);
+        const headingText = tryHeadingContext(el, matches);
+        if (headingText) {
+            const pwLocator = `getByRole(${escapeString(role)}, { name: ${escapeString(name)} })`;
+            return { js: jsLocator, pw: pwLocator, ancestor: { role: '', text: headingText } };
+        }
+    }
+
+    return { js: jsLocator, pw: jsLocator };
 }
 
 // ─── Element classification ─────────────────────────────────────────────
@@ -400,7 +481,9 @@ export function buildCommands(action: string, el: Element, opts?: {
     const role = getImplicitRole(el);
     const pwArgs = locatorToPwArgs(pwLocator, role);
     const q = (s: string) => `"${s}"`;
-    const inFlag = ancestor ? ` --in ${ancestor.role} ${q(ancestor.text)}` : '';
+    const inFlag = ancestor
+        ? ` --in ${ancestor.role ? `${ancestor.role} ` : ''}${q(ancestor.text)}`
+        : '';
 
     switch (action) {
         case 'hover':

--- a/packages/extension/src/panel/components/Toolbar.tsx
+++ b/packages/extension/src/panel/components/Toolbar.tsx
@@ -302,14 +302,14 @@ function Toolbar({ editorContent, editorMode, stepLine, attachedUrl, attachedTab
 
         setIsPicking(true);
         try {
-            const result = await chrome.runtime.sendMessage({ type: 'pick' }) as { ok: boolean; info?: ElementPickInfo & { ariaSnapshot?: string }; error?: string };
+            const result = await chrome.runtime.sendMessage({ type: 'pick' }) as { ok: boolean; info?: ElementPickInfo & { ariaSnapshot?: string; headingContext?: string | null }; error?: string };
             if (!result?.ok || !result.info) {
                 if (result?.error !== 'cancelled')
                     dispatch({ type: 'ADD_LINE', line: { text: `Pick failed: ${result?.error ?? 'unknown error'}`, type: 'error' } });
                 return;
             }
             const info = result.info;
-            const pickResult = buildPickResult(info, info.locator, info.ariaSnapshot);
+            const pickResult = buildPickResult(info, info.locator, info.ariaSnapshot, info.headingContext);
             if (info.ariaSnapshot)
                 pickResult.ariaSnapshot = info.ariaSnapshot;
             dispatch({ type: 'ADD_LINE', line: { text: '', type: 'info', pickResult } });

--- a/packages/extension/src/panel/lib/pick-info.ts
+++ b/packages/extension/src/panel/lib/pick-info.ts
@@ -97,9 +97,11 @@ function parseJsLocator(locator: string): { role?: string; name?: string } {
 /**
  * Derive a .pw keyword command from aria snapshot + locator.
  * Uses aria snapshot as primary source; falls back to JS locator parsing.
+ * When headingContext is provided and --nth is present, replaces --nth with --in "heading".
  */
-function derivePwCommand(info: ElementPickInfo, ariaSnapshot?: string): string | null {
+function derivePwCommand(info: ElementPickInfo, ariaSnapshot?: string, headingContext?: string | null): string | null {
     const nth = extractNth(info.locator);
+    const headingIn = headingContext ? ` --in "${headingContext}"` : '';
 
     // Primary: derive from aria snapshot
     if (ariaSnapshot) {
@@ -112,19 +114,23 @@ function derivePwCommand(info: ElementPickInfo, ariaSnapshot?: string): string |
                 const parentName = parent.name ? ` "${parent.name}"` : '';
                 inFlag = ` --in ${parent.role}${parentName}`;
             }
+            // Prefer heading --in over --nth when no aria parent context exists
+            if (!inFlag && headingIn) {
+                return `highlight ${element.role}${nameArg}${headingIn}`;
+            }
             return `highlight ${element.role}${nameArg}${nth}${inFlag}`;
         }
     }
 
     // Fallback: parse JS locator string
     const { role, name } = parseJsLocator(info.locator);
-    if (role && name) return `highlight ${role} "${name}"${nth}`;
-    if (role) return `highlight ${role}${nth}`;
-    if (name) return `highlight "${name}"${nth}`;
+    if (role && name) return `highlight ${role} "${name}"${headingIn || nth}`;
+    if (role) return `highlight ${role}${headingIn || nth}`;
+    if (name) return `highlight "${name}"${headingIn || nth}`;
 
     // Last resort: element text
     const text = info.text?.trim();
-    if (text && text.length <= 80) return `highlight "${text}"${nth}`;
+    if (text && text.length <= 80) return `highlight "${text}"${headingIn || nth}`;
 
     return null;
 }
@@ -234,7 +240,7 @@ function deriveAssertion(info: ElementPickInfo, locator: string, pwCommand: stri
  * Uses aria snapshot (when available) to derive .pw commands from
  * Playwright's semantic model instead of regex-parsing the JS locator.
  */
-export function buildPickResult(info: ElementPickInfo, cdpLocator?: string | null, ariaSnapshot?: string): PickResultData {
+export function buildPickResult(info: ElementPickInfo, cdpLocator?: string | null, ariaSnapshot?: string, headingContext?: string | null): PickResultData {
     const jsLocator = cdpLocator ?? info.locator;
     const locator = `page.${jsLocator}`;
     const jsExpression = `await page.${jsLocator}.highlight();`;
@@ -243,15 +249,16 @@ export function buildPickResult(info: ElementPickInfo, cdpLocator?: string | nul
     const frame = extractFrameContext(jsLocator);
     const innerLocator = frame ? frame.innerLocator : jsLocator;
     const exact = /exact:\s*true/.test(innerLocator);
-    const pwFlags = (exact ? ' --exact' : '') + (frame ? ` --frame "${frame.frameSelector}"` : '');
+    const extraFlags = (exact ? ' --exact' : '') + (frame ? ` --frame "${frame.frameSelector}"` : '');
+    const headingIn = headingContext ? ` --in "${headingContext}"` : '';
 
-    let pwCommand = derivePwCommand({ ...info, locator: innerLocator }, ariaSnapshot);
-    if (pwCommand) pwCommand += pwFlags;
+    let pwCommand = derivePwCommand({ ...info, locator: innerLocator }, ariaSnapshot, headingContext);
+    if (pwCommand) pwCommand += extraFlags; // --in already inside derivePwCommand
 
     const assertion = deriveAssertion(info, locator, pwCommand, ariaSnapshot);
     const assertJs = assertion.assertJs;
     let assertPw = assertion.assertPw;
-    if (assertPw) assertPw += pwFlags;
+    if (assertPw) assertPw += headingIn + extraFlags; // assertions need --in added here
 
     return {
         locator,

--- a/packages/extension/test/content/locator.test.ts
+++ b/packages/extension/test/content/locator.test.ts
@@ -542,6 +542,95 @@ describe('locator', () => {
             const pair = generateLocatorPair(btn);
             expect(pair.ancestor).toBeUndefined();
         });
+
+        it('uses heading context for PW --in when no container role exists', () => {
+            document.body.innerHTML = `
+                <div>
+                    <h3>Robot Framework</h3>
+                    <div><a href="/rf">RFCP® Certified</a></div>
+                </div>
+                <div>
+                    <h3>Testspezialist</h3>
+                    <div><a href="/ts">RFCP® Certified</a></div>
+                </div>`;
+            const links = document.querySelectorAll('a');
+            const pair0 = generateLocatorPair(links[0]);
+            expect(pair0.js).toContain('.first()');
+            expect(pair0.pw).toBe("getByRole('link', { name: 'RFCP® Certified' })");
+            expect(pair0.ancestor).toEqual({ role: '', text: 'Robot Framework' });
+
+            const pair1 = generateLocatorPair(links[1]);
+            expect(pair1.js).toContain('.nth(1)');
+            expect(pair1.pw).toBe("getByRole('link', { name: 'RFCP® Certified' })");
+            expect(pair1.ancestor).toEqual({ role: '', text: 'Testspezialist' });
+        });
+
+        it('falls back to .nth() when heading text is not unique', () => {
+            document.body.innerHTML = `
+                <div>
+                    <h3>Section</h3>
+                    <div><a href="/a">Same Link</a></div>
+                </div>
+                <div>
+                    <h3>Section</h3>
+                    <div><a href="/b">Same Link</a></div>
+                </div>`;
+            const links = document.querySelectorAll('a');
+            const pair = generateLocatorPair(links[0]);
+            expect(pair.js).toContain('.first()');
+            expect(pair.pw).toContain('.first()');
+            expect(pair.ancestor).toBeUndefined();
+        });
+
+        it('finds heading in nested wrapper before target branch', () => {
+            document.body.innerHTML = `
+                <div>
+                    <div><h2>Alpha</h2></div>
+                    <div><button>Go</button></div>
+                </div>
+                <div>
+                    <div><h2>Beta</h2></div>
+                    <div><button>Go</button></div>
+                </div>`;
+            const buttons = document.querySelectorAll('button');
+            const pair = generateLocatorPair(buttons[1]);
+            expect(pair.pw).toBe("getByRole('button', { name: 'Go' })");
+            expect(pair.ancestor).toEqual({ role: '', text: 'Beta' });
+        });
+
+        it('finds label in banner/accordion preceding the target branch', () => {
+            document.body.innerHTML = `
+                <div>
+                    <div role="banner"><p>Testspezialist</p><button>Aufklappen</button></div>
+                    <div><a href="/rf">RFCP® Certified</a></div>
+                </div>
+                <div>
+                    <div role="banner"><p>Robot Framework</p><button>Zuklappen</button></div>
+                    <div><a href="/rf2">RFCP® Certified</a></div>
+                </div>`;
+            const links = document.querySelectorAll('a');
+            const pair0 = generateLocatorPair(links[0]);
+            expect(pair0.pw).toBe("getByRole('link', { name: 'RFCP® Certified' })");
+            expect(pair0.ancestor).toEqual({ role: '', text: 'Testspezialist' });
+
+            const pair1 = generateLocatorPair(links[1]);
+            expect(pair1.ancestor).toEqual({ role: '', text: 'Robot Framework' });
+        });
+
+        it('finds label in plain div (no role) before target branch', () => {
+            document.body.innerHTML = `
+                <div>
+                    <div class="title">Section A</div>
+                    <div><a href="/a">Same Link</a></div>
+                </div>
+                <div>
+                    <div class="title">Section B</div>
+                    <div><a href="/b">Same Link</a></div>
+                </div>`;
+            const links = document.querySelectorAll('a');
+            const pair = generateLocatorPair(links[1]);
+            expect(pair.ancestor).toEqual({ role: '', text: 'Section B' });
+        });
     });
 
     // ─── locatorToPwArgs ───────────────────────────────────────────────────
@@ -866,6 +955,26 @@ describe('locator', () => {
             const editButtons = [...document.querySelectorAll('button')].filter(b => b.textContent === 'Edit');
             const cmds = buildCommands('click', editButtons[1]);
             expect(cmds!.pw).toBe('click button "Edit" --in row "Bob"');
+        });
+
+        it('uses text-only --in from heading context instead of --nth', () => {
+            document.body.innerHTML = `
+                <div>
+                    <h3>Robot Framework</h3>
+                    <div><a href="/rf">RFCP® Certified</a></div>
+                </div>
+                <div>
+                    <h3>Testspezialist</h3>
+                    <div><a href="/ts">RFCP® Certified</a></div>
+                </div>`;
+            const links = document.querySelectorAll('a');
+            const cmds0 = buildCommands('click', links[0]);
+            expect(cmds0!.pw).toBe('click link "RFCP® Certified" --in "Robot Framework"');
+            expect(cmds0!.js).toContain('.first()');
+            expect(cmds0!.js).toContain('.click()');
+
+            const cmds1 = buildCommands('click', links[1]);
+            expect(cmds1!.pw).toBe('click link "RFCP® Certified" --in "Testspezialist"');
         });
     });
 

--- a/packages/extension/test/lib/pick-info.test.ts
+++ b/packages/extension/test/lib/pick-info.test.ts
@@ -450,4 +450,53 @@ describe('buildPickResult', () => {
         const result = buildPickResult(makeInfo());
         expect(result.pwCommand).not.toContain('--frame');
     });
+
+    // ─── Heading context (--in instead of --nth) ─────────────────────────
+
+    it('replaces --nth with --in when headingContext provided', () => {
+        const result = buildPickResult(makeInfo({
+            locator: "getByRole('link', { name: 'RFCP® Certified', exact: true }).nth(1)",
+            tag: 'a',
+            text: 'RFCP® Certified',
+            attributes: { href: '/rf' },
+        }), null, undefined, 'Robot Framework');
+        expect(result.pwCommand).toBe('highlight link "RFCP® Certified" --in "Robot Framework" --exact');
+        expect(result.pwCommand).not.toContain('--nth');
+    });
+
+    it('adds --in even without --nth when headingContext provided', () => {
+        const result = buildPickResult(makeInfo({
+            locator: "getByRole('link', { name: 'RFCP® Certified' })",
+            tag: 'a',
+            text: 'RFCP® Certified',
+            attributes: { href: '/rf' },
+        }), null, undefined, 'Robot Framework');
+        expect(result.pwCommand).toBe('highlight link "RFCP® Certified" --in "Robot Framework"');
+        // assertion should also get --in
+        expect(result.assertPw).toContain('--in "Robot Framework"');
+    });
+
+    it('keeps --nth when no headingContext', () => {
+        const result = buildPickResult(makeInfo({
+            locator: "getByRole('link', { name: 'RFCP® Certified', exact: true }).nth(1)",
+            tag: 'a',
+            text: 'RFCP® Certified',
+            attributes: { href: '/rf' },
+        }), null, undefined, null);
+        expect(result.pwCommand).toContain('--nth 1');
+        expect(result.pwCommand).not.toContain('--in');
+    });
+
+    it('prefers aria snapshot parent over headingContext', () => {
+        const result = buildPickResult(makeInfo({
+            locator: "getByRole('checkbox', { name: 'reading', exact: true }).first()",
+            tag: 'input',
+            text: '',
+            attributes: { type: 'checkbox' },
+            checked: true,
+        }), null, '- listitem:\n  - checkbox "reading"', 'Some Heading');
+        // aria snapshot provides listitem parent — use that, not heading
+        expect(result.pwCommand).toContain('--in listitem');
+        expect(result.pwCommand).not.toContain('Some Heading');
+    });
 });


### PR DESCRIPTION
## Summary
- When duplicate elements need disambiguation, prefer `--in "section label"` over `--nth N`
- Generic approach: find first short leaf text in preceding sibling without links (works for headings, banners, accordions, plain divs — no hardcoded selectors)
- Recorder: `generateLocatorPair()` tries heading context before `.nth()` fallback
- Picker: `background.ts` detects `headingContext` via `locator.evaluate()`, passes to `buildPickResult`/`derivePwCommand`. Assertions also get `--in`

## Test plan
- [x] 205 unit tests pass (locator, pick-info, commands)
- [x] Manual test on imbus.de/akademie/kurstermine — recorder produces `--in "Robot Framework"` / `--in "Testspezialist"`
- [x] Picker produces `--in` on both highlight and assertion commands
- [x] Existing ancestor context (listitem, row) still works
- [x] Falls back to `--nth` when no unique section label found

Closes #742

🤖 Generated with [Claude Code](https://claude.com/claude-code)