### PR TITLE
fix: highlight treats dot in text as CSS selector

### DIFF
--- a/packages/extension/src/panel/lib/commands.ts
+++ b/packages/extension/src/panel/lib/commands.ts
@@ -458,7 +458,7 @@ function resolveArgs(args: ParsedArgs): ParsedArgs | DirectExecution {
       if (/^e\d+$/.test(loc)) return { jsExpr: call(highlightByRef, loc) };
       const nth = args.nth !== undefined ? parseInt(String(args.nth), 10) : undefined;
       const exact = args.exact ? true : undefined;
-      const isSelector = /[.#[\]>:=]/.test(loc);
+      const isSelector = /^[.#]|\[|^[a-z]+[:.#]/.test(loc);
       // highlight <role> "<name>" → getByRole(role, { name })
       const inRole = args['in-role'] !== undefined ? String(args['in-role']) : undefined;
       const inText = args['in-text'] !== undefined ? String(args['in-text']) : undefined;

--- a/packages/extension/test/content/locator.test.ts
+++ b/packages/extension/test/content/locator.test.ts
@@ -127,6 +127,11 @@ describe('locator', () => {
             expect(getImplicitRole(el)).toBe('listitem');
         });
 
+        it('returns null for STRONG (no implicit role)', () => {
+            const el = document.createElement('strong');
+            expect(getImplicitRole(el)).toBeNull();
+        });
+
         it('returns null for unknown elements', () => {
             const el = document.createElement('div');
             expect(getImplicitRole(el)).toBeNull();
@@ -390,6 +395,13 @@ describe('locator', () => {
             el.setAttribute('title', 'Tooltip text');
             document.body.appendChild(el);
             expect(generateLocator(el)).toBe("getByTitle('Tooltip text')");
+        });
+
+        it('uses getByText for STRONG element (no implicit role)', () => {
+            const el = document.createElement('strong');
+            el.textContent = 'Node.js';
+            document.body.appendChild(el);
+            expect(generateLocator(el)).toBe("getByText('Node.js', { exact: true })");
         });
 
         it('uses getByText with exact: true for element with short text', () => {


### PR DESCRIPTION
## Summary
- `highlight "Node.js"` was broken — the `.` in "Node.js" caused the `isSelector` regex to route it to `page.locator()` (CSS mode) instead of `page.getByText()` (text mode)
- Tighten the heuristic to only match actual CSS patterns: starts with `.`/`#`, contains `[`, or lowercase tag followed by `:.#`
- Add tests for `<strong>` element locator generation

## Test plan
- [ ] `highlight "Node.js"` → "Highlighted 1 element" (was 0)
- [ ] `highlight .btn-primary` → still works as CSS selector
- [ ] `highlight div:has-text("text")` → still works as CSS selector
- [ ] Existing highlight tests pass (691/691)

🤖 Generated with [Claude Code](https://claude.com/claude-code)