### PR TITLE
fix: remove data-pw-in attributes after --in scoped command completes

### DIFF
--- a/packages/extension/src/panel/lib/commands.ts
+++ b/packages/extension/src/panel/lib/commands.ts
@@ -210,7 +210,11 @@ function callScoped(fn: any, inText: string, targetText: string, ...args: unknow
         if (__sel) __scope = page.locator(__sel);
       } catch {}
     }
-    return await (${fn.toString()})(__scope, ${args.map(ser).join(', ')});
+    try {
+      return await (${fn.toString()})(__scope, ${args.map(ser).join(', ')});
+    } finally {
+      await page.evaluate(() => document.querySelectorAll('[data-pw-in]').forEach(el => el.removeAttribute('data-pw-in'))).catch(() => {});
+    }
   })()`;
 }
 


### PR DESCRIPTION
## Summary
- Clean up stale `data-pw-in` attributes from the DOM after `--in` scoped commands complete
- Prevents `pickLocator()` from generating useless locators like `[data-pw-in="__pw_in_abc"]` instead of semantic locators

Closes #745

## Test plan
- [ ] Run a command with `--in` scoping (e.g. `click "Submit" --in "Login"`)
- [ ] Inspect the DOM after — no `data-pw-in` attributes should remain
- [ ] Run `pickLocator()` after — should generate semantic locators, not `data-pw-in` based ones

🤖 Generated with [Claude Code](https://claude.com/claude-code)