### PR TITLE
fix: reduce bridge command logging noise in extension console

### DIFF
--- a/packages/extension/src/background.ts
+++ b/packages/extension/src/background.ts
@@ -620,7 +620,7 @@ async function handleBridgeCommand(msg: {
 }): Promise<BridgeResult> {
   // Recording/picker commands — handled before currentPage check
   const cmd = msg.command.trim();
-  console.log('[bridge] command:', JSON.stringify(cmd), 'type:', msg.scriptType);
+  console.debug('[bridge] command:', JSON.stringify(cmd), 'type:', msg.scriptType);
   if (cmd === 'record-start') {
     const r = await startRecording();
     return { text: r.ok ? `Recording started${r.url ? ': ' + r.url : ''}` : (r.error || 'Failed'), isError: !r.ok };

--- a/packages/extension/src/panel/lib/commands.ts
+++ b/packages/extension/src/panel/lib/commands.ts
@@ -773,7 +773,7 @@ export function parseReplCommand(input: string): ParseResult {
 
   // Parse input (tokenize + alias + options)
   const args = parseInput(input);
-  console.log('[pw-repl] parseInput result:', JSON.stringify(args));
+  console.debug('[pw-repl] parseInput result:', JSON.stringify(args));
   if (!args) return { error: 'Empty command' };
 
   // Resolve to DirectExecution, TabOperation, or unrecognised ParsedArgs


### PR DESCRIPTION
## Summary
- Change `console.log` → `console.debug` for bridge command and parseInput logs
- Logs are hidden by default in DevTools, visible when "Verbose" level is enabled
- Only 2 lines changed — no logs removed, just quieted

Closes #789

🤖 Generated with [Claude Code](https://claude.com/claude-code)