### PR TITLE
ci: parallelize test jobs for faster CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ on:
   workflow_call:
 
 jobs:
-  build-and-test:
+  build:
     name: build (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
 
@@ -49,9 +49,6 @@ jobs:
         run: pnpm run lint
         working-directory: packages/extension
 
-      - name: Run tests
-        run: pnpm -r run test
-
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4
         with:
@@ -65,9 +62,9 @@ jobs:
             packages/vscode/dist/
           retention-days: 1
 
-  extension-tests:
-    name: extension (${{ matrix.os }})
-    needs: build-and-test
+  core-cli-runner-mcp:
+    name: core+cli+runner+mcp (${{ matrix.os }})
+    needs: build
     runs-on: ${{ matrix.os }}
 
     strategy:
@@ -106,70 +103,21 @@ jobs:
           name: dist-${{ matrix.os }}
           path: packages
 
-      - name: Cache Playwright browsers
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cache/ms-playwright
-            ~/Library/Caches/ms-playwright
-          key: playwright-${{ matrix.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+      - name: Run core tests
+        run: pnpm run test
+        working-directory: packages/core
 
-      - name: Install Playwright browsers
-        run: pnpm exec playwright install ${{ runner.os == 'Linux' && '--with-deps' || '' }} chromium chrome
-        working-directory: packages/extension
+      - name: Run CLI tests
+        run: pnpm run test
+        working-directory: packages/cli
 
-      - name: Run extension component tests
-        run: pnpm run test:component
-        working-directory: packages/extension
+      - name: Run runner tests
+        run: pnpm run test
+        working-directory: packages/runner
 
-      - name: Run extension E2E tests
-        run: pnpm exec playwright test
-        working-directory: packages/extension
-
-      - name: Merge extension coverage
-        run: pnpm run coverage:merge
-        working-directory: packages/extension
-
-  cli-e2e:
-    name: cli-e2e (${{ matrix.os }})
-    needs: build-and-test
-    runs-on: ${{ matrix.os }}
-
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest, macos-latest]
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@v4
-
-      - name: Use Node.js 22
-        uses: actions/setup-node@v4
-        with:
-          node-version: 22
-          cache: 'pnpm'
-
-      - name: Cache node_modules
-        uses: actions/cache@v4
-        id: nm-cache
-        with:
-          path: |
-            node_modules
-            packages/*/node_modules
-          key: nm-${{ matrix.os }}-${{ hashFiles('pnpm-lock.yaml') }}
-
-      - name: Install dependencies
-        if: steps.nm-cache.outputs.cache-hit != 'true'
-        run: pnpm install --frozen-lockfile
-
-      - name: Download build artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: dist-${{ matrix.os }}
-          path: packages
+      - name: Run MCP tests
+        run: pnpm run test
+        working-directory: packages/mcp
 
       - name: Cache Playwright browsers
         uses: actions/cache@v4
@@ -187,9 +135,78 @@ jobs:
         run: node dist/playwright-repl.js --headless --replay examples/
         working-directory: packages/cli
 
-  vscode-tests:
+  extension:
+    name: extension (${{ matrix.os }})
+    needs: build
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Use Node.js 22
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: 'pnpm'
+
+      - name: Cache node_modules
+        uses: actions/cache@v4
+        id: nm-cache
+        with:
+          path: |
+            node_modules
+            packages/*/node_modules
+          key: nm-${{ matrix.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+
+      - name: Install dependencies
+        if: steps.nm-cache.outputs.cache-hit != 'true'
+        run: pnpm install --frozen-lockfile
+
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: dist-${{ matrix.os }}
+          path: packages
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/ms-playwright
+            ~/Library/Caches/ms-playwright
+          key: playwright-${{ matrix.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+
+      - name: Install Playwright browsers
+        run: pnpm exec playwright install ${{ runner.os == 'Linux' && '--with-deps' || '' }} chromium chrome
+        working-directory: packages/extension
+
+      - name: Run unit tests
+        run: pnpm run test:coverage
+        working-directory: packages/extension
+
+      - name: Run component tests
+        run: pnpm run test:component
+        working-directory: packages/extension
+
+      - name: Run E2E tests
+        run: pnpm exec playwright test
+        working-directory: packages/extension
+
+      - name: Merge coverage
+        run: pnpm run coverage:merge
+        working-directory: packages/extension
+
+  vscode:
     name: vscode (${{ matrix.os }})
-    needs: build-and-test
+    needs: build
     runs-on: ${{ matrix.os }}
 
     strategy:
@@ -240,17 +257,21 @@ jobs:
         run: pnpm exec playwright install ${{ runner.os == 'Linux' && '--with-deps' || '' }} chromium chrome
         working-directory: packages/vscode
 
-      - name: Run VS Code extension mock tests
+      - name: Run unit tests
+        run: pnpm run test:coverage
+        working-directory: packages/vscode
+
+      - name: Run mock tests
         run: pnpm exec playwright test --config tests/playwright/playwright.config.ts --project default
         working-directory: packages/vscode
         timeout-minutes: 10
 
-      - name: Merge VS Code extension coverage
+      - name: Merge coverage
         run: pnpm run coverage:merge
         working-directory: packages/vscode
 
       # VS Code E2E tests disabled — flaky on CI, works locally
-      # - name: Run VS Code extension E2E tests
+      # - name: Run E2E tests
       #   run: ${{ runner.os == 'Linux' && 'xvfb-run' || '' }} pnpm exec playwright test --config e2e/playwright.config.ts
       #   working-directory: packages/vscode
       #   timeout-minutes: 5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ on:
   workflow_call:
 
 jobs:
-  build:
+  build-and-test:
     name: build (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
 
@@ -29,7 +29,17 @@ jobs:
           node-version: 22
           cache: 'pnpm'
 
+      - name: Cache node_modules
+        uses: actions/cache@v4
+        id: nm-cache
+        with:
+          path: |
+            node_modules
+            packages/*/node_modules
+          key: nm-${{ matrix.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+
       - name: Install dependencies
+        if: steps.nm-cache.outputs.cache-hit != 'true'
         run: pnpm install --frozen-lockfile
 
       - name: Build and type check (with sourcemaps for coverage)
@@ -38,6 +48,9 @@ jobs:
       - name: Lint extension
         run: pnpm run lint
         working-directory: packages/extension
+
+      - name: Run tests
+        run: pnpm -r run test
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4
@@ -52,42 +65,9 @@ jobs:
             packages/vscode/dist/
           retention-days: 1
 
-  unit-tests:
-    name: unit (${{ matrix.os }})
-    needs: build
-    runs-on: ${{ matrix.os }}
-
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest, macos-latest]
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@v4
-
-      - name: Use Node.js 22
-        uses: actions/setup-node@v4
-        with:
-          node-version: 22
-          cache: 'pnpm'
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Download build artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: dist-${{ matrix.os }}
-
-      - name: Run tests
-        run: pnpm -r run test
-
   extension-tests:
     name: extension (${{ matrix.os }})
-    needs: build
+    needs: build-and-test
     runs-on: ${{ matrix.os }}
 
     strategy:
@@ -107,13 +87,24 @@ jobs:
           node-version: 22
           cache: 'pnpm'
 
+      - name: Cache node_modules
+        uses: actions/cache@v4
+        id: nm-cache
+        with:
+          path: |
+            node_modules
+            packages/*/node_modules
+          key: nm-${{ matrix.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+
       - name: Install dependencies
+        if: steps.nm-cache.outputs.cache-hit != 'true'
         run: pnpm install --frozen-lockfile
 
       - name: Download build artifacts
         uses: actions/download-artifact@v4
         with:
           name: dist-${{ matrix.os }}
+          path: packages
 
       - name: Cache Playwright browsers
         uses: actions/cache@v4
@@ -141,7 +132,7 @@ jobs:
 
   cli-e2e:
     name: cli-e2e (${{ matrix.os }})
-    needs: build
+    needs: build-and-test
     runs-on: ${{ matrix.os }}
 
     strategy:
@@ -161,13 +152,24 @@ jobs:
           node-version: 22
           cache: 'pnpm'
 
+      - name: Cache node_modules
+        uses: actions/cache@v4
+        id: nm-cache
+        with:
+          path: |
+            node_modules
+            packages/*/node_modules
+          key: nm-${{ matrix.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+
       - name: Install dependencies
+        if: steps.nm-cache.outputs.cache-hit != 'true'
         run: pnpm install --frozen-lockfile
 
       - name: Download build artifacts
         uses: actions/download-artifact@v4
         with:
           name: dist-${{ matrix.os }}
+          path: packages
 
       - name: Cache Playwright browsers
         uses: actions/cache@v4
@@ -187,7 +189,7 @@ jobs:
 
   vscode-tests:
     name: vscode (${{ matrix.os }})
-    needs: build
+    needs: build-and-test
     runs-on: ${{ matrix.os }}
 
     strategy:
@@ -207,13 +209,24 @@ jobs:
           node-version: 22
           cache: 'pnpm'
 
+      - name: Cache node_modules
+        uses: actions/cache@v4
+        id: nm-cache
+        with:
+          path: |
+            node_modules
+            packages/*/node_modules
+          key: nm-${{ matrix.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+
       - name: Install dependencies
+        if: steps.nm-cache.outputs.cache-hit != 'true'
         run: pnpm install --frozen-lockfile
 
       - name: Download build artifacts
         uses: actions/download-artifact@v4
         with:
           name: dist-${{ matrix.os }}
+          path: packages
 
       - name: Cache Playwright browsers
         uses: actions/cache@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,8 +8,8 @@ on:
   workflow_call:
 
 jobs:
-  test:
-    name: test (${{ matrix.os }}, node 22)
+  build:
+    name: build (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
 
     strategy:
@@ -35,14 +35,94 @@ jobs:
       - name: Build and type check (with sourcemaps for coverage)
         run: pnpm run build:dev
 
-      - name: Run tests
-        run: pnpm -r run test
-
       - name: Lint extension
         run: pnpm run lint
         working-directory: packages/extension
 
-      # Install Playwright browsers (all packages now use 1.59 stable)
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist-${{ matrix.os }}
+          path: |
+            packages/core/dist/
+            packages/cli/dist/
+            packages/mcp/dist/
+            packages/runner/dist/
+            packages/extension/dist/
+            packages/vscode/dist/
+          retention-days: 1
+
+  unit-tests:
+    name: unit (${{ matrix.os }})
+    needs: build
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Use Node.js 22
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: dist-${{ matrix.os }}
+
+      - name: Run tests
+        run: pnpm -r run test
+
+  extension-tests:
+    name: extension (${{ matrix.os }})
+    needs: build
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Use Node.js 22
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: dist-${{ matrix.os }}
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/ms-playwright
+            ~/Library/Caches/ms-playwright
+          key: playwright-${{ matrix.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+
       - name: Install Playwright browsers
         run: pnpm exec playwright install ${{ runner.os == 'Linux' && '--with-deps' || '' }} chromium chrome
         working-directory: packages/extension
@@ -51,11 +131,6 @@ jobs:
         run: pnpm run test:component
         working-directory: packages/extension
 
-      - name: Run CLI E2E tests
-        run: node dist/playwright-repl.js --headless --replay examples/
-        working-directory: packages/cli
-
-
       - name: Run extension E2E tests
         run: pnpm exec playwright test
         working-directory: packages/extension
@@ -63,6 +138,94 @@ jobs:
       - name: Merge extension coverage
         run: pnpm run coverage:merge
         working-directory: packages/extension
+
+  cli-e2e:
+    name: cli-e2e (${{ matrix.os }})
+    needs: build
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Use Node.js 22
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: dist-${{ matrix.os }}
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/ms-playwright
+            ~/Library/Caches/ms-playwright
+          key: playwright-${{ matrix.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+
+      - name: Install Playwright browsers
+        run: pnpm exec playwright install ${{ runner.os == 'Linux' && '--with-deps' || '' }} chromium chrome
+        working-directory: packages/cli
+
+      - name: Run CLI E2E tests
+        run: node dist/playwright-repl.js --headless --replay examples/
+        working-directory: packages/cli
+
+  vscode-tests:
+    name: vscode (${{ matrix.os }})
+    needs: build
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Use Node.js 22
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: dist-${{ matrix.os }}
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/ms-playwright
+            ~/Library/Caches/ms-playwright
+          key: playwright-${{ matrix.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+
+      - name: Install Playwright browsers
+        run: pnpm exec playwright install ${{ runner.os == 'Linux' && '--with-deps' || '' }} chromium chrome
+        working-directory: packages/vscode
 
       - name: Run VS Code extension mock tests
         run: pnpm exec playwright test --config tests/playwright/playwright.config.ts --project default


### PR DESCRIPTION
## Summary
- Split sequential CI into parallel jobs: `build` → `unit-tests`, `extension-tests`, `cli-e2e`, `vscode-tests`
- Build artifacts (`dist/`) shared via `actions/upload-artifact` with 1-day retention
- Add Playwright browser caching (`actions/cache`) to skip ~300MB downloads on cache hit

## Test plan
- [ ] Verify all 5 jobs appear in the CI workflow run
- [ ] Confirm test jobs run in parallel after build completes
- [ ] Check browser cache hits on subsequent runs

Closes #750

🤖 Generated with [Claude Code](https://claude.com/claude-code)