### PR TITLE
fix: add css subcommand support for verify commands

### DIFF
--- a/packages/core/src/page-scripts.ts
+++ b/packages/core/src/page-scripts.ts
@@ -130,6 +130,27 @@ export async function verifyVisible(page, role, name) {
     throw new Error('Element not visible: ' + role + ' "' + name + '"');
 }
 
+export async function verifyCssVisible(page, selector) {
+  if (!(await page.locator(selector).isVisible()))
+    throw new Error('Element not visible: css "' + selector + '"');
+}
+
+export async function verifyCssElement(page, selector) {
+  if (await page.locator(selector).count() === 0)
+    throw new Error('Element not found: css "' + selector + '"');
+}
+
+export async function verifyCssNoElement(page, selector) {
+  if (await page.locator(selector).count() > 0)
+    throw new Error('Element still exists: css "' + selector + '"');
+}
+
+export async function verifyCssValue(page, selector, expected) {
+  const v = await page.locator(selector).inputValue();
+  if (v !== expected)
+    throw new Error('Expected "' + expected + '", got "' + v + '"');
+}
+
 export async function verifyInputValue(page, label, expected) {
   let loc = page.getByLabel(label);
   if (await loc.count() === 0) loc = page.getByRole('spinbutton', { name: label });

--- a/packages/core/src/parser.ts
+++ b/packages/core/src/parser.ts
@@ -11,7 +11,8 @@ import { minimist, COMMANDS } from './resolve.js';
 import {
   buildRunCode, buildRunCodeScoped, verifyText, verifyElement, verifyValue, verifyList,
   verifyTitle, verifyUrl, verifyNoText, verifyNoElement,
-  verifyVisible, verifyInputValue, waitForText,
+  verifyVisible, verifyCssVisible, verifyCssElement, verifyCssNoElement, verifyCssValue,
+  verifyInputValue, waitForText,
   actionByText, fillByText, selectByText, checkByText, uncheckByText,
   actionByRole, fillByRole, selectByRole, pressKeyByRole,
 } from './page-scripts.js';
@@ -206,27 +207,52 @@ export function resolveArgs(args: ParsedArgs): ParsedArgs {
     const subType = args._[1];
     const rest = args._.slice(2);
     let translated: ParsedArgs | null = null;
-    if (subType === 'title' && rest.length > 0)
-      translated = buildRunCode(verifyTitle as PageScriptFn, rest.join(' '));
-    else if (subType === 'url' && rest.length > 0)
-      translated = buildRunCode(verifyUrl as PageScriptFn, rest.join(' '));
-    else if (subType === 'text' && rest.length > 0)
-      translated = buildRunCode(verifyText as PageScriptFn, rest.join(' '));
-    else if (subType === 'no-text' && rest.length > 0)
-      translated = buildRunCode(verifyNoText as PageScriptFn, rest.join(' '));
-    else if (subType === 'element' && rest.length >= 2)
-      translated = buildRunCode(verifyElement as PageScriptFn, rest[0], rest.slice(1).join(' '));
-    else if (subType === 'no-element' && rest.length >= 2)
-      translated = buildRunCode(verifyNoElement as PageScriptFn, rest[0], rest.slice(1).join(' '));
-    else if (subType === 'value' && rest.length >= 2)
-      translated = buildRunCode(verifyValue as PageScriptFn, rest[0], rest.slice(1).join(' '));
-    else if (subType === 'visible' && rest.length >= 2)
-      translated = buildRunCode(verifyVisible as PageScriptFn, rest[0], rest.slice(1).join(' '));
-    else if (subType === 'input-value' && rest.length >= 2)
-      translated = buildRunCode(verifyInputValue as PageScriptFn, rest[0], rest.slice(1).join(' '));
-    else if (subType === 'list' && rest.length >= 2)
-      translated = buildRunCode(verifyList as PageScriptFn, rest[0], rest.slice(1));
+    // css subcommand: verify element css ".sel", verify visible css ".sel", etc.
+    if (rest[0] === 'css' && rest.length >= 2) {
+      const selector = rest.slice(1).join(' ');
+      if (subType === 'visible') translated = buildRunCode(verifyCssVisible as PageScriptFn, selector);
+      else if (subType === 'element') translated = buildRunCode(verifyCssElement as PageScriptFn, selector);
+      else if (subType === 'no-element') translated = buildRunCode(verifyCssNoElement as PageScriptFn, selector);
+      else if (subType === 'value' && rest.length >= 3) {
+        const sel = rest.slice(1, -1).join(' ');
+        translated = buildRunCode(verifyCssValue as PageScriptFn, sel, rest[rest.length - 1]);
+      }
+    }
+    if (!translated) {
+      if (subType === 'title' && rest.length > 0)
+        translated = buildRunCode(verifyTitle as PageScriptFn, rest.join(' '));
+      else if (subType === 'url' && rest.length > 0)
+        translated = buildRunCode(verifyUrl as PageScriptFn, rest.join(' '));
+      else if (subType === 'text' && rest.length > 0)
+        translated = buildRunCode(verifyText as PageScriptFn, rest.join(' '));
+      else if (subType === 'no-text' && rest.length > 0)
+        translated = buildRunCode(verifyNoText as PageScriptFn, rest.join(' '));
+      else if (subType === 'element' && rest.length >= 2)
+        translated = buildRunCode(verifyElement as PageScriptFn, rest[0], rest.slice(1).join(' '));
+      else if (subType === 'no-element' && rest.length >= 2)
+        translated = buildRunCode(verifyNoElement as PageScriptFn, rest[0], rest.slice(1).join(' '));
+      else if (subType === 'value' && rest.length >= 2)
+        translated = buildRunCode(verifyValue as PageScriptFn, rest[0], rest.slice(1).join(' '));
+      else if (subType === 'visible' && rest.length >= 2)
+        translated = buildRunCode(verifyVisible as PageScriptFn, rest[0], rest.slice(1).join(' '));
+      else if (subType === 'input-value' && rest.length >= 2)
+        translated = buildRunCode(verifyInputValue as PageScriptFn, rest[0], rest.slice(1).join(' '));
+      else if (subType === 'list' && rest.length >= 2)
+        translated = buildRunCode(verifyList as PageScriptFn, rest[0], rest.slice(1));
+    }
     if (translated) args = translated;
+  }
+
+  // ── Verify css subcommand (verify-visible css ".sel", verify-element css ".sel") ─
+  if ((cmdName === 'verify-visible' || cmdName === 'verify-element' || cmdName === 'verify-no-element') && args._[1] === 'css' && args._.length >= 3) {
+    const selector = args._.slice(2).join(' ');
+    const fn = cmdName === 'verify-visible' ? verifyCssVisible : cmdName === 'verify-element' ? verifyCssElement : verifyCssNoElement;
+    args = buildRunCode(fn as PageScriptFn, selector);
+  }
+  if (cmdName === 'verify-value' && args._[1] === 'css' && args._.length >= 4) {
+    const selector = args._.slice(2, -1).join(' ');
+    const expected = args._[args._.length - 1];
+    args = buildRunCode(verifyCssValue as PageScriptFn, selector, expected);
   }
 
   // ── Legacy verify-* commands (backward compat) ─────────────

--- a/packages/core/test/parser.test.ts
+++ b/packages/core/test/parser.test.ts
@@ -275,6 +275,62 @@ describe('--in with text locators (resolveArgs)', () => {
   });
 });
 
