### PR TITLE
feat: add explicit css subcommand for CSS selectors

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -345,7 +345,7 @@ pw> click "Submit" --frame "#my-iframe"      # click inside an iframe
 |---------|-------|-------------|
 | `snapshot` | `s` | Accessibility tree with element refs |
 | `screenshot` | `ss` | Take a screenshot (saved to file) |
-| `highlight <text\|selector>` | `hl` | Highlight matching elements on page |
+| `highlight <text\|role\|css>` | `hl` | Highlight matching elements on page |
 | `eval <expr>` | `e` | Evaluate JavaScript in browser context |
 | `console` | `con` | Browser console messages |
 | `network` | `net` | Network requests log |

--- a/packages/cli/src/engine.ts
+++ b/packages/cli/src/engine.ts
@@ -142,21 +142,43 @@ export class Engine {
         } else {
           const nth = args.nth !== undefined ? parseInt(String(args.nth), 10) : undefined;
           let locExpr: string;
+          // highlight css <selector> → explicit CSS selector
+          if (parts[0] === 'css') {
+            const selector = parts.slice(1).join(' ');
+            locExpr = `page.locator(${JSON.stringify(selector)})`;
           // highlight <role> "<name>" → getByRole(role, { name })
-          if (parts.length >= 2 && /^[a-z]+$/.test(parts[0])) {
+          } else if (parts.length >= 2 && /^[a-z]+$/.test(parts[0])) {
             const role = parts[0];
             const name = parts.slice(1).join(' ');
             locExpr = `page.getByRole(${JSON.stringify(role)}, { name: ${JSON.stringify(name)}, exact: true })`;
           } else {
             const loc = parts.join(' ');
-            const isSelector = /[.#\[\]>:=]/.test(loc);
-            locExpr = isSelector
-              ? `page.locator(${JSON.stringify(loc)})`
-              : `page.getByText(${JSON.stringify(loc)})`;
+            locExpr = `page.getByText(${JSON.stringify(loc)})`;
           }
           if (nth !== undefined) locExpr += `.nth(${nth})`;
           args = { _: ['run-code', `async (page) => { await ${locExpr}.highlight(); return "Highlighted"; }`] };
         }
+      }
+    }
+
+    // ── css subcommand → run-code translation ──
+    const CSS_ACTIONS: Record<string, string> = {
+      click: 'click', dblclick: 'dblclick', hover: 'hover',
+      check: 'check', uncheck: 'uncheck',
+      fill: 'fill', select: 'selectOption',
+    };
+    if (CSS_ACTIONS[args._[0]] && args._[1] === 'css') {
+      const action = CSS_ACTIONS[args._[0]];
+      const needsValue = action === 'fill' || action === 'selectOption';
+      const selectorParts = needsValue ? args._.slice(2, -1) : args._.slice(2);
+      const selector = selectorParts.join(' ');
+      if (selector) {
+        const locExpr = `page.locator(${JSON.stringify(selector)})`;
+        const value = needsValue ? args._[args._.length - 1] : undefined;
+        const actionCall = value
+          ? `${locExpr}.${action}(${JSON.stringify(value)})`
+          : `${locExpr}.${action}()`;
+        args = { _: ['run-code', `async (page) => { await ${actionCall}; return "Done"; }`] };
       }
     }
 

--- a/packages/cli/test/engine.test.ts
+++ b/packages/cli/test/engine.test.ts
@@ -244,8 +244,8 @@ describe('Engine', () => {
       });
     });
 
