### PR TITLE
feat: dedicated AI Chat panel with streaming responses

### DIFF
--- a/packages/vscode/build.mjs
+++ b/packages/vscode/build.mjs
@@ -14,6 +14,7 @@ const options = {
     'src/locatorsView.script.ts',
     'src/replView.script.ts',
     'src/assertView.script.ts',
+    'src/aiChatView.script.ts',
   ],
   bundle: true,
   outdir: 'dist',

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -159,6 +159,12 @@
         "command": "playwright-repl.aiAssist",
         "icon": "$(sparkle)",
         "title": "AI Assist"
+      },
+      {
+        "category": "Playwright REPL",
+        "command": "playwright-repl.aiChat.clear",
+        "icon": "$(clear-all)",
+        "title": "Clear AI Chat"
       }
     ],
     "menus": {
@@ -191,6 +197,11 @@
           "command": "playwright-repl.repl.find",
           "group": "navigation@3",
           "when": "view == playwright-repl.replView"
+        },
+        {
+          "command": "playwright-repl.aiChat.clear",
+          "group": "navigation@1",
+          "when": "view == playwright-repl.aiChatView"
         }
       ]
     },
@@ -276,6 +287,11 @@
           "id": "assertContainer",
           "title": "Assert",
           "icon": "images/playwright-logo.png"
+        },
+        {
+          "id": "aiChatContainer",
+          "title": "AI Chat",
+          "icon": "images/playwright-logo.png"
         }
       ]
     },
@@ -306,6 +322,13 @@
           "type": "webview",
           "id": "playwright-repl.assertView",
           "name": "Assert"
+        }
+      ],
+      "aiChatContainer": [
+        {
+          "type": "webview",
+          "id": "playwright-repl.aiChatView",
+          "name": "AI Chat"
         }
       ]
     }

--- a/packages/vscode/src/ai/agent.ts
+++ b/packages/vscode/src/ai/agent.ts
@@ -13,6 +13,19 @@ import playwrightPlugin from 'eslint-plugin-playwright';
 import { execFile } from 'child_process';
 import path from 'path';
 
+// ─── Agent Event Protocol ────────────────────────────────────────────────────
+
+export type AgentEvent =
+  | { type: 'text'; value: string }
+  | { type: 'toolCallStart'; name: string; input: Record<string, unknown>; callId: string }
+  | { type: 'toolCallEnd'; name: string; callId: string; result: string }
+  | { type: 'iteration'; current: number; max: number }
+  | { type: 'verifyStart'; testName: string }
+  | { type: 'verifyEnd'; testName: string; passed: boolean; output: string }
+  | { type: 'codeApplied'; code: string }
+  | { type: 'done'; summary: string }
+  | { type: 'error'; message: string };
+
 // ─── Test Detection ──────────────────────────────────────────────────────────
 
 /** Detect the full range of the test() call enclosing the cursor. */
