### PR TITLE
feat: add lint tool to AI Assist — eslint-plugin-playwright

### DIFF
--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -325,7 +325,9 @@
   "dependencies": {
     "@playwright-repl/browser-extension": "workspace:*",
     "@playwright-repl/core": "workspace:*",
-    "@playwright-repl/runner": "workspace:*"
+    "@playwright-repl/runner": "workspace:*",
+    "eslint": "^10.0.2",
+    "eslint-plugin-playwright": "^2.10.1"
   },
   "devDependencies": {
     "@babel/core": "^7.23.2",

--- a/packages/vscode/src/ai/agent.ts
+++ b/packages/vscode/src/ai/agent.ts
@@ -8,6 +8,8 @@
 import type * as vscodeTypes from '../vscodeTypes';
 import type { IBrowserManager } from '../browser';
 import { parsePolishResponse, selectModel } from './provider';
+import { Linter } from 'eslint/universal';
+import playwrightPlugin from 'eslint-plugin-playwright';
 
 // ─── Test Detection ──────────────────────────────────────────────────────────
 
@@ -112,7 +114,21 @@ const AGENT_TOOLS = [
       required: ['testName'],
     },
   },
+  {
+    name: 'lint',
+    description: 'Run eslint-plugin-playwright rules against the current file. Returns lint violations (missing awaits, deprecated APIs, raw locators, etc.). Use this during the review phase to catch anti-patterns.',
+    inputSchema: { type: 'object' as const, properties: {} },
+  },
 ];
+
+// ─── Linter ──────────────────────────────────────────────────────────────────
+
+const linter = new Linter();
+const recommendedConfig = (playwrightPlugin as any).configs['flat/recommended'];
+const lintConfig = {
+  ...recommendedConfig,
+  languageOptions: { ecmaVersion: 2022 as const, sourceType: 'module' as const },
+};
 
 // ─── System Prompt ────────────────────────────────────────────────────────────
 
@@ -164,14 +180,16 @@ ${goal ? `4. **User instruction** — ${goal}\n` : ''}
 - **run_command**: Execute a single REPL command (goto, click, fill, press, snapshot, etc.).
 - **run_script**: Run multi-line JavaScript in the browser context for complex operations.
 - **run_test**: Run a specific test by name from the current file. Compiles the full file (including beforeEach, fixtures) and returns pass/fail with errors.