+describe('verify css subcommand (#787)', () => {
+  it('verify-visible css resolves to verifyCssVisible', () => {
+    const args = parseInput('verify-visible css "#LoginName"');
+    const resolved = resolveArgs(args);
+    expect(resolved._[0]).toBe('run-code');
+    expect(resolved._[1]).toContain('verifyCssVisible');
+    expect(resolved._[1]).toContain('#LoginName');
+  });
+
+  it('verify-element css resolves to verifyCssElement', () => {
+    const args = parseInput('verify-element css ".my-btn"');
+    const resolved = resolveArgs(args);
+    expect(resolved._[0]).toBe('run-code');
+    expect(resolved._[1]).toContain('verifyCssElement');
+    expect(resolved._[1]).toContain('.my-btn');
+  });
+
+  it('verify-no-element css resolves to verifyCssNoElement', () => {
+    const args = parseInput('verify-no-element css ".deleted"');
+    const resolved = resolveArgs(args);
+    expect(resolved._[0]).toBe('run-code');
+    expect(resolved._[1]).toContain('verifyCssNoElement');
+  });
+
+  it('verify-value css resolves to verifyCssValue', () => {
+    const args = parseInput('verify-value css "#LoginName" "testuser"');
+    const resolved = resolveArgs(args);
+    expect(resolved._[0]).toBe('run-code');
+    expect(resolved._[1]).toContain('verifyCssValue');
+    expect(resolved._[1]).toContain('#LoginName');
+    expect(resolved._[1]).toContain('testuser');
+  });
+
+  it('verify visible css (unified) resolves to verifyCssVisible', () => {
+    const args = parseInput('verify visible css "#LoginName"');
+    const resolved = resolveArgs(args);
+    expect(resolved._[0]).toBe('run-code');
+    expect(resolved._[1]).toContain('verifyCssVisible');
+  });
+
+  it('verify element css (unified) resolves to verifyCssElement', () => {
+    const args = parseInput('verify element css ".my-btn"');
+    const resolved = resolveArgs(args);
+    expect(resolved._[0]).toBe('run-code');
+    expect(resolved._[1]).toContain('verifyCssElement');
+  });
+
+  it('verify-visible without css still uses role-based', () => {
+    const args = parseInput('verify-visible button "Submit"');
+    const resolved = resolveArgs(args);
+    expect(resolved._[0]).toBe('run-code');
+    expect(resolved._[1]).toContain('verifyVisible');
+    expect(resolved._[1]).not.toContain('verifyCssVisible');
+  });
+});
+
 describe('booleanOptions', () => {
   it('includes expected options', () => {
     expect(booleanOptions.has('headed')).toBe(true);

--- a/packages/extension/src/panel/lib/commands.ts
+++ b/packages/extension/src/panel/lib/commands.ts
@@ -130,7 +130,8 @@ export const JS_CATEGORIES: Record<string, string[]> = {
 import {
   verifyText, verifyElement, verifyValue, verifyList,
   verifyTitle, verifyUrl, verifyNoText, verifyNoElement,
-  verifyVisible, verifyInputValue, waitForText,
+  verifyVisible, verifyCssVisible, verifyCssElement, verifyCssNoElement, verifyCssValue,
+  verifyInputValue, waitForText,
   actionByText, fillByText, selectByText, checkByText, uncheckByText,
   actionByRole, fillByRole, selectByRole,
   highlightByText, highlightByRole, highlightBySelector, highlightByRef, clearHighlight, chainAction, goBack, goForward,
@@ -364,6 +365,17 @@ function resolveArgs(args: ParsedArgs): ParsedArgs | DirectExecution {
   if (cmdName === 'verify') {
     const subType = args._[1];
     const rest = args._.slice(2);
+    // css subcommand: verify element css ".sel", verify visible css ".sel", etc.
+    if (rest[0] === 'css' && rest.length >= 2) {
+      const selector = rest.slice(1).join(' ');
+      if (subType === 'visible') return { jsExpr: call(verifyCssVisible, selector) };
+      if (subType === 'element') return { jsExpr: call(verifyCssElement, selector) };
+      if (subType === 'no-element') return { jsExpr: call(verifyCssNoElement, selector) };
+      if (subType === 'value' && rest.length >= 3) {
+        const sel = rest.slice(1, -1).join(' ');
+        return { jsExpr: call(verifyCssValue, sel, rest[rest.length - 1]) };
+      }
+    }
     if (subType === 'title' && rest.length > 0)
       return { jsExpr: call(verifyTitle, rest.join(' ')) };
     if (subType === 'url' && rest.length > 0)
@@ -380,6 +392,22 @@ function resolveArgs(args: ParsedArgs): ParsedArgs | DirectExecution {
       return { jsExpr: call(verifyValue, rest[0], rest.slice(1).join(' ')) };
     if (subType === 'list' && rest.length >= 2)
       return { jsExpr: call(verifyList, rest[0], rest.slice(1)) };
+  }
+
+  // ── Verify css subcommand (verify-visible css ".sel", verify-element css ".sel") ─
+  const CSS_VERIFY: Record<string, any> = {
+    'verify-visible': verifyCssVisible,
+    'verify-element': verifyCssElement,
+    'verify-no-element': verifyCssNoElement,
+  };
+  if (CSS_VERIFY[cmdName] && args._[1] === 'css' && args._.length >= 3) {
+    const selector = args._.slice(2).join(' ');
+    return { jsExpr: call(CSS_VERIFY[cmdName], selector) };
+  }
+  if (cmdName === 'verify-value' && args._[1] === 'css' && args._.length >= 4) {
+    const selector = args._.slice(2, -1).join(' ');
+    const expected = args._[args._.length - 1];
+    return { jsExpr: call(verifyCssValue, selector, expected) };
   }
 
   // ── Legacy verify-* commands ────────────────────────────────

--- a/packages/extension/src/panel/lib/page-scripts.ts
+++ b/packages/extension/src/panel/lib/page-scripts.ts
@@ -68,6 +68,27 @@ export async function verifyVisible(page, role, name) {
     throw new Error('Element not visible: ' + role + ' "' + name + '"');
 }
 
+export async function verifyCssVisible(page, selector) {
+  if (!(await page.locator(selector).isVisible()))
+    throw new Error('Element not visible: css "' + selector + '"');
+}
+
+export async function verifyCssElement(page, selector) {
+  if (await page.locator(selector).count() === 0)
+    throw new Error('Element not found: css "' + selector + '"');
+}
+
+export async function verifyCssNoElement(page, selector) {
+  if (await page.locator(selector).count() > 0)
+    throw new Error('Element still exists: css "' + selector + '"');
+}
+
+export async function verifyCssValue(page, selector, expected) {
+  const v = await page.locator(selector).inputValue();
+  if (v !== expected)
+    throw new Error('Expected "' + expected + '", got "' + v + '"');
+}
+
 export async function verifyInputValue(page, label, expected) {
   let loc = page.getByLabel(label);
   if (await loc.count() === 0) loc = page.getByRole('spinbutton', { name: label });


### PR DESCRIPTION
## Summary
- `verify-visible css`, `verify-element css`, `verify-no-element css`, and `verify-value css` now work correctly
- Previously `css` was misinterpreted as a role name (e.g., `getByRole('css', ...)`)
- Added `verifyCss*` page-script functions in both core and extension
- Supports both unified (`verify visible css ".sel"`) and legacy (`verify-visible css ".sel"`) syntax

## Test plan
- [x] 49 core parser tests pass (7 new verify css tests)
- [x] 704 extension tests pass
- [x] `verify-visible css "#LoginName"` — verified in browser ✓
- [x] `verify-value css "#LoginName" "testuser"` — verified in browser ✓
- [x] `verify-value css "#LoginName" "wrongvalue"` — correctly fails with error ✓

Closes #787

🤖 Generated with [Claude Code](https://claude.com/claude-code)