### PR TITLE
test: add e2e test for recording inside <frame> elements

### DIFF
--- a/packages/extension/e2e/recording/recording.spec.ts
+++ b/packages/extension/e2e/recording/recording.spec.ts
@@ -101,6 +101,33 @@ test.describe('Recording flow', () => {
       expect(editorText).toContain('click');
     });
 
+    test('clicking inside a <frame> uses frame tag, not iframe (#769)', async ({ sidePanel, testPage }) => {
+      const ctx = testPage.context();
+      // Serve frameset pages via route so they're same-origin (file:// treats frames as cross-origin)
+      await ctx.route('https://test.local/frameset.html', route => route.fulfill({
+        contentType: 'text/html',
+        body: '<html><frameset><frame name="main" src="https://test.local/frame-content.html" /></frameset></html>',
+      }));
+      await ctx.route('https://test.local/frame-content.html', route => route.fulfill({
+        contentType: 'text/html',
+        body: '<button>Arbeitskorb</button>',
+      }));
+
+      await testPage.goto('https://test.local/frameset.html');
+      await testPage.bringToFront();
+      await sidePanel.attachToActiveTab();
+
+      await sidePanel.startRecording();
+
+      await testPage.bringToFront();
+      await testPage.frame({ name: 'main' })!.getByRole('button', { name: 'Arbeitskorb' }).click();
+
+      await sidePanel.waitForEditorText('click button "Arbeitskorb"');
+      const editorText = await sidePanel.getEditorText();
+      expect(editorText).toContain('--frame "frame[name=');
+      expect(editorText).not.toContain('iframe');
+    });
+
     test('stop recording resets button state', async ({ sidePanel }) => {
       await sidePanel.recordBtn.click();
       await expect(sidePanel.recordBtn).toHaveClass(/recording/, { timeout: 10000 });


### PR DESCRIPTION
## Summary
- Adds an e2e test verifying the recorder generates `--frame "frame[name=...]"` (not `iframe[...]`) when clicking inside a `<frameset>`/`<frame>` page.
- Uses `context.route()` to serve same-origin frameset HTML inline, avoiding file:// cross-origin restrictions.

Related: #769

## Test plan
- [x] New e2e test passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)