### PR TITLE
chore: release v0.26.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,38 @@
 # Changelog
 
+## v0.26.0
+
+**2026-04-17**
+
+### Features
+
+- **Iframe support**: Record and replay with `--frame` flag — interact with elements inside iframes. ([#737](https://github.com/stevez/playwright-repl/pull/737))
+- **`--in` scoping**: Text-based `--in` flag scopes commands to containers (e.g., `click "Delete" --in listitem "reading"`). ([#741](https://github.com/stevez/playwright-repl/pull/741))
+- **Auto-generate `--in`**: Picker replaces `--nth` with `--in` using nearby heading context for more readable commands. ([#743](https://github.com/stevez/playwright-repl/pull/743))
+- **Polish with AI**: AI-powered command to improve test code quality. ([#729](https://github.com/stevez/playwright-repl/pull/729))
+- **AI-suggested assertions**: AssertBuilder suggests assertions using AI. ([#728](https://github.com/stevez/playwright-repl/pull/728))
+- **Fix with AI**: AI context for bridge-mode test failures. ([#725](https://github.com/stevez/playwright-repl/pull/725))
+
+### Fixes
+
+- **Picker**: Stale page detection, `--frame` and `--exact` in pick results. ([#739](https://github.com/stevez/playwright-repl/pull/739))
+- **Picker**: Full accessible name used for PW commands (aria snapshot name over JS locator substring). ([#744](https://github.com/stevez/playwright-repl/pull/744))
+- **Picker**: Heading context captures full element text for `--in` matching. ([#744](https://github.com/stevez/playwright-repl/pull/744))
+- **CSS tokenizer**: Preserve quotes and spaces inside parens for CSS pseudo-class locators. ([#727](https://github.com/stevez/playwright-repl/pull/727))
+- **Timeouts**: Prevent silent hangs in bridge, service worker, and HTTP endpoints. ([#717](https://github.com/stevez/playwright-repl/pull/717))
+- **Child process**: Use `close` instead of `exit` to prevent truncated output. ([#716](https://github.com/stevez/playwright-repl/pull/716))
+- **VS Code**: Dedupe concurrent browser launches. ([#711](https://github.com/stevez/playwright-repl/pull/711))
+- **VS Code**: Route pick/recording through BrowserController when showBrowser is on. ([#713](https://github.com/stevez/playwright-repl/pull/713))
+- **Video**: Remove in-page REC overlay from video capture. ([#709](https://github.com/stevez/playwright-repl/pull/709))
+
+### Refactors
+
+- **Picker**: Derive PW commands by parsing JS locator as single source of truth, replacing dual-path aria+regex approach. ([#744](https://github.com/stevez/playwright-repl/pull/744))
+
+### Tests
+
+- Unit tests for MCP, bridge-server, and runner packages. ([#718](https://github.com/stevez/playwright-repl/pull/718), [#719](https://github.com/stevez/playwright-repl/pull/719), [#720](https://github.com/stevez/playwright-repl/pull/720))
+
 ## v0.25.0
 
 **2026-04-11**

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -314,12 +314,14 @@ Short aliases are CLI-only.
 
 ### Locator Flags
 
-All text-based interaction commands support `--nth` and `--exact`:
+All text-based interaction commands support these flags:
 
 | Flag | Description |
 |------|-------------|
 | `--nth <n>` | Select the nth visible match (0-indexed) |
 | `--exact` | Exact text match only — skip the fallback chain |
+| `--in <text>` | Scope command to a container matching text |
+| `--frame <selector>` | Target an element inside an iframe |
 
 ```
 pw> click "Submit" --nth 0           # click the first "Submit"
@@ -333,6 +335,8 @@ pw> highlight "npm" --nth 0          # highlight just the first match
 → Highlighted 1 of 24
 pw> highlight --clear                # dismiss the highlight overlay
 → Cleared
+pw> click "Delete" --in listitem "reading"   # click within a specific container
+pw> click "Submit" --frame "#my-iframe"      # click inside an iframe
 ```
 
 ### Inspection

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "playwright-repl",
-  "version": "0.25.0",
+  "version": "0.26.0",
   "description": "Interactive REPL for Playwright — keyword commands, recording, and replay",
   "type": "module",
   "bin": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@playwright-repl/core",
   "description": "Shared parser, servers, and utilities for playwright-repl",
-  "version": "0.25.0",
+  "version": "0.26.0",
   "type": "module",
   "main": "./dist/index.js",
   "exports": {

--- a/packages/extension/README.md
+++ b/packages/extension/README.md
@@ -7,6 +7,7 @@ Chrome side panel extension that runs the full Playwright API directly inside yo
 | **Console** | Auto-detects input type — `.pw` keywords or Playwright API / JavaScript |
 | **Script Editor** | Syntax highlighting, pass/fail gutter, autocomplete, run/step/stop |
 | **JS Debugger** | Breakpoints, step over/into/out, variables with scope inspection |
+| **Element Picker** | Pick elements visually, get locators, assertions, and ARIA snapshots |
 | **Recorder** | Captures clicks, fills, navigations as `.pw` commands and Playwright code |
 | **Object Tree** | Expandable CDP object tree, like Chrome DevTools |
 | **Tab Switcher** | Switch active target to any open tab from the toolbar |
@@ -71,7 +72,7 @@ Click **Record**, interact with the page — clicks, hovers, fills, and navigati
 - **`.pw` commands** — `goto`, `click`, `fill`, `press` — ready to replay
 - **JS Playwright code** — `await page.click(...)` — ready to paste into a test
 
-Ambiguous elements are disambiguated with ancestor context (e.g. `click "Save" --in "Settings"`).
+Ambiguous elements are disambiguated with ancestor context (e.g. `click "Save" --in "Settings"`). Iframe elements use the `--frame` flag (e.g. `click "Submit" --frame "#my-iframe"`).
 
 ## Tab Management
 

--- a/packages/extension/public/manifest.json
+++ b/packages/extension/public/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Dramaturg",
-  "version": "0.25.0",
+  "version": "0.26.0",
   "description": "Playwright engineer's companion — console, editor, runner, debugger, and recorder in a Chrome side panel.",
   "permissions": [
     "activeTab",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@playwright-repl/mcp",
     "description": "MCP server — AI agents control your real Chrome browser",
-    "version": "0.25.0",
+    "version": "0.26.0",
     "type": "module",
     "bin": {
         "playwright-repl-mcp": "./dist/index.js"

--- a/packages/runner/package.json
+++ b/packages/runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@playwright-repl/runner",
-  "version": "0.25.0",
+  "version": "0.26.0",
   "description": "Playwright test utilities — bridge-mode compilation, node detection, and CLI subcommands",
   "type": "module",
   "bin": {

--- a/packages/vscode/CHANGELOG.md
+++ b/packages/vscode/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## 0.26.0
+
+**2026-04-17**
+
+### Features
+
+- Iframe support — `--frame` flag for interacting with elements inside iframes
+- `--in` scoping — text-based flag scopes commands to containers
+- Auto-generate `--in` — picker replaces `--nth` with heading context
+- Polish with AI — AI-powered test code improvement
+- AI-suggested assertions in AssertBuilder
+- Fix with AI — AI context for bridge-mode test failures
+
+### Fixes
+
+- Picker: stale page detection, `--frame` and `--exact` in pick results
+- Picker: full accessible name used for PW commands
+- Dedupe concurrent browser launches
+- Route pick/recording through BrowserController when showBrowser is on
+
 ## 0.25.0
 
 **2026-04-11**

--- a/packages/vscode/README.md
+++ b/packages/vscode/README.md
@@ -42,7 +42,8 @@ Interactive command panel in the bottom bar. Type keyword commands (`snapshot`, 
 - Inline screenshot display
 - PDF save
 - Execution timing
-- Local commands: `help`, `.aliases`, `.status`, `.history`, `locator`, `page`
+- Local commands: `video-start`, `video-stop`, `video-chapter`, `tracing-start`, `tracing-stop`
+- `--in` flag for scoping commands to containers, `--frame` for iframe elements
 
 <img src="https://raw.githubusercontent.com/stevez/playwright-repl/main/packages/vscode/images/repl.gif" width="75%">
 
@@ -64,10 +65,11 @@ Build and verify Playwright assertions interactively:
 1. **Pick Locator** — pick an element or type a locator manually
 2. **Select Matcher** — 13 matchers, smart-filtered by element type
 3. **Verify** — run the assertion against the live page, see pass/fail instantly
+4. **AI Suggest** — get AI-suggested assertions based on the picked element
 
 Matchers: `toContainText`, `toHaveText`, `toBeVisible`, `toBeHidden`, `toBeAttached`, `toBeEnabled`, `toBeDisabled`, `toBeChecked`, `toHaveValue`, `toHaveAttribute`, `toHaveCount`, `toHaveURL`, `toHaveTitle`
 
-Supports negation (`not` checkbox) and editable assertions.
+Supports negation (`not` checkbox), editable assertions, and AI-suggested assertions.
 
 <img src="https://raw.githubusercontent.com/stevez/playwright-repl/main/packages/vscode/images/assert.gif" width="75%">
 

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -7,7 +7,7 @@
     "color": "#ffffff",
     "theme": "light"
   },
-  "version": "0.25.0",
+  "version": "0.26.0",
   "private": true,
   "publisher": "playwright-repl",
   "repository": {


### PR DESCRIPTION
## Summary
- Bump all packages to 0.26.0
- Update root and VS Code changelogs
- Update CLI, VS Code, and extension READMEs with `--frame`, `--in`, AI features, picker docs

## Changes since v0.25.0
- **Features**: iframe `--frame` flag, `--in` scoping, auto-generated `--in`, Polish/Fix with AI, AI-suggested assertions
- **Fixes**: picker stale page detection, full accessible name in PW commands, heading context text matching, CSS tokenizer, timeouts, child process output, VS Code browser dedup
- **Tests**: unit tests for MCP, bridge-server, and runner packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)