### PR TITLE
fix: picker generates PW commands for CSS fallback locators

### DIFF
--- a/packages/extension/src/panel/lib/pick-info.ts
+++ b/packages/extension/src/panel/lib/pick-info.ts
@@ -179,6 +179,10 @@ function derivePwCommand(info: ElementPickInfo, ariaSnapshot?: string, headingCo
     const text = info.text?.trim();
     if (text && text.length <= 80) return `highlight "${text}"${(needsScoping && headingIn) || nth}`;
 
+    // CSS fallback — pure CSS selectors without semantic role/name/text
+    const cssMatch = info.locator.match(/^locator\(['"](.+?)['"]\)(?:\.(?:first|last)\(\)|\.nth\(\d+\))?$/);
+    if (cssMatch) return `highlight css "${cssMatch[1]}"${nth}`;
+
     return null;
 }
 
@@ -198,8 +202,10 @@ function deriveAssertion(info: ElementPickInfo, locator: string, pwCommand: stri
     const tag = info.tag;
     const inputType = info.attributes?.type?.toLowerCase() ?? '';
     // Extract name from pw command, falling back to JS locator parsing
+    // Skip extraction for CSS fallback commands — the quoted value is a selector, not a name
     const parsed = parseJsLocator(locator);
-    const name = (pwCommand ? extractPwName(pwCommand) : null) ?? parsed.name ?? null;
+    const isCssPw = pwCommand?.includes(' css ') ?? false;
+    const name = (pwCommand && !isCssPw ? extractPwName(pwCommand) : null) ?? parsed.name ?? null;
     const quotedName = name ? `"${name}"` : null;
     // Extract role from aria snapshot, element attributes, or JS locator
     const ariaRole = ariaSnapshot ? parseAriaSnapshot(ariaSnapshot)?.element.role : null;
@@ -262,6 +268,10 @@ function deriveAssertion(info: ElementPickInfo, locator: string, pwCommand: stri
         assertPw = `verify-visible ${role}${nth}`;
     } else if (target) {
         assertPw = `verify-text ${target}`;
+    } else if (isCssPw) {
+        // CSS fallback — extract selector from pw command
+        const cssSel = extractPwName(pwCommand!);
+        assertPw = cssSel ? `verify-visible css "${cssSel}"${nth}` : '';
     } else {
         assertPw = '';
     }

--- a/packages/extension/test/lib/pick-info.test.ts
+++ b/packages/extension/test/lib/pick-info.test.ts
@@ -547,4 +547,33 @@ describe('buildPickResult', () => {
         expect(result.pwCommand).toContain('--in listitem');
         expect(result.pwCommand).not.toContain('Some Heading');
     });
+
+    // ─── CSS fallback ─────────────────────────────────────────────────────
+
+    it('generates css fallback pw command for pure CSS selectors', () => {
+        const result = buildPickResult(makeInfo({
+            locator: "locator('#movie_player video')",
+            tag: 'VIDEO',
+            text: '',
+        }), null, '', null);
+        expect(result.pwCommand).toBe('highlight css "#movie_player video"');
+    });
+
+    it('generates css fallback assert for pure CSS selectors', () => {
+        const result = buildPickResult(makeInfo({
+            locator: "locator('#movie_player video')",
+            tag: 'VIDEO',
+            text: '',
+        }), null, '', null);
+        expect(result.assertPw).toBe('verify-visible css "#movie_player video"');
+    });
+
+    it('generates css fallback with --nth for CSS + .first()', () => {
+        const result = buildPickResult(makeInfo({
+            locator: "locator('.item').first()",
+            tag: 'DIV',
+            text: '',
+        }), null, '', null);
+        expect(result.pwCommand).toBe('highlight css ".item" --nth 0');
+    });
 });


### PR DESCRIPTION
## Summary
- When picking elements without semantic roles/names/text (e.g. `<video>` on YouTube), the picker only showed JS format with no PW keyword output
- Add CSS fallback in `derivePwCommand()` — generates `highlight css "selector"` instead of returning `null`
- Add CSS fallback in `deriveAssertion()` — generates `verify-visible css "selector"` instead of empty string
- Skip extracting "name" from CSS PW commands so the selector isn't misused as assertion text

## Test plan
- [x] 3 new unit tests for CSS fallback (pw command, assert, --nth)
- [x] All 702 extension tests pass
- [ ] Manual: pick a `<video>` element on YouTube → verify pw/assert lines appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)