-    it('uses page.locator() for CSS selectors', async () => {
-      await engine.run({ _: ['highlight', '.btn'] });
+    it('uses page.locator() for css subcommand', async () => {
+      await engine.run({ _: ['highlight', 'css', '.btn'] });
       expect(mocks.callTool).toHaveBeenCalledWith(
         'browser_run_code',
         expect.objectContaining({ code: expect.stringContaining('page.locator(".btn").highlight()') }),

--- a/packages/cli/test/repl-processline.test.ts
+++ b/packages/cli/test/repl-processline.test.ts
@@ -345,10 +345,10 @@ describe('processLine', () => {
     expect(output).toContain('Unknown command');
   });
 
-  it('passes highlight command through to engine', async () => {
+  it('passes highlight css command through to engine', async () => {
     const ctx = makeCtx();
-    await processLine(ctx, 'highlight .btn');
-    expect(ctx.conn.run).toHaveBeenCalledWith(expect.objectContaining({ _: ['highlight', '.btn'] }));
+    await processLine(ctx, 'highlight css .btn');
+    expect(ctx.conn.run).toHaveBeenCalledWith(expect.objectContaining({ _: ['highlight', 'css', '.btn'] }));
   });
 
   it('passes >> chained selector through to engine', async () => {

--- a/packages/extension/src/panel/lib/commands.ts
+++ b/packages/extension/src/panel/lib/commands.ts
@@ -32,8 +32,8 @@ export const COMMANDS: Record<string, CommandInfo> = {
                               examples: ['goto https://example.com'] },
     'help':                 { desc: 'Show available commands', usage: 'help [command]',
                               examples: ['help', 'help click'] },
-    'highlight':            { desc: 'Highlight element on page', usage: 'highlight <text|selector>',
-                              examples: ['highlight "Submit"', 'highlight .btn-primary'] },
+    'highlight':            { desc: 'Highlight element on page', usage: 'highlight <text|role|css>',
+                              examples: ['highlight "Submit"', 'highlight css .btn-primary'] },
     'history':              { desc: 'Show command history' },
     'history clear':        { desc: 'Clear command history' },
     'hover':                { desc: 'Hover over element', usage: 'hover <text> | hover <ref>' },
@@ -456,22 +456,41 @@ function resolveArgs(args: ParsedArgs): ParsedArgs | DirectExecution {
     if (loc) {
       // highlight <ref> → use aria-ref selector
       if (/^e\d+$/.test(loc)) return { jsExpr: call(highlightByRef, loc) };
+      // highlight css <selector> → explicit CSS selector
+      if (loc === 'css') {
+        const selector = args._.slice(2).join(' ');
+        if (!selector) return args; // fall through to MCP
+        const nth = args.nth !== undefined ? parseInt(String(args.nth), 10) : undefined;
+        return { jsExpr: call(highlightBySelector, selector, nth) };
+      }
       const nth = args.nth !== undefined ? parseInt(String(args.nth), 10) : undefined;
       const exact = args.exact ? true : undefined;
-      const isSelector = /^[.#]|\[|^[a-z]+[:.#]/.test(loc);
       // highlight <role> "<name>" → getByRole(role, { name })
       const inRole = args['in-role'] !== undefined ? String(args['in-role']) : undefined;
       const inText = args['in-text'] !== undefined ? String(args['in-text']) : undefined;
-      if (!isSelector && args._.length >= 3 && /^[a-z]+$/.test(loc)) {
+      if (args._.length >= 3 && /^[a-z]+$/.test(loc)) {
         const name = args._.slice(2).join(' ');
         if (inText && !inRole) return { jsExpr: callScoped(highlightByRole, inText, name, loc, name, nth) };
         return { jsExpr: call(highlightByRole, loc, name, nth, inRole, inText) };
       }
-      if (!isSelector && inText && !inRole) return { jsExpr: callScoped(highlightByText, inText, loc, loc, nth, exact) };
-      return isSelector
-        ? { jsExpr: call(highlightBySelector, loc, nth) }
-        : { jsExpr: call(highlightByText, loc, nth, exact) };
+      if (inText && !inRole) return { jsExpr: callScoped(highlightByText, inText, loc, loc, nth, exact) };
+      return { jsExpr: call(highlightByText, loc, nth, exact) };
     }
+  }
+
+  // ── css subcommand (e.g. click css .btn, hover css div.menu) ─
+  const CSS_ACTIONS: Record<string, string> = {
+    click: 'click', dblclick: 'dblclick', hover: 'hover',
+    check: 'check', uncheck: 'uncheck',
+    fill: 'fill', select: 'selectOption',
+  };
+  if (CSS_ACTIONS[cmdName] && args._[1] === 'css') {
+    const needsValue = cmdName === 'fill' || cmdName === 'select';
+    const selectorParts = needsValue ? args._.slice(2, -1) : args._.slice(2);
+    const selector = selectorParts.join(' ');
+    const action = CSS_ACTIONS[cmdName];
+    const value = needsValue ? args._[args._.length - 1] : undefined;
+    if (selector) return { jsExpr: call(chainAction, selector, action, value) };
   }
 
   // ── >> chaining ─────────────────────────────────────────────

--- a/packages/extension/test/lib/commands.test.ts
+++ b/packages/extension/test/lib/commands.test.ts
@@ -172,8 +172,8 @@ describe("highlight", () => {
     expect(jsExpr).toContain('"Submit"');
   });
 
-  it("routes CSS selector to highlightBySelector", () => {
-    const { jsExpr } = direct("highlight .btn-primary");
+  it("routes css subcommand to highlightBySelector", () => {
+    const { jsExpr } = direct("highlight css .btn-primary");
     expect(jsExpr).toContain('highlightBySelector');
     expect(jsExpr).toContain('".btn-primary"');
   });
@@ -183,22 +183,48 @@ describe("highlight", () => {
     expect(jsExpr).toContain('clearHighlight');
   });
 
-  it("preserves quotes inside :has-text() CSS pseudo-class", () => {
-    const { jsExpr } = direct('highlight div:has-text("RFCP")');
+  it("routes css with :has-text() pseudo-class", () => {
+    const { jsExpr } = direct('highlight css div:has-text("RFCP")');
     expect(jsExpr).toContain('highlightBySelector');
     expect(jsExpr).toContain('has-text(\\"RFCP\\")');
   });
 
-  it("preserves single quotes inside :has-text()", () => {
-    const { jsExpr } = direct("highlight div:has-text('RFCP')");
-    expect(jsExpr).toContain('highlightBySelector');
-    expect(jsExpr).toContain("has-text('RFCP')");
+  it("routes text with dot as text, not CSS", () => {
+    const { jsExpr } = direct('highlight "Node.js"');
+    expect(jsExpr).toContain('highlightByText');
+    expect(jsExpr).toContain('"Node.js"');
+  });
+});
+
+// ─── css subcommand ──────────────────────────────────────────────────────────
+
+describe("css subcommand", () => {
+  it("routes click css to locator", () => {
+    const { jsExpr } = direct("click css .btn-primary");
+    expect(jsExpr).toContain('chainAction');
+    expect(jsExpr).toContain('".btn-primary"');
+    expect(jsExpr).toContain('"click"');
   });
 
-  it("preserves spaces inside :has-text()", () => {
-    const { jsExpr } = direct('highlight div:has-text("Hello World")');
-    expect(jsExpr).toContain('highlightBySelector');
-    expect(jsExpr).toContain('has-text(\\"Hello World\\")');
+  it("routes hover css to locator", () => {
+    const { jsExpr } = direct("hover css div.menu-item");
+    expect(jsExpr).toContain('chainAction');
+    expect(jsExpr).toContain('"div.menu-item"');
+    expect(jsExpr).toContain('"hover"');
+  });
+
+  it("routes fill css with value", () => {
+    const { jsExpr } = direct('fill css .input "hello"');
+    expect(jsExpr).toContain('chainAction');
+    expect(jsExpr).toContain('".input"');
+    expect(jsExpr).toContain('"fill"');
+    expect(jsExpr).toContain('"hello"');
+  });
+
+  it("routes check css to locator", () => {
+    const { jsExpr } = direct('check css input[type="checkbox"]');
+    expect(jsExpr).toContain('chainAction');
+    expect(jsExpr).toContain('"check"');
   });
 });
 


### PR DESCRIPTION
## Summary
- Replace the ambiguous `isSelector` heuristic with an explicit `css` subcommand
- Works consistently across **all** action commands, not just `highlight`
- No more false positives for text containing `.`, `#`, `:`, `>`, `=`, `[`, `]`

### Before
```
highlight .btn-primary     → CSS (heuristic guess)
highlight "Node.js"        → CSS (wrong! dot triggered heuristic)
click .btn                 → text search (inconsistent with highlight)
```

### After
```
highlight css .btn-primary → CSS (explicit)
highlight "Node.js"        → text (always)
click css .btn-primary     → CSS (explicit, consistent)
hover css div.menu-item    → CSS (explicit)
fill css .input "hello"    → CSS (explicit)
```

## Test plan
- [x] `highlight css .todoapp` — highlights correctly
- [x] `highlight "Node.js"` — text mode, no longer misrouted as CSS
- [x] Extension tests: 694 passed
- [x] CLI tests: 221 passed
- [ ] Manual: `click css .new-todo`, `hover css .info`

Closes #779

🤖 Generated with [Claude Code](https://claude.com/claude-code)