@@ -70,7 +83,8 @@ function detectTestRange(
 
 // ─── Constants ────────────────────────────────────────────────────────────────
 
-const MAX_ITERATIONS = 10;
+const MAX_ITERATIONS_AUTO = 5;   // auto mode: test → fix → verify
+const MAX_ITERATIONS_CUSTOM = 3; // custom prompt: use tools, respond
 
 const AGENT_TOOLS = [
   {
@@ -134,68 +148,34 @@ const lintConfig = {
 
 // ─── System Prompt ────────────────────────────────────────────────────────────
 
-function buildAgentSystemPrompt(userPrompt?: string): string {
-  const goal = userPrompt
-    ? `Follow the user's instructions: "${userPrompt}"`
-    : '';
-
-  return `You are a Playwright test assistant. You have browser tools to interact with a live page.
-
-Your job is to **fix**, **polish**, and **review** the given test code in a single pass.
-
-## Playwright Best Practices
-
-Follow these practices when polishing and reviewing:
-
-**Locators** — use user-facing attributes, never implementation details:
-- Prefer: getByRole() > getByText() > getByLabel() > getByPlaceholder() > getByTestId()
-- Avoid: CSS selectors, XPath, page.$(), page.$$(), page.evaluate() when a locator works
-- Use \`filter({ hasText })\` and \`locator()\` chaining instead of complex selectors
-
-**Assertions** — use web-first assertions (they auto-wait and auto-retry):
-- Use \`expect(locator).toBeVisible()\` — never \`waitForSelector()\`
-- Use \`expect(page).toHaveURL()\` / \`toHaveTitle()\` for navigation
-- Use \`toHaveText()\`, \`toHaveValue()\`, \`toHaveAttribute()\` for content checks
-- Add assertions after every state-changing action (click, fill, navigate)
-- Prefer specific assertions (toHaveText("Submit")) over generic ones (toBeVisible)
-
-**Anti-patterns** — fix these when found:
-- Replace \`page.waitForTimeout()\` with web-first assertions
-- Replace \`page.waitForSelector()\` with \`expect(locator).toBeVisible()\`
-- Replace \`elementHandle\` API with locators
-- Remove \`force: true\` unless absolutely necessary
-- Remove redundant or duplicate steps
-
-**Readability**:
-- Extract repeated locator chains into variables
-- Add brief comments for complex multi-step flows (3+ actions)
-
-## Steps
-
-1. **Fix** — run the test; if it fails, diagnose and fix until it passes.
-2. **Polish** — apply the best practices above, even when the test already passes.
-3. **Review** — check for flaky patterns, missing assertions, and anti-patterns.
-${goal ? `4. **User instruction** — ${goal}\n` : ''}
-## Available tools
+const TOOLS_DESCRIPTION = `## Available tools
 - **snapshot**: Get the page's accessibility tree to understand what's on the page.
 - **screenshot**: Take a screenshot to see visual layout, styling, or issues the ARIA tree can't show.
 - **run_command**: Execute a single REPL command (goto, click, fill, press, snapshot, etc.).
 - **run_script**: Run multi-line JavaScript in the browser context for complex operations.
-- **run_test**: Run a specific test by name from the current file. Compiles the full file (including beforeEach, fixtures) and returns pass/fail with errors.
-- **lint**: Run eslint-plugin-playwright rules on the current file. Returns violations like missing awaits, deprecated APIs, raw locators, etc.
+- **run_test**: Run a specific test by name from the current file. Returns pass/fail with errors.
+- **lint**: Run eslint-plugin-playwright rules on the current file. Returns violations.`;
+
+const BEST_PRACTICES = `## Playwright Best Practices
+**Locators**: getByRole() > getByText() > getByLabel() > getByPlaceholder() > getByTestId(). Avoid CSS/XPath.
+**Assertions**: Use web-first assertions (toBeVisible, toHaveText, toHaveURL). Never waitForSelector/waitForTimeout.
+**Anti-patterns**: Replace page.$eval, elementHandle API, force:true. Remove redundant steps.
+**Readability**: Extract repeated locators into variables. Brief comments for complex flows.`;
+
+function buildAutoSystemPrompt(): string {
+  return `You are a Playwright test assistant. Fix, polish, and review the given test code.
+
+${BEST_PRACTICES}
+
+${TOOLS_DESCRIPTION}
 
 ## Workflow
-1. Use \`snapshot\` to understand the current page state.
-2. Use \`run_test\` to see if the test currently passes or fails.
-3. If it fails — fix the issues (wrong locators, missing waits, incorrect assertions).
-4. Polish and review the code using the best practices above.
-5. Use \`lint\` to check for Playwright anti-patterns and fix any violations.
-6. Use \`run_test\` again to verify your final code passes.
-7. Only return the final code AFTER verifying it passes with \`run_test\`.
-
-## Constraints
-- All tools run in the browser context (Chrome extension service worker). Node.js APIs are NOT available.
-- Do NOT use require(), fs, path, or any Node.js modules in run_script.
+1. Run \`run_test\` to see if the test passes or fails.
+2. If it fails — fix the issues.
+3. Polish: improve locators, assertions, readability.
+4. Run \`lint\` to catch anti-patterns, fix violations.
+5. Run \`run_test\` again to verify your final code passes.
+6. Return the final code AFTER verifying it passes.
 
 ## Output Rules
 - Return ONLY the final improved code. No prose, no explanation, no code fences.
@@ -203,6 +183,28 @@ ${goal ? `4. **User instruction** — ${goal}\n` : ''}
 - Return the EXACT same structure as the input (full test() block or code fragment).
 - Preserve the original indentation style.
 - Do NOT add imports, describe() wrappers, or test() wrappers that weren't in the input.`;
+}
+
+function buildCustomSystemPrompt(userPrompt: string): string {
+  return `You are a Playwright test assistant. Follow the user's instructions.
+
+${BEST_PRACTICES}
+
+${TOOLS_DESCRIPTION}
+
+## Instructions
+${userPrompt}
+
+## Guidelines
+- Use the tools above as needed to accomplish the task.
+- If the user asks for information (e.g. "run lint", "show me"), use the appropriate tool and report the results as text.
+- If the user asks you to modify code, return ONLY the modified code. No prose, no code fences.
+- If no code changes are needed, explain your findings in plain text.
+- Be concise and direct.`;
+}
+
+function buildAgentSystemPrompt(userPrompt?: string): string {
+  return userPrompt ? buildCustomSystemPrompt(userPrompt) : buildAutoSystemPrompt();
 }
 
 // ─── Tool Execution ───────────────────────────────────────────────────────────
@@ -336,11 +338,14 @@ function findWorkspaceRoot(filePath: string): string {
 
 export async function aiAssist(
   vscode: vscodeTypes.VSCode,
-  editor: vscodeTypes.TextEditor,
+  initialEditor: vscodeTypes.TextEditor,
   browserManager: IBrowserManager | undefined,
   logger?: vscodeTypes.LogOutputChannel,
   userPrompt?: string,
+  onEvent?: (event: AgentEvent) => void,
+  token?: vscodeTypes.CancellationToken,
 ): Promise<void> {
+  let editor = initialEditor;
   const log = (msg: string) => logger?.info(`[AI Assist] ${msg}`);
   // Determine target range: selection > test block under cursor > whole file
   const selection = editor.selection;
@@ -384,145 +389,161 @@ export async function aiAssist(
     ),
   ];
 
-  // Run agent loop with progress
+  // ─── Agent loop ─────────────────────────────────────────────────────────
+
   let finalCode: string | undefined;
-  let lastRunTestName: string | undefined; // track full test name from agent's run_test calls
-  let codeAlreadyApplied = false; // set when auto-verify applies + saves the code
+  let lastRunTestName: string | undefined;
+  let codeAlreadyApplied = false;
 
-  try {
-    finalCode = await vscode.window.withProgress(
-      {
-        location: 15 /* ProgressLocation.Notification */,
-        title: 'AI Assist',
-        cancellable: true,
-      },
-      async (progress, token) => {
-        for (let iteration = 0; iteration < MAX_ITERATIONS; iteration++) {
-          if (token.isCancellationRequested) return undefined;
+  const emit = onEvent || (() => {});
 
-          progress.report({ message: `iteration ${iteration + 1}/${MAX_ITERATIONS}` });
+  /** Ensure the editor is visible before editing (it may have lost focus to the chat panel). */
+  async function showEditor() {
+    editor = await vscode.window.showTextDocument(editor.document, editor.viewColumn, false);
+  }
 
-          // Force tool use on the first iteration so the AI inspects before changing
-          let tools = AGENT_TOOLS;
-          let toolMode: number | undefined;
-          if (iteration === 0) {
-            if (hasBrowser) {
-              // Force snapshot when browser is available
-              tools = [AGENT_TOOLS[0]]; // snapshot only
-              toolMode = 2; /* LanguageModelChatToolMode.Required */
-            } else {
-              // Headless: force lint on first iteration (no args needed)
-              tools = AGENT_TOOLS.filter(t => t.name === 'lint');
-              toolMode = 2;
-            }
-          }
-          const response = await model.sendRequest(messages, { tools, toolMode }, token);
+  async function runAgentLoop(loopToken: vscodeTypes.CancellationToken): Promise<string | undefined> {
+    const maxIterations = userPrompt ? MAX_ITERATIONS_CUSTOM : MAX_ITERATIONS_AUTO;
+    for (let iteration = 0; iteration < maxIterations; iteration++) {
+      if (loopToken.isCancellationRequested) return undefined;
 
-          // Collect text and tool call parts from the stream
-          const textParts: string[] = [];
-          const toolCalls: Array<{ callId: string; name: string; input: Record<string, unknown> }> = [];
+      emit({ type: 'iteration', current: iteration + 1, max: maxIterations });
 
-          for await (const chunk of response.stream) {
-            if (chunk instanceof (vscode as any).LanguageModelTextPart) {
-              textParts.push(chunk.value);
-            } else if (chunk instanceof (vscode as any).LanguageModelToolCallPart) {
-              toolCalls.push({ callId: chunk.callId, name: chunk.name, input: chunk.input });
-            }
-          }
+      // Force tool use on the first iteration (only for auto mode, not custom prompts)
+      let tools = AGENT_TOOLS;
+      let toolMode: number | undefined;
+      if (iteration === 0 && !userPrompt) {
+        if (hasBrowser) {
+          tools = [AGENT_TOOLS[0]]; // force snapshot
+          toolMode = 2;
+        } else {
+          tools = AGENT_TOOLS.filter(t => t.name === 'lint'); // force lint
+          toolMode = 2;
+        }
+      }
+      const response = await model.sendRequest(messages, { tools, toolMode }, loopToken);
 
-          log(`Iteration ${iteration + 1}: ${toolCalls.length} tool calls, ${textParts.join('').length} chars text`);
+      // Collect text and tool call parts from the stream
+      const textParts: string[] = [];
+      const toolCalls: Array<{ callId: string; name: string; input: Record<string, unknown> }> = [];
 
-          // No tool calls — model is done, text is the final answer
-          if (toolCalls.length === 0) {
-            const finalText = textParts.join('');
-            log('Model returned final answer (no tool calls)');
-            log(`Response:\n${finalText}`);
+      for await (const chunk of response.stream) {
+        if (chunk instanceof (vscode as any).LanguageModelTextPart) {
+          textParts.push(chunk.value);
+          emit({ type: 'text', value: chunk.value });
+        } else if (chunk instanceof (vscode as any).LanguageModelToolCallPart) {
+          toolCalls.push({ callId: chunk.callId, name: chunk.name, input: chunk.input });
+        }
+      }
 
-            // Auto-verify: run the test before accepting the code
-            const candidateCode = parsePolishResponse(finalText, originalText);
-            const verifyName = lastRunTestName || extractTestName(candidateCode);
-            if (verifyName && candidateCode.trim() !== originalText.trim()) {
-              progress.report({ message: 'verifying...' });
-              // Apply code and save so run_test compiles the latest file
-              await editor.edit(eb => eb.replace(targetRange, candidateCode));
-              await editor.document.save();
-              const verifyResult = await runTestFromFile(editor, verifyName, browserManager);
-              log(`Auto-verify "${verifyName}": ${verifyResult.slice(0, 200)}`);
-              // Check for pass: bridge shim uses ✓/✗, Playwright CLI uses "N passed"/"N failed"
-              const hasPassed = verifyResult.includes('✓') || /\d+ passed/.test(verifyResult);
-              const hasFailed = verifyResult.includes('✗') || /[1-9]\d* failed/.test(verifyResult);
-              const failed = !hasPassed || hasFailed;
-              if (failed && iteration < MAX_ITERATIONS - 1) {
-                // Revert and feed error back to the agent
-                await vscode.commands.executeCommand('undo');
-                await editor.document.save();
-                log('Test failed — feeding error back to agent');
-                messages.push(
-                  vscode.LanguageModelChatMessage.Assistant(finalText),
-                  vscode.LanguageModelChatMessage.User(
-                    `I applied your code and ran the test "${verifyName}", but it FAILED:\n\n${verifyResult}\n\n`
-                    + 'Please fix the code and return the corrected version. Remember to preserve the original test structure.',
-                  ),
-                );
-                continue; // retry
-              }
-              // Auto-verify passed — code is already in the editor
-              codeAlreadyApplied = true;
-            }
+      log(`Iteration ${iteration + 1}: ${toolCalls.length} tool calls, ${textParts.join('').length} chars text`);
 
-            return finalText;
-          }
+      // No tool calls — model is done, text is the final answer
+      if (toolCalls.length === 0) {
+        const finalText = textParts.join('');
+        log('Model returned final answer (no tool calls)');
+        log(`Response:\n${finalText}`);
 
-          // Execute tool calls and feed results back
-          for (const tc of toolCalls) {
-            if (token.isCancellationRequested) return undefined;
-
-            progress.report({ message: `iteration ${iteration + 1}/${MAX_ITERATIONS} — ${tc.name}` });
-
-            log(`Tool call: ${tc.name}(${JSON.stringify(tc.input)})`);
-
-            // Track the full test name (with describe prefix) from run_test calls
-            if (tc.name === 'run_test' && tc.input.testName)
-              lastRunTestName = tc.input.testName as string;
-
-            let result: ToolResult;
-            try {
-              result = await executeTool(tc.name, tc.input, browserManager, editor);
-            } catch (e: unknown) {
-              result = `ERROR: ${(e as Error).message}`;
-            }
-
-            const resultSummary = typeof result === 'string' ? result.slice(0, 500) : `[image ${result.mime}]`;
-            log(`Tool result: ${resultSummary}`);
-
-            const resultParts: any[] = typeof result === 'string'
-              ? [new (vscode as any).LanguageModelTextPart(result)]
-              : [(vscode as any).LanguageModelDataPart.image(result.image, result.mime)];
-
-            const LMMessage = vscode.LanguageModelChatMessage;
+        // Auto-verify: run the test before accepting the code
+        const candidateCode = parsePolishResponse(finalText, originalText);
+        const verifyName = lastRunTestName || extractTestName(candidateCode);
+        if (verifyName && candidateCode.trim() !== originalText.trim()) {
+          emit({ type: 'verifyStart', testName: verifyName });
+          await showEditor();
+          await editor.edit(eb => eb.replace(targetRange, candidateCode));
+          await editor.document.save();
+          const verifyResult = await runTestFromFile(editor, verifyName, browserManager);
+          log(`Auto-verify "${verifyName}": ${verifyResult.slice(0, 200)}`);
+          const hasPassed = verifyResult.includes('✓') || /\d+ passed/.test(verifyResult);
+          const hasFailed = verifyResult.includes('✗') || /[1-9]\d* failed/.test(verifyResult);
+          const failed = !hasPassed || hasFailed;
+          emit({ type: 'verifyEnd', testName: verifyName, passed: !failed, output: verifyResult });
+          if (failed && iteration < maxIterations - 1) {
+            await vscode.commands.executeCommand('undo');
+            await editor.document.save();
+            log('Test failed — feeding error back to agent');
             messages.push(
-              (LMMessage as any).Assistant([
-                new (vscode as any).LanguageModelToolCallPart(tc.callId, tc.name, tc.input),
-              ]),
-              (LMMessage as any).User([
-                new (vscode as any).LanguageModelToolResultPart(tc.callId, resultParts),
-              ]),
+              vscode.LanguageModelChatMessage.Assistant(finalText),
+              vscode.LanguageModelChatMessage.User(
+                `I applied your code and ran the test "${verifyName}", but it FAILED:\n\n${verifyResult}\n\n`
+                + 'Please fix the code and return the corrected version. Remember to preserve the original test structure.',
+              ),
             );
+            continue;
           }
+          codeAlreadyApplied = true;
         }
 
-        // Max iterations reached — ask model for final answer without tools
-        progress.report({ message: 'finishing up...' });
-        const finalResponse = await model.sendRequest(messages, {}, token);
-        let text = '';
-        for await (const chunk of finalResponse.text) text += chunk;
-        return text;
-      },
-    );
+        return finalText;
+      }
+
+      // Execute tool calls and feed results back
+      for (const tc of toolCalls) {
+        if (loopToken.isCancellationRequested) return undefined;
+
+        log(`Tool call: ${tc.name}(${JSON.stringify(tc.input)})`);
+        emit({ type: 'toolCallStart', name: tc.name, input: tc.input, callId: tc.callId });
+
+        if (tc.name === 'run_test' && tc.input.testName)
+          lastRunTestName = tc.input.testName as string;
+
+        let result: ToolResult;
+        try {
+          result = await executeTool(tc.name, tc.input, browserManager, editor);
+        } catch (e: unknown) {
+          result = `ERROR: ${(e as Error).message}`;
+        }
+
+        const resultSummary = typeof result === 'string' ? result.slice(0, 500) : `[image ${result.mime}]`;
+        log(`Tool result: ${resultSummary}`);
+        emit({ type: 'toolCallEnd', name: tc.name, callId: tc.callId, result: resultSummary });
+
+        const resultParts: any[] = typeof result === 'string'
+          ? [new (vscode as any).LanguageModelTextPart(result)]
+          : [(vscode as any).LanguageModelDataPart.image(result.image, result.mime)];
+
+        const LMMessage = vscode.LanguageModelChatMessage;
+        messages.push(
+          (LMMessage as any).Assistant([
+            new (vscode as any).LanguageModelToolCallPart(tc.callId, tc.name, tc.input),
+          ]),
+          (LMMessage as any).User([
+            new (vscode as any).LanguageModelToolResultPart(tc.callId, resultParts),
+          ]),
+        );
+      }
+    }
+
+    // Max iterations reached — ask model for final answer without tools
+    const finalResponse = await model.sendRequest(messages, {}, loopToken);
+    let text = '';
+    for await (const chunk of finalResponse.text) {
+      text += chunk;
+      emit({ type: 'text', value: chunk });
+    }
+    return text;
+  }
+
+  // ─── Run the loop ──────────────────────────────────────────────────────
+
+  try {
+    if (onEvent && token) {
+      // Streaming path: events go to the chat panel, use provided token
+      finalCode = await runAgentLoop(token);
+    } else {
+      // Notification path: withProgress for backward compat
+      finalCode = await vscode.window.withProgress(
+        { location: 15, title: 'AI Assist', cancellable: true },
+        (_progress, progressToken) => runAgentLoop(progressToken),
+      );
+    }
   } catch (e: unknown) {
-    if ((e as Error).message?.includes('Cancelled') || (e as Error).message?.includes('canceled'))
+    const msg = (e as Error).message || '';
+    if (msg.includes('Cancelled') || msg.includes('canceled') || msg.includes('no choices')) {
+      emit({ type: 'done', summary: 'Cancelled.' });
       return;
-    vscode.window.showErrorMessage(`AI Assist failed: ${(e as Error).message}`);
+    }
+    emit({ type: 'error', message: msg });
     return;
   }
 
@@ -531,21 +552,24 @@ export async function aiAssist(
   log(`Final code: ${finalCode.length} chars`);
 
   try {
-    // Detect prose responses (reviews, explanations) vs code
-    const isProse = /^(Here|I |The |This |Sure|Let me|##|Based on|\*\*)/im.test(finalCode.trim());
-    if (isProse) {
-      log('Response is prose — showing in output channel');
-      if (logger) {
+    // Check if the response looks like code (contains test/function patterns) vs prose
+    const looksLikeCode = /(?:test|it|describe|import|export|const |let |var |async |await |function )\s*[\(\{]/.test(finalCode.trim());
+    if (!looksLikeCode) {
+      log('Response is prose');
+      if (!onEvent && logger) {
         logger.appendLine('\n── AI Assist ──────────────────────────────────');
         logger.appendLine(finalCode);
         logger.appendLine('───────────────────────────────────────────────\n');
-        logger.show(true); // true = preserve focus on editor
+        logger.show(true);
       }
+      emit({ type: 'done', summary: 'Review complete.' });
       return;
     }
 
     if (codeAlreadyApplied) {
       log('Code already applied and verified by auto-verify');
+      emit({ type: 'codeApplied', code: finalCode });
+      emit({ type: 'done', summary: 'Code applied and verified.' });
       return;
     }
 
@@ -555,18 +579,23 @@ export async function aiAssist(
 
     if (polished.trim() === originalText.trim()) {
       log('No changes needed');
+      emit({ type: 'done', summary: 'Code looks good — no changes needed.' });
       vscode.window.showInformationMessage('Code looks good — no changes needed.');
       return;
     }
 
     // Replace code (user can Ctrl+Z to revert)
     log('Replacing editor content...');
+    await showEditor();
     const success = await editor.edit(editBuilder => {
       editBuilder.replace(targetRange, polished);
     });
     log(`Replace result: ${success}`);
+    emit({ type: 'codeApplied', code: polished });
+    emit({ type: 'done', summary: 'Code applied.' });
   } catch (e: unknown) {
     log(`Error in final step: ${(e as Error).message}\n${(e as Error).stack}`);
+    emit({ type: 'error', message: (e as Error).message });
     vscode.window.showErrorMessage(`AI Assist failed: ${(e as Error).message}`);
   }
 }

--- a/packages/vscode/src/aiChatView.script.ts
+++ b/packages/vscode/src/aiChatView.script.ts
@@ -1,0 +1,186 @@
+/**
+ * AI Chat webview script — renders streaming AI responses, tool calls, and status.
+ */
+
+import { vscode } from './common';
+
+const messages = document.getElementById('messages')!;
+const chatInput = document.getElementById('chat-input') as HTMLTextAreaElement;
+const sendBtn = document.getElementById('send-btn') as HTMLButtonElement;
+const cancelBtn = document.getElementById('cancel-btn') as HTMLButtonElement;
+
+let currentAiMessage: HTMLElement | null = null;
+let isRunning = false;
+
+// ─── Input handling ──────────────────────────────────────────────────────────
+
+chatInput.addEventListener('keydown', (e: KeyboardEvent) => {
+  if (e.key === 'Enter' && !e.shiftKey) {
+    e.preventDefault();
+    sendMessage();
+  }
+});
+
+sendBtn.addEventListener('click', sendMessage);
+
+cancelBtn.addEventListener('click', () => {
+  vscode.postMessage({ method: 'cancel' });
+});
+
+function sendMessage() {
+  const text = chatInput.value.trim();
+  if (!text && !isRunning) {
+    // Empty prompt = auto fix/polish/review
+    vscode.postMessage({ method: 'send', params: { prompt: '' } });
+    return;
+  }
+  if (isRunning) return;
+  vscode.postMessage({ method: 'send', params: { prompt: text } });
+  chatInput.value = '';
+}
+
+// ─── Messages from extension ─────────────────────────────────────────────────
+
+window.addEventListener('message', event => {
+  const { method, params } = event.data;
+
+  if (method === 'userMessage') {
+    appendUserMessage(params.text);
+    currentAiMessage = null;
+  } else if (method === 'agentEvent') {
+    handleAgentEvent(params);
+  } else if (method === 'running') {
+    isRunning = params.running;
+    chatInput.disabled = isRunning;
+    sendBtn.style.display = isRunning ? 'none' : '';
+    cancelBtn.style.display = isRunning ? '' : 'none';
+    if (!isRunning) chatInput.focus();
+  } else if (method === 'clear') {
+    messages.innerHTML = '';
+    currentAiMessage = null;
+  }
+});
+
+// ─── Event handlers ──────────────────────────────────────────────────────────
+
+function handleAgentEvent(event: any) {
+  switch (event.type) {
+    case 'text':
+      if (!currentAiMessage) {
+        currentAiMessage = document.createElement('div');
+        currentAiMessage.className = 'msg msg-ai';
+        messages.appendChild(currentAiMessage);
+      }
+      currentAiMessage.textContent += event.value;
+      scrollToBottom();
+      break;
+
+    case 'toolCallStart':
+      appendToolCall(event.name, event.input, event.callId);
+      break;
+
+    case 'toolCallEnd':
+      updateToolResult(event.callId, event.result);
+      break;
+
+    case 'iteration':
+      appendStatus(`Iteration ${event.current}/${event.max}`);
+      currentAiMessage = null; // reset for next AI response
+      break;
+
+    case 'verifyStart':
+      appendStatus(`Verifying: "${event.testName}"...`);
+      break;
+
+    case 'verifyEnd':
+      appendStatus(event.passed
+        ? `\u2713 Test passed: "${event.testName}"`
+        : `\u2717 Test failed: "${event.testName}"`
+      );
+      break;
+
+    case 'codeApplied':
+      appendStatus('\u2713 Code applied to editor.');
+      break;
+
+    case 'done':
+      appendStatus(event.summary);
+      currentAiMessage = null;
+      break;
+
+    case 'error':
+      appendError(event.message);
+      currentAiMessage = null;
+      break;
+  }
+}
+
+// ─── Rendering helpers ───────────────────────────────────────────────────────
+
+function appendUserMessage(text: string) {
+  const el = document.createElement('div');
+  el.className = 'msg msg-user';
+  el.textContent = text;
+  messages.appendChild(el);
+  scrollToBottom();
+}
+
+function appendStatus(text: string) {
+  const el = document.createElement('div');
+  el.className = 'msg msg-status';
+  el.textContent = text;
+  messages.appendChild(el);
+  scrollToBottom();
+}
+
+function appendError(text: string) {
+  const el = document.createElement('div');
+  el.className = 'msg msg-error';
+  el.textContent = `Error: ${text}`;
+  messages.appendChild(el);
+  scrollToBottom();
+}
+
+function appendToolCall(name: string, input: Record<string, unknown>, callId: string) {
+  const details = document.createElement('details');
+  details.className = 'msg msg-tool';
+  details.setAttribute('data-call-id', callId);
+
+  const summary = document.createElement('summary');
+  const inputStr = Object.keys(input).length > 0
+    ? ` ${JSON.stringify(input)}`
+    : '';
+  summary.textContent = `\u2192 ${name}${inputStr}`;
+  details.appendChild(summary);
+
+  // Placeholder for result
+  const resultDiv = document.createElement('div');
+  resultDiv.className = 'tool-result';
+  resultDiv.textContent = 'Running...';
+  details.appendChild(resultDiv);
+
+  messages.appendChild(details);
+  scrollToBottom();
+}
+
+function updateToolResult(callId: string, result: string) {
+  const details = messages.querySelector(`[data-call-id="${callId}"]`);
+  if (!details) return;
+  const resultDiv = details.querySelector('.tool-result');
+  if (resultDiv) {
+    resultDiv.textContent = result;
+  }
+  // Update summary to show completion
+  const summary = details.querySelector('summary');
+  if (summary) {
+    summary.textContent = summary.textContent!.replace('\u2192', '\u2713');
+  }
+}
+
+function scrollToBottom() {
+  messages.scrollTop = messages.scrollHeight;
+}
+
+// ─── Focus input on load ─────────────────────────────────────────────────────
+
+chatInput.focus();

--- a/packages/vscode/src/aiChatView.ts
+++ b/packages/vscode/src/aiChatView.ts
@@ -1,0 +1,235 @@
+/**
+ * AiChatView — dedicated webview panel for AI Assist conversations.
+ *
+ * Streams AI text, tool calls, verify status, and errors in real-time.
+ * Replaces the showInputBox popup and Output channel fallback.
+ */
+
+import { WebviewBase } from './webviewBase';
+import type { IBrowserManager } from './browser';
+import type * as vscodeTypes from './vscodeTypes';
+import { aiAssist, type AgentEvent } from './ai/agent';
+import { VSCodeLMProvider } from './ai/provider';
+
+export class AiChatView extends WebviewBase {
+  private _browserManager: IBrowserManager | undefined;
+  private _logger: vscodeTypes.LogOutputChannel | undefined;
+  private _cancellation: vscodeTypes.CancellationTokenSource | undefined;
+  private _isRunning = false;
+  private _lastEditor: vscodeTypes.TextEditor | undefined;
+
+  get viewId() { return 'playwright-repl.aiChatView'; }
+  get scriptName() { return 'aiChatView.script.js'; }
+  get bodyClass() { return 'ai-chat-view'; }
+
+  setBrowserManager(manager: IBrowserManager | undefined) {
+    this._browserManager = manager;
+  }
+
+  setLogger(logger: vscodeTypes.LogOutputChannel) {
+    this._logger = logger;
+  }
+
+  bodyHtml(): string {
+    return `
+      <style>
+        body.ai-chat-view {
+          display: flex;
+          flex-direction: column;
+          height: 100vh;
+          overflow: hidden;
+          font-family: var(--vscode-font-family);
+          font-size: var(--vscode-font-size);
+        }
+        #messages {
+          flex: 1;
+          overflow-y: auto;
+          padding: 8px;
+          user-select: text;
+          -webkit-user-select: text;
+        }
+        .msg {
+          margin-bottom: 8px;
+          line-height: 1.5;
+          white-space: pre-wrap;
+          word-wrap: break-word;
+        }
+        .msg-user {
+          color: var(--vscode-terminal-ansiBrightWhite);
+          padding: 4px 8px;
+          border-left: 3px solid var(--vscode-terminal-ansiBlue);
+          background: var(--vscode-editor-inactiveSelectionBackground);
+          border-radius: 2px;
+        }
+        .msg-ai {
+          color: var(--vscode-editor-foreground);
+          padding: 4px 0;
+        }
+        .msg-status {
+          color: var(--vscode-descriptionForeground);
+          font-size: 0.9em;
+          font-style: italic;
+          padding: 2px 0;
+        }
+        .msg-error {
+          color: var(--vscode-errorForeground);
+          padding: 2px 0;
+        }
+        .msg-tool {
+          color: var(--vscode-descriptionForeground);
+          font-size: 0.9em;
+          padding: 2px 0;
+        }
+        .msg-tool summary {
+          cursor: pointer;
+          user-select: none;
+        }
+        .msg-tool .tool-result {
+          padding: 4px 8px;
+          margin-top: 4px;
+          background: var(--vscode-editor-inactiveSelectionBackground);
+          border-radius: 2px;
+          max-height: 200px;
+          overflow-y: auto;
+          font-family: var(--vscode-editor-font-family);
+          font-size: var(--vscode-editor-font-size);
+        }
+        #input-row {
+          display: flex;
+          gap: 4px;
+          padding: 6px 8px;
+          border-top: 1px solid var(--vscode-panel-border);
+          align-items: flex-end;
+        }
+        #chat-input {
+          flex: 1;
+          resize: none;
+          border: 1px solid var(--vscode-input-border, transparent);
+          background: var(--vscode-input-background);
+          color: var(--vscode-input-foreground);
+          padding: 4px 8px;
+          font-family: var(--vscode-font-family);
+          font-size: var(--vscode-font-size);
+          border-radius: 2px;
+          field-sizing: content;
+          max-height: 120px;
+          outline: none;
+        }
+        #chat-input:focus {
+          border-color: var(--vscode-focusBorder);
+        }
+        #chat-input:disabled {
+          opacity: 0.5;
+        }
+        #send-btn {
+          border: none;
+          background: var(--vscode-button-background);
+          color: var(--vscode-button-foreground);
+          padding: 4px 10px;
+          border-radius: 2px;
+          cursor: pointer;
+          font-size: var(--vscode-font-size);
+        }
+        #send-btn:hover {
+          background: var(--vscode-button-hoverBackground);
+        }
+        #send-btn:disabled {
+          opacity: 0.5;
+          cursor: default;
+        }
+        #cancel-btn {
+          border: none;
+          background: var(--vscode-button-secondaryBackground);
+          color: var(--vscode-button-secondaryForeground);
+          padding: 4px 10px;
+          border-radius: 2px;
+          cursor: pointer;
+          font-size: var(--vscode-font-size);
+        }
+        #cancel-btn:hover {
+          background: var(--vscode-button-secondaryHoverBackground);
+        }
+      </style>
+      <div id="messages"></div>
+      <div id="input-row">
+        <textarea id="chat-input" rows="1" placeholder="What should AI do? (Enter to send)"></textarea>
+        <button id="send-btn" title="Send">Send</button>
+        <button id="cancel-btn" title="Cancel" style="display:none">Cancel</button>
+      </div>
+    `;
+  }
+
+  async onMessage(data: any): Promise<void> {
+    if (data.method === 'send') {
+      // When sending from webview, use the last known editor (panel has focus, not editor)
+      if (!this._lastEditor)
+        this._lastEditor = this._vscode.window.activeTextEditor;
+      // User typed a prompt — pass it directly (no template)
+      const prompt = data.params.prompt?.trim() || undefined;
+      await this._startAssist(prompt);
+    } else if (data.method === 'cancel') {
+      this._cancellation?.cancel();
+    }
+  }
+
+  /** Public API: focus the panel and auto-start with the default template. */
+  async startAssist(userPrompt?: string) {
+    // Capture the editor BEFORE focusing the panel (focus changes activeTextEditor)
+    this._lastEditor = this._vscode.window.activeTextEditor;
+    await this._vscode.commands.executeCommand('playwright-repl.aiChatView.focus');
+    // Small delay to let the webview resolve if first open
+    await new Promise(r => setTimeout(r, 100));
+    // Auto-start: undefined = default fix/polish/review template
+    await this._startAssist(userPrompt);
+  }
+
+  /** Clear the chat history. */
+  clear() {
+    this.postMessage('clear');
+  }
+
+  private async _startAssist(userPrompt?: string) {
+    if (this._isRunning) return;
+
+    const editor = this._lastEditor || this._vscode.window.activeTextEditor;
+    if (!editor) {
+      this.postMessage('agentEvent', { type: 'error', message: 'No active editor. Open a test file first.' });
+      return;
+    }
+
+    const aiProvider = new VSCodeLMProvider(this._vscode);
+    if (!await aiProvider.isAvailable()) {
+      this.postMessage('agentEvent', { type: 'error', message: 'No AI model available. Install GitHub Copilot or another LLM extension.' });
+      return;
+    }
+
+    const browserManager = this._browserManager?.isRunning()
+      ? this._browserManager
+      : undefined;
+
+    this._isRunning = true;
+    this.postMessage('running', { running: true });
+    this.postMessage('userMessage', { text: userPrompt || '(auto fix/polish/review)' });
+
+    this._cancellation = new this._vscode.CancellationTokenSource();
+
+    const onEvent = (event: AgentEvent) => {
+      this.postMessage('agentEvent', event);
+    };
+
+    try {
+      await aiAssist(
+        this._vscode, editor, browserManager,
+        this._logger, userPrompt || undefined,
+        onEvent, this._cancellation.token,
+      );
+    } catch (e: unknown) {
+      this.postMessage('agentEvent', { type: 'error', message: (e as Error).message });
+    } finally {
+      this._isRunning = false;
+      this._cancellation.dispose();
+      this._cancellation = undefined;
+      this.postMessage('running', { running: false });
+    }
+  }
+}

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -37,8 +37,8 @@ import { findTestEndPosition } from './babelHighlightUtil';
 import { createRequire } from 'node:module';
 import { ReplView } from './replView';
 import { AssertView } from './assertView';
+import { AiChatView } from './aiChatView';
 import { VSCodeLMProvider } from './ai/provider';
-import { aiAssist } from './ai/agent';
 import { BrowserController } from './browserController';
 
 const stackUtils = new StackUtils({
@@ -98,6 +98,7 @@ export class Extension implements RunHooks {
   private _browserController!: BrowserController;
   private _replView!: ReplView;
   private _assertView!: AssertView;
+  private _aiChatView!: AiChatView;
 
   private _modelRebuild?: { result: Promise<void>; token: vscodeTypes.CancellationTokenSource; needsAnother: boolean; };
 
@@ -206,6 +207,8 @@ export class Extension implements RunHooks {
     this._replView = new ReplView(vscode, this._context.extensionUri);
     this._assertView = new AssertView(vscode, this._context.extensionUri);
     this._assertView.setAIProvider(new VSCodeLMProvider(vscode));
+    this._aiChatView = new AiChatView(vscode, this._context.extensionUri);
+    this._aiChatView.setLogger(this._logger);
     this._browserController = new BrowserController(vscode, this._logger);
     this._browserController.setViews(this._replView, this._locatorsView, this._assertView, this._settingsView);
     const messageNoPlaywrightTestsFound = this._vscode.l10n.t('No Playwright tests found.');
@@ -374,30 +377,16 @@ export class Extension implements RunHooks {
       }),
       vscode.commands.registerCommand('playwright-repl.aiAssist', async () => {
         this._logger.info('[AI Assist] Command triggered');
-        const editor = vscode.window.activeTextEditor;
-        if (!editor) { this._logger.info('[AI Assist] No active editor'); return; }
-        const aiProvider = new VSCodeLMProvider(vscode);
-        if (!await aiProvider.isAvailable()) {
-          this._logger.info('[AI Assist] No AI model available');
-          vscode.window.showWarningMessage('No AI model available. Install GitHub Copilot or another LLM extension.');
-          return;
-        }
-        // Browser is optional — AI Assist works headless (run_test via subprocess)
+        // Pass browser manager to the chat view
         const browserManager = this._browserController.browserManager?.isRunning()
           ? this._browserController.browserManager
           : undefined;
-        if (browserManager)
-          this._logger.info('[AI Assist] Browser running — will reuse for snapshot/run_command');
-        else
-          this._logger.info('[AI Assist] No browser — running headless (run_test only)');
-        this._logger.info('[AI Assist] Showing input box...');
-        const userPrompt = await vscode.window.showInputBox({
-          prompt: 'What should AI do? (leave empty for auto fix/polish/review)',
-          placeHolder: 'e.g. "add assertions for all visible headings"',
-        });
-        if (userPrompt === undefined) return; // cancelled
-        this._logger.info(`[AI Assist] Starting... prompt: ${userPrompt || '(auto)'}`);
-        await aiAssist(vscode, editor, browserManager, this._logger, userPrompt || undefined);
+        this._aiChatView.setBrowserManager(browserManager);
+        // Focus the AI Chat panel — user types prompt in the webview
+        await this._aiChatView.startAssist();
+      }),
+      vscode.commands.registerCommand('playwright-repl.aiChat.clear', () => {
+        this._aiChatView.clear();
       }),
     ];
 


### PR DESCRIPTION
## Summary
- New **AI Chat** webview panel in the bottom panel area (alongside REPL, Locator, Assert)
- Replaces `showInputBox` popup and Output channel prose fallback
- Streams AI text responses in real-time as they arrive
- Shows tool calls (lint, run_test, snapshot) as collapsible elements
- Shows auto-verify progress and results
- Cancel button to stop the agent mid-run

## Two modes
- **Sparkle button** → auto-starts fix/polish/review (5 iterations max)
- **User types in chat** → free-form prompt, follows instructions (3 iterations max)

## Key changes
- `AgentEvent` streaming protocol (text, toolCallStart/End, verifyStart/End, done, error)
- Split system prompt: auto mode (fix/polish/review) vs custom mode (follow instructions)
- Semantic code detection — only apply to editor if response contains code patterns
- `showTextDocument` before `editor.edit` to prevent closed-editor errors

## Test plan
- [x] Sparkle button opens chat panel and auto-runs
- [x] User can type custom prompts in the chat input
- [x] AI text streams in real-time
- [x] Tool calls shown as collapsible items
- [x] Cancel button stops execution
- [x] Clear button resets chat
- [x] Prose responses stay in chat, not applied to editor
- [x] Code responses applied to editor correctly

Closes #752

🤖 Generated with [Claude Code](https://claude.com/claude-code)