### PR TITLE
fix: support --in flag for text-based locators

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -7,7 +7,7 @@ export { parseInput, ALIASES, ALL_COMMANDS, booleanOptions, resolveArgs } from '
 export { buildCompletionItems } from './completion-data.js';
 export { c, prettyJson } from './colors.js';
 export {
-  buildRunCode, verifyText, verifyElement, verifyValue, verifyList,
+  buildRunCode, buildRunCodeScoped, verifyText, verifyElement, verifyValue, verifyList,
   verifyTitle, verifyUrl, verifyNoText, verifyNoElement,
   verifyVisible, verifyInputValue, waitForText,
   actionByText, fillByText, selectByText, checkByText, uncheckByText,

--- a/packages/core/src/page-scripts.ts
+++ b/packages/core/src/page-scripts.ts
@@ -30,6 +30,46 @@ export function buildRunCode(fn, ...args) {
   return { _: ['run-code', `async (page) => (${fn.toString()})(page, ${serialized})`] };
 }
 
+/**
+ * Like buildRunCode, but scopes the page to an ancestor containing both
+ * inText and targetText. Mirrors callScoped() in the extension.
+ */
+export function buildRunCodeScoped(fn, inText, targetText, ...args) {
+  const filtered = args.filter(a => a !== undefined);
+  const serialized = filtered.map(a => JSON.stringify(a)).join(', ');
+  const inSer = JSON.stringify(inText);
+  const tgtSer = JSON.stringify(targetText);
+  return { _: ['run-code', `async (page) => {
+  let __scope = page;
+  for (const __r of ['region','group','article','listitem','dialog','form']) {
+    const __c = page.getByRole(__r).filter({ hasText: ${inSer} });
+    if (await __c.getByText(${tgtSer}, { exact: true }).count() > 0) { __scope = __c; break; }
+  }
+  if (__scope === page) {
+    try {
+      const __sel = await page.getByText(${inSer}, { exact: true }).first().evaluate((el, tgt) => {
+        let a = el.parentElement;
+        while (a && a !== document.body) {
+          if (a.textContent.includes(tgt)) {
+            const id = '__pw_in_' + Math.random().toString(36).slice(2);
+            a.setAttribute('data-pw-in', id);
+            return '[data-pw-in="' + id + '"]';
+          }
+          a = a.parentElement;
+        }
+        return null;
+      }, ${tgtSer});
+      if (__sel) __scope = page.locator(__sel);
+    } catch {}
+  }
+  try {
+    return await (${fn.toString()})(__scope, ${serialized});
+  } finally {
+    await page.evaluate(() => document.querySelectorAll('[data-pw-in]').forEach(el => el.removeAttribute('data-pw-in'))).catch(() => {});
+  }
+}`] };
+}
+
 // ─── Verify functions ───────────────────────────────────────────────────────
 
 export async function verifyText(page, text) {

--- a/packages/core/src/parser.ts
+++ b/packages/core/src/parser.ts
@@ -9,7 +9,7 @@
 
 import { minimist, COMMANDS } from './resolve.js';
 import {
-  buildRunCode, verifyText, verifyElement, verifyValue, verifyList,
+  buildRunCode, buildRunCodeScoped, verifyText, verifyElement, verifyValue, verifyList,
   verifyTitle, verifyUrl, verifyNoText, verifyNoElement,
   verifyVisible, verifyInputValue, waitForText,
   actionByText, fillByText, selectByText, checkByText, uncheckByText,
@@ -303,9 +303,11 @@ export function resolveArgs(args: ParsedArgs): ParsedArgs {
     const fn = textFns[cmdName];
     const nth = args.nth !== undefined ? parseInt(String(args.nth), 10) : undefined;
     const exact = args.exact === true ? true : undefined;
-    if (fn === actionByText) args = buildRunCode(fn, textArg, cmdName, nth, exact);
-    else if (cmdName === 'fill' || cmdName === 'select') args = buildRunCode(fn, textArg, extraArgs[0] || '', nth, exact);
-    else args = buildRunCode(fn, textArg, nth, exact);
+    const inText = args['in-text'] !== undefined ? String(args['in-text']) : undefined;
+    const build = inText ? (f: PageScriptFn, ...a: unknown[]) => buildRunCodeScoped(f, inText, textArg, ...a) : buildRunCode;
+    if (fn === actionByText) args = build(fn, textArg, cmdName, nth, exact);
+    else if (cmdName === 'fill' || cmdName === 'select') args = build(fn, textArg, extraArgs[0] || '', nth, exact);
+    else args = build(fn, textArg, nth, exact);
   }
 
   // ── go-back / go-forward → evaluate history.back/forward ──

--- a/packages/core/test/parser.test.ts
+++ b/packages/core/test/parser.test.ts
@@ -217,6 +217,45 @@ describe('--frame flag', () => {
   });
 });
 
+describe('--in with text locators (resolveArgs)', () => {
+  it('scopes text-based click with --in', () => {
+    const args = parseInput('click "Bis 45 km/h" --in "Moped, Roller"');
+    const resolved = resolveArgs(args);
+    expect(resolved._[0]).toBe('run-code');
+    expect(resolved._[1]).toContain('actionByText');
+    expect(resolved._[1]).toContain('"Moped, Roller"');
+    expect(resolved._[1]).toContain('"Bis 45 km/h"');
+    // Should use scoping logic (role-based fallback + data-pw-in)
+    expect(resolved._[1]).toContain('getByRole');
+    expect(resolved._[1]).toContain('data-pw-in');
+  });
+
+  it('scopes text-based check with --in', () => {
+    const args = parseInput('check "Newsletter" --in "Preferences"');
+    const resolved = resolveArgs(args);
+    expect(resolved._[0]).toBe('run-code');
+    expect(resolved._[1]).toContain('checkByText');
+    expect(resolved._[1]).toContain('"Preferences"');
+  });
+
+  it('scopes text-based fill with --in', () => {
+    const args = parseInput('fill "Email" user@example.com --in "Contact"');
+    const resolved = resolveArgs(args);
+    expect(resolved._[0]).toBe('run-code');
+    expect(resolved._[1]).toContain('fillByText');
+    expect(resolved._[1]).toContain('"Contact"');
+    expect(resolved._[1]).toContain('"Email"');
+  });
+
+  it('does not scope text-based click without --in', () => {
+    const args = parseInput('click "Submit"');
+    const resolved = resolveArgs(args);
+    expect(resolved._[0]).toBe('run-code');
+    expect(resolved._[1]).toContain('actionByText');
+    expect(resolved._[1]).not.toContain('data-pw-in');
+  });
+});
+
 describe('booleanOptions', () => {
   it('includes expected options', () => {
     expect(booleanOptions.has('headed')).toBe(true);

--- a/packages/extension/src/panel/lib/commands.ts
+++ b/packages/extension/src/panel/lib/commands.ts
@@ -536,10 +536,16 @@ function resolveArgs(args: ParsedArgs): ParsedArgs | DirectExecution {
     const fn = textFns[cmdName];
     const nth = args.nth !== undefined ? parseInt(String(args.nth), 10) : undefined;
     const exact = args.exact ? true : undefined;
-    if (fn === actionByText)
+    const inText = args['in-text'] !== undefined ? String(args['in-text']) : undefined;
+    if (fn === actionByText) {
+      if (inText) return { jsExpr: callScoped(fn, inText, textArg, textArg, cmdName, nth, exact) };
       return { jsExpr: call(fn, textArg, cmdName, nth, exact) };
-    if (cmdName === 'fill' || cmdName === 'select')
+    }
+    if (cmdName === 'fill' || cmdName === 'select') {
+      if (inText) return { jsExpr: callScoped(fn, inText, textArg, textArg, extraArgs[0] || '', nth, exact) };
       return { jsExpr: call(fn, textArg, extraArgs[0] || '', nth, exact) };
+    }
+    if (inText) return { jsExpr: callScoped(fn, inText, textArg, textArg, nth, exact) };
     return { jsExpr: call(fn, textArg, nth, exact) };
   }
 

--- a/packages/extension/test/lib/commands.test.ts
+++ b/packages/extension/test/lib/commands.test.ts
@@ -259,6 +259,36 @@ describe("--in text-only", () => {
     expect(jsExpr).toContain('"dialog"');
     expect(jsExpr).toContain('"Settings"');
   });
+
+  it("scopes text-based click with --in via callScoped", () => {
+    const { jsExpr } = direct('click "Bis 45 km/h" --in "Moped, Roller"');
+    expect(jsExpr).toContain('actionByText');
+    expect(jsExpr).toContain('"Moped, Roller"');
+    expect(jsExpr).toContain('"Bis 45 km/h"');
+    expect(jsExpr).toContain('getByRole');
+    expect(jsExpr).toContain('data-pw-in');
+  });
+
+  it("scopes text-based check with --in via callScoped", () => {
+    const { jsExpr } = direct('check "Newsletter" --in "Preferences"');
+    expect(jsExpr).toContain('checkByText');
+    expect(jsExpr).toContain('"Preferences"');
+    expect(jsExpr).toContain('data-pw-in');
+  });
+
+  it("scopes text-based fill with --in via callScoped", () => {
+    const { jsExpr } = direct('fill "Email" user@example.com --in "Contact"');
+    expect(jsExpr).toContain('fillByText');
+    expect(jsExpr).toContain('"Contact"');
+    expect(jsExpr).toContain('"Email"');
+    expect(jsExpr).toContain('data-pw-in');
+  });
+
+  it("does not scope text-based click without --in", () => {
+    const { jsExpr } = direct('click "Submit"');
+    expect(jsExpr).toContain('actionByText');
+    expect(jsExpr).not.toContain('data-pw-in');
+  });
 });
 
 describe("press", () => {


### PR DESCRIPTION
## Summary
- The `--in` flag was silently ignored for text-based locators (e.g. `click "Bis 45 km/h" --in "Moped, Roller"`). It only worked when a role was specified (`click radio "..." --in "..."`).
- Added `callScoped` / `buildRunCodeScoped` support in the text locator paths of both the extension (`commands.ts`) and core (`parser.ts`), so `--in` correctly scopes `click`, `fill`, `check`, `select`, etc. when used without a role.
- Added 8 new tests across core and extension.

Closes #734

## Test plan
- [x] All existing tests pass (128/128)
- [x] 8 new tests for `--in` with text locators pass
- [x] Manually verified on https://www.provinzial.de/west/versicherung/kfz-versicherung/rollerund-mopedversicherung/rollerundmoped-abschluss.html — `click "Bis 45 km/h" --in "Moped, Roller"` now works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)