+- **lint**: Run eslint-plugin-playwright rules on the current file. Returns violations like missing awaits, deprecated APIs, raw locators, etc.
 
 ## Workflow
 1. Use \`snapshot\` to understand the current page state.
 2. Use \`run_test\` to see if the test currently passes or fails.
 3. If it fails — fix the issues (wrong locators, missing waits, incorrect assertions).
 4. Polish and review the code using the best practices above.
-5. Use \`run_test\` again to verify your final code passes.
-6. Only return the final code AFTER verifying it passes with \`run_test\`.
+5. Use \`lint\` to check for Playwright anti-patterns and fix any violations.
+6. Use \`run_test\` again to verify your final code passes.
+7. Only return the final code AFTER verifying it passes with \`run_test\`.
 
 ## Constraints
 - All tools run in the browser context (Chrome extension service worker). Node.js APIs are NOT available.
@@ -217,6 +235,14 @@ async function executeTool(
     case 'run_script': {
       const result = await browserManager.runScript(input.code as string, 'javascript');
       return result.isError ? `ERROR: ${result.text}` : (result.text || 'OK');
+    }
+    case 'lint': {
+      const code = editor.document.getText();
+      const messages = linter.verify(code, lintConfig);
+      if (messages.length === 0) return 'No lint violations found.';
+      return messages
+        .map(m => `Line ${m.line}:${m.column} [${m.ruleId}] ${m.message}`)
+        .join('\n');
     }
     case 'run_test': {
       const testResult = await runTestFromFile(editor, input.testName as string, browserManager);
@@ -280,16 +306,13 @@ export async function aiAssist(
   userPrompt?: string,
 ): Promise<void> {
   const log = (msg: string) => logger?.info(`[AI Assist] ${msg}`);
-  // Determine target range
+  // Determine target range: selection > test block under cursor > whole file
   const selection = editor.selection;
+  const doc = editor.document;
   const targetRange = (selection && !selection.isEmpty)
     ? new vscode.Range(selection.start, selection.end)
-    : detectTestRange(vscode, editor);
-
-  if (!targetRange) {
-    vscode.window.showWarningMessage('Place your cursor inside a test() function, or select code to fix.');
-    return;
-  }
+    : detectTestRange(vscode, editor)
+      || new vscode.Range(new vscode.Position(0, 0), new vscode.Position(doc.lineCount - 1, doc.lineAt(doc.lineCount - 1).text.length));
 
   log(`Target range: lines ${targetRange.start.line + 1}-${targetRange.end.line + 1}`);
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -240,6 +240,12 @@ importers:
       '@playwright-repl/runner':
         specifier: workspace:*
         version: link:../runner
+      eslint:
+        specifier: ^10.0.2
+        version: 10.0.2(jiti@2.6.1)
+      eslint-plugin-playwright:
+        specifier: ^2.10.1
+        version: 2.10.1(eslint@10.0.2(jiti@2.6.1))
     devDependencies:
       '@babel/core':
         specifier: ^7.23.2
@@ -2166,6 +2172,12 @@ packages:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
 
+  eslint-plugin-playwright@2.10.1:
+    resolution: {integrity: sha512-qea3UxBOb8fTwJ77FMApZKvRye5DOluDHcev0LDJwID3RELeun0JlqzrNIXAB/SXCyB/AesCW/6sZfcT9q3Edg==}
+    engines: {node: '>=16.9.0'}
+    peerDependencies:
+      eslint: '>=8.40.0'
+
   eslint-scope@9.1.1:
     resolution: {integrity: sha512-GaUN0sWim5qc8KVErfPBWmc31LEsOkrUJbvJZV+xuL3u2phMUK4HIvXlWAakfC8W4nzlK+chPEAkYOYb5ZScIw==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
@@ -2393,6 +2405,10 @@ packages:
     resolution: {integrity: sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==}
     engines: {node: '>=12'}
     deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+
+  globals@17.5.0:
+    resolution: {integrity: sha512-qoV+HK2yFl/366t2/Cb3+xxPUo5BuMynomoDmiaZBIdbs+0pYbjfZU+twLhGKp4uCZ/+NbtpVepH5bGCxRyy2g==}
+    engines: {node: '>=18'}
 
   globby@14.1.0:
     resolution: {integrity: sha512-0Ia46fDOaT7k4og1PDW4YbodWWr3scS2vAr2lTbsplOt2WkKp0vQbkI9wKis/T5LV/dqPjO3bpS/z6GTJB82LA==}
@@ -5837,6 +5853,11 @@ snapshots:
 
   escape-string-regexp@4.0.0: {}
 
+  eslint-plugin-playwright@2.10.1(eslint@10.0.2(jiti@2.6.1)):
+    dependencies:
+      eslint: 10.0.2(jiti@2.6.1)
+      globals: 17.5.0
+
   eslint-scope@9.1.1:
     dependencies:
       '@types/esrecurse': 4.3.1
@@ -6124,6 +6145,8 @@ snapshots:
       inherits: 2.0.4
       minimatch: 5.1.9
       once: 1.4.0
+
+  globals@17.5.0: {}
 
   globby@14.1.0:
     dependencies:


### PR DESCRIPTION
## Summary
- Add `lint` tool to AI Assist that runs `eslint-plugin-playwright` recommended rules in-memory
- Uses ESLint's `Linter` class from `eslint/universal` — zero filesystem access, bundles cleanly with esbuild (~1.4 MB)
- AI calls `lint` during the review phase, gets specific violations (missing awaits, deprecated APIs, raw locators), and fixes them
- Fall back to whole-file scope when cursor is outside a test block (no more "place cursor inside test()" requirement)

## Test plan
- [x] AI agent calls lint tool and receives violations
- [x] Only recommended rules enabled (no `require-soft-assert`, `require-tags`)
- [x] Cursor inside test → targets that test
- [x] Cursor outside test → targets whole file
- [x] Extension builds cleanly with eslint bundled

Closes #751

🤖 Generated with [Claude Code](https://claude.com/claude-code)