### PR TITLE
fix: recorder generates --in for both radios in yes/no groups

### DIFF
--- a/packages/extension/src/background.ts
+++ b/packages/extension/src/background.ts
@@ -396,6 +396,8 @@ async function pickElement(): Promise<{ ok: boolean; info?: any; error?: string 
         for (const child of cur.children) {
           if (child.contains(el)) break;
           if (child.matches('a') || child.querySelector('a')) continue; // skip peer items with links
+          if (child.querySelector('input[type="radio"], input[type="checkbox"]')) continue; // skip peer radio/checkbox labels
+          if (child.matches('input[type="radio"], input[type="checkbox"]')) continue;
           const t = leafText(child);
           if (t) { headingContext = t; break; }
         }

--- a/packages/extension/src/content/locator.ts
+++ b/packages/extension/src/content/locator.ts
@@ -183,6 +183,9 @@ function findNearestHeading(el: Element): { container: Element; text: string } |
             if (child.contains(el)) break; // stop at el's branch
             // Skip peer items — section labels don't contain navigation links
             if (child.matches('a') || child.querySelector('a')) continue;
+            // Skip peer radio/checkbox labels — "Ja" label is not a heading for "Nein"
+            if (child.querySelector('input[type="radio"], input[type="checkbox"]')) continue;
+            if (child.matches('input[type="radio"], input[type="checkbox"]')) continue;
             const text = findLeafText(child);
             if (text) return { container: current, text };
         }

--- a/packages/extension/test/content/locator.test.ts
+++ b/packages/extension/test/content/locator.test.ts
@@ -1001,6 +1001,32 @@ describe('locator', () => {
             expect(cmds!.js).toContain("getByText('Bis 45 km/h', { exact: true })");
         });
 
+        it('generates --in for both Ja and Nein radios in yes/no groups (#771)', () => {
+            document.body.innerHTML = `
+                <div>
+                    <span>Abweichender Sachbearbeiter?</span>
+                    <div>
+                        <label><input type="radio" name="q1" value="ja"> Ja</label>
+                        <label><input type="radio" name="q1" value="nein"> Nein</label>
+                    </div>
+                </div>
+                <div>
+                    <span>Newsletter abonnieren?</span>
+                    <div>
+                        <label><input type="radio" name="q2" value="ja"> Ja</label>
+                        <label><input type="radio" name="q2" value="nein"> Nein</label>
+                    </div>
+                </div>`;
+            const radios = document.querySelectorAll('input[type="radio"]');
+            // "Ja" in first group
+            const jaCmd = buildCommands('check', radios[0]);
+            expect(jaCmd!.pw).toContain('--in "Abweichender Sachbearbeiter?"');
+            // "Nein" in first group — should also get --in, not --nth
+            const neinCmd = buildCommands('check', radios[1]);
+            expect(neinCmd!.pw).toContain('--in "Abweichender Sachbearbeiter?"');
+            expect(neinCmd!.pw).not.toContain('--nth');
+        });
+
         it('uses text-only --in from heading context instead of --nth', () => {
             document.body.innerHTML = `
                 <div>


### PR DESCRIPTION
## Summary
- `findNearestHeading()` was resolving the "Ja" `<label>` as the heading for "Nein" radios (preceding sibling). Every "Nein" on the page got heading "Ja", failing the uniqueness check → fallback to `--nth`.
- Now skips siblings containing `<input type="radio">` or `<input type="checkbox">` in both `findNearestHeading()` (locator.ts) and the picker's heading walk (background.ts).
- "Nein" now skips the "Ja" label and finds the actual question text (e.g. "Abweichender Sachbearbeiter?").

Related: #771
Picker --in tracked separately in #774.

## Test plan
- [x] All 567 unit tests pass (including new yes/no radio group test)
- [x] Manually verified on https://www.imbus.de/akademie/anmeldung/rfcp-robot-framework-certified-professional/6215

🤖 Generated with [Claude Code](https://claude.com/claude-code)