### PR TITLE
fix: recorder — frame tag, --exact, and fill locator

### DIFF
--- a/packages/extension/src/content/locator.ts
+++ b/packages/extension/src/content/locator.ts
@@ -101,6 +101,12 @@ export function getLabel(el: HTMLInputElement | HTMLTextAreaElement | HTMLSelect
         const text = (clone.textContent || '').trim();
         if (text) return text;
     }
+    // Informal association: preceding table cell or sibling text (common in legacy forms)
+    const cell = el.closest('td, th');
+    if (cell?.previousElementSibling) {
+        const text = (cell.previousElementSibling.textContent || '').trim();
+        if (text && text.length <= 80) return text;
+    }
     return '';
 }
 
@@ -319,10 +325,11 @@ export function locatorToPwArgs(locator: string, role?: string | null): string {
     if (testIdMatch) return `${q(testIdMatch[1])}${nth}`;
 
     // getByLabel / getByText / getByPlaceholder / getByTitle / getByAltText — prepend role if available
-    const getByMatch = locator.match(/getBy\w+\(['"](.+?)['"]\)/);
+    const getByMatch = locator.match(/getBy\w+\(['"](.+?)['"](,\s*\{[^}]*\})?\)/);
     if (getByMatch) {
         const prefix = role ? `${role} ` : '';
-        return `${prefix}${q(getByMatch[1])}${nth}`;
+        const exact = getByMatch[0].includes('exact: true') ? ' --exact' : '';
+        return `${prefix}${q(getByMatch[1])}${exact}${nth}`;
     }
 
     // locator('css') fallback
@@ -382,10 +389,11 @@ export function generateLocator(el: Element): string {
     const title = el.getAttribute('title');
     if (title) return `getByTitle(${escapeString(title)})`;
 
-    // 7. Text content (use substring for long text — getByText does partial matching)
+    // 7. Text content — use exact matching for full text, substring for long text
     const text = (el.textContent || '').trim();
     if (text) {
-        const snippet = text.length <= 80 ? text : text.slice(0, 50).replace(/\s+\S*$/, '');
+        if (text.length <= 80) return `getByText(${escapeString(text)}, { exact: true })`;
+        const snippet = text.slice(0, 50).replace(/\s+\S*$/, '');
         if (snippet) return `getByText(${escapeString(snippet)})`;
     }
 
@@ -500,8 +508,13 @@ export function buildCommands(action: string, el: Element, opts?: {
 
         case 'fill': {
             const val = opts?.value ?? '';
+            // Bare role without name (e.g. "textbox") makes fill ambiguous:
+            // `fill textbox "val"` parses as fill(role=textbox, name="val", value="")
+            const fillLoc = /^[a-z]+$/.test(pwArgs)
+                ? q(buildCssSelector(el))
+                : pwArgs;
             return {
-                pw: `fill ${pwArgs} ${q(val)}${inFlag}`,
+                pw: `fill ${fillLoc} ${q(val)}${inFlag}`,
                 js: `await ${jsLoc}.fill(${escapeString(val)});`,
             };
         }
@@ -520,8 +533,12 @@ export function buildCommands(action: string, el: Element, opts?: {
 
         case 'select': {
             const optVal = opts?.option ?? '';
+            // Same bare-role guard as fill
+            const selLoc = /^[a-z]+$/.test(pwArgs)
+                ? q(buildCssSelector(el))
+                : pwArgs;
             return {
-                pw: `select ${pwArgs} ${q(optVal)}${inFlag}`,
+                pw: `select ${selLoc} ${q(optVal)}${inFlag}`,
                 js: `await ${jsLoc}.selectOption(${escapeString(optVal)});`,
             };
         }

--- a/packages/extension/src/content/recorder.ts
+++ b/packages/extension/src/content/recorder.ts
@@ -33,28 +33,29 @@ function detectFrameSelector(): string | null {
         // Same-origin: window.frameElement is accessible
         const frame = window.frameElement;
         if (frame) {
+            const tag = frame.tagName.toLowerCase(); // 'frame' or 'iframe'
             // Prefer id selector
             if (frame.id) return `#${CSS.escape(frame.id)}`;
             // Prefer name attribute
             const name = frame.getAttribute('name');
-            if (name) return `iframe[name="${name}"]`;
+            if (name) return `${tag}[name="${name}"]`;
             // Prefer src attribute
             const src = frame.getAttribute('src');
-            if (src) return `iframe[src="${src}"]`;
+            if (src) return `${tag}[src="${src}"]`;
             // Fall back to tag + nth-of-type
             const parent = frame.parentElement;
             if (parent) {
-                const siblings = Array.from(parent.querySelectorAll(':scope > iframe'));
+                const siblings = Array.from(parent.querySelectorAll(`:scope > ${tag}`));
                 const idx = siblings.indexOf(frame);
-                if (siblings.length === 1) return 'iframe';
-                return `iframe:nth-of-type(${idx + 1})`;
+                if (siblings.length === 1) return tag;
+                return `${tag}:nth-of-type(${idx + 1})`;
             }
-            return 'iframe';
+            return tag;
         }
     } catch { /* cross-origin — frameElement throws */ }
 
     // Cross-origin fallback: use location to build a src-based selector
-    // This is a best-effort approach
+    // This is a best-effort approach — assume iframe (modern standard)
     try {
         const src = window.location.href;
         if (src && src !== 'about:blank') return `iframe[src="${src}"]`;

--- a/packages/extension/test/content/locator.test.ts
+++ b/packages/extension/test/content/locator.test.ts
@@ -241,6 +241,18 @@ describe('locator', () => {
             const input = document.querySelector('input') as HTMLInputElement;
             expect(getLabel(input)).toBe('Name');
         });
+
+        it('detects informal label from preceding table cell', () => {
+            document.body.innerHTML = '<table><tr><td>Benutzerkennung:*</td><td><input type="text"></td></tr></table>';
+            const input = document.querySelector('input') as HTMLInputElement;
+            expect(getLabel(input)).toBe('Benutzerkennung:*');
+        });
+
+        it('returns empty when preceding cell has no text', () => {
+            document.body.innerHTML = '<table><tr><td></td><td><input type="text"></td></tr></table>';
+            const input = document.querySelector('input') as HTMLInputElement;
+            expect(getLabel(input)).toBe('');
+        });
     });
 
     // ─── findByRoleAndName ────────────────────────────────────────────────
@@ -380,11 +392,11 @@ describe('locator', () => {
             expect(generateLocator(el)).toBe("getByTitle('Tooltip text')");
         });
 
-        it('uses getByText for element with short text', () => {
+        it('uses getByText with exact: true for element with short text', () => {
             const el = document.createElement('span');
             el.textContent = 'Hello world';
             document.body.appendChild(el);
-            expect(generateLocator(el)).toBe("getByText('Hello world')");
+            expect(generateLocator(el)).toBe("getByText('Hello world', { exact: true })");
         });
 
         it('uses getByRole without name for role-only elements', () => {
@@ -654,6 +666,11 @@ describe('locator', () => {
         it('parses getByText', () => {
             expect(locatorToPwArgs("getByText('hello')"))
                 .toBe('"hello"');
+        });
+
+        it('parses getByText with exact: true and adds --exact', () => {
+            expect(locatorToPwArgs("getByText('Bis 45 km/h', { exact: true })"))
+                .toBe('"Bis 45 km/h" --exact');
         });
 
         it('parses getByTestId', () => {
@@ -955,6 +972,33 @@ describe('locator', () => {
             const editButtons = [...document.querySelectorAll('button')].filter(b => b.textContent === 'Edit');
             const cmds = buildCommands('click', editButtons[1]);
             expect(cmds!.pw).toBe('click button "Edit" --in row "Bob"');
+        });
+
+        it('uses CSS fallback for fill when textbox has no accessible name', () => {
+            document.body.innerHTML = '<input type="text" class="username">';
+            const input = document.querySelector('input')!;
+            const cmds = buildCommands('fill', input, { value: 'user' });
+            // Should NOT produce `fill textbox "user"` (ambiguous)
+            expect(cmds!.pw).not.toMatch(/^fill textbox /);
+            // Should use CSS selector fallback
+            expect(cmds!.pw).toContain('"user"');
+            expect(cmds!.js).toContain(".fill('user')");
+        });
+
+        it('uses label from preceding table cell for fill', () => {
+            document.body.innerHTML = '<table><tr><td>Username:</td><td><input type="text"></td></tr></table>';
+            const input = document.querySelector('input')!;
+            const cmds = buildCommands('fill', input, { value: 'admin' });
+            expect(cmds!.pw).toContain('"Username:"');
+            expect(cmds!.pw).toContain('"admin"');
+        });
+
+        it('adds --exact for text-based click locator', () => {
+            document.body.innerHTML = '<div>Bis 45 km/h</div>';
+            const div = document.querySelector('div')!;
+            const cmds = buildCommands('click', div);
+            expect(cmds!.pw).toContain('--exact');
+            expect(cmds!.js).toContain("getByText('Bis 45 km/h', { exact: true })");
         });
 
         it('uses text-only --in from heading context instead of --nth', () => {


### PR DESCRIPTION
## Summary
- **#769**: `detectFrameSelector()` hardcoded `iframe` in CSS selectors. Now uses `frame.tagName.toLowerCase()` to correctly handle `<frame>` elements in frameset pages.
- **#767**: `generateLocator()` now emits `getByText(text, { exact: true })` for short text (<=80 chars), and `locatorToPwArgs()` converts it to the `--exact` flag. Prevents substring matching from resolving to multiple elements.
- **#768**: `getLabel()` now detects informal labels from preceding table cells (common in legacy enterprise forms). `buildCommands()` falls back to CSS selector for fill/select when the locator is a bare role without a name, preventing the ambiguous `fill textbox "value"` output.

Related: #767, #768, #769

## Test plan
- [x] All 566 extension tests pass (including 131 locator tests)
- [x] 6 new tests: getLabel table cell detection (2), locatorToPwArgs exact flag (1), buildCommands fill/label/exact (3)
- [x] 1 existing test updated to match new exact: true behavior
- [x] Full build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)