### PR TITLE
feat: make command timeout configurable in extension preferences

### DIFF
--- a/packages/extension/src/panel/lib/bridge.ts
+++ b/packages/extension/src/panel/lib/bridge.ts
@@ -2,6 +2,7 @@ export type CommandResult = { text: string; isError: boolean; image?: string };
 export type { CdpRemoteObject } from '@/components/Console/cdpToSerialized';
 import type { CdpRemoteObject } from '@/components/Console/cdpToSerialized';
 import { parseReplCommand } from './commands';
+import { loadSettings } from './settings';
 export type ConsoleCommandResult = { cdpResult: CdpRemoteObject } | { text: string; image?: string; video?: string; duration?: number; size?: number; trace?: boolean; traceSize?: number };
 
 type CdpResult = { type?: string; value?: unknown; description?: string; objectId?: string };
@@ -23,14 +24,17 @@ export async function executeCommand(command: string): Promise<CommandResult> {
   const parsed = parseReplCommand(command);
   if ('help' in parsed) return { text: parsed.help, isError: false };
 
-  const { swDebugEval, swCallFunctionOn } = await import('@/lib/sw-debugger');
+  const [{ swDebugEval, swCallFunctionOn }, { commandTimeout }] = await Promise.all([
+    import('@/lib/sw-debugger'),
+    loadSettings(),
+  ]);
 
   let timer: ReturnType<typeof setTimeout>;
   const withTimeout = <T>(p: Promise<T>): Promise<T> =>
     Promise.race([
       p,
       new Promise<T>((_, reject) => {
-        timer = setTimeout(() => reject(new Error('Command timed out after 15s')), 15000);
+        timer = setTimeout(() => reject(new Error(`Command timed out after ${commandTimeout / 1000}s`)), commandTimeout);
       }),
     ]).finally(() => clearTimeout(timer!));
 
@@ -113,7 +117,10 @@ export async function executeCommandForConsole(command: string): Promise<Console
   if ('error' in parsed) throw new Error(parsed.error);
   if ('help' in parsed) return { text: parsed.help };
 
-  const { swDebugEval } = await import('@/lib/sw-debugger');
+  const [{ swDebugEval }, { commandTimeout }] = await Promise.all([
+    import('@/lib/sw-debugger'),
+    loadSettings(),
+  ]);
   const { jsExpr } = parsed;
 
   let timer: ReturnType<typeof setTimeout>;
@@ -121,7 +128,7 @@ export async function executeCommandForConsole(command: string): Promise<Console
     Promise.race([
       p,
       new Promise<T>((_, reject) => {
-        timer = setTimeout(() => reject(new Error('Command timed out after 15s')), 15000);
+        timer = setTimeout(() => reject(new Error(`Command timed out after ${commandTimeout / 1000}s`)), commandTimeout);
       }),
     ]).finally(() => clearTimeout(timer!));
 

--- a/packages/extension/src/panel/lib/settings.ts
+++ b/packages/extension/src/panel/lib/settings.ts
@@ -2,12 +2,13 @@ export type PwReplSettings = {
     openAs: 'sidepanel' | 'popup',
     bridgePort: number,
     languageMode: 'pw' | 'js',
+    commandTimeout: number,
 };
 
-const DEFAULT: PwReplSettings = { openAs: 'sidepanel', bridgePort: 9876, languageMode: 'pw' };
+const DEFAULT: PwReplSettings = { openAs: 'sidepanel', bridgePort: 9876, languageMode: 'pw', commandTimeout: 15000 };
 
 export async function loadSettings(): Promise<PwReplSettings> {
-    const stored = await chrome.storage.local.get(['openAs', 'bridgePort', 'languageMode']) as Partial<PwReplSettings>;
+    const stored = await chrome.storage.local.get(['openAs', 'bridgePort', 'languageMode', 'commandTimeout']) as Partial<PwReplSettings>;
     return { ...DEFAULT, ...stored };
 }
 

--- a/packages/extension/src/preferences/PreferencesForm.tsx
+++ b/packages/extension/src/preferences/PreferencesForm.tsx
@@ -3,7 +3,7 @@ import { loadSettings, storeSettings } from '../panel/lib/settings';
 import type { PwReplSettings } from '../panel/lib/settings';
 
 export default function PreferencesForm() {
-  const [settings, setSettings] = useState<PwReplSettings>({ openAs: 'sidepanel', bridgePort: 9876, languageMode: 'pw' });
+  const [settings, setSettings] = useState<PwReplSettings>({ openAs: 'sidepanel', bridgePort: 9876, languageMode: 'pw', commandTimeout: 15000 });
 
   useEffect(() => {
     loadSettings().then(setSettings);
@@ -84,6 +84,24 @@ export default function PreferencesForm() {
           />
           js
         </label>
+      </fieldset>
+      <fieldset style={{ border: 'none', padding: 0, margin: '20px 0 0' }}>
+        <legend style={{ fontWeight: 600, marginBottom: '12px' }}>Command Timeout (seconds):</legend>
+        <input
+          type="number"
+          min={1}
+          max={300}
+          value={settings.commandTimeout / 1000}
+          onChange={(e) => {
+            const next = { ...settings, commandTimeout: Number(e.target.value) * 1000 };
+            setSettings(next);
+            storeSettings(next);
+          }}
+          style={{ width: '100px', padding: '4px 8px', fontSize: '14px' }}
+        />
+        <p style={{ margin: '6px 0 0', fontSize: '12px', color: '#888' }}>
+          Max time a command can run before timing out (default: 15).
+        </p>
       </fieldset>
       <p style={{ marginTop: '16px', fontSize: '12px', color: '#888' }}>Saved automatically.</p>
     </form>

--- a/packages/extension/test/components/PreferencesForm.browser.test.tsx
+++ b/packages/extension/test/components/PreferencesForm.browser.test.tsx
@@ -15,7 +15,7 @@ import PreferencesForm from '../../src/preferences/PreferencesForm';
 
 beforeEach(() => {
     vi.clearAllMocks();
-    mockLoadSettings.mockResolvedValue({ openAs: 'sidepanel', bridgePort: 9876, languageMode: 'pw' });
+    mockLoadSettings.mockResolvedValue({ openAs: 'sidepanel', bridgePort: 9876, languageMode: 'pw', commandTimeout: 15000 });
     mockStoreSettings.mockResolvedValue(undefined);
 });
 
@@ -80,6 +80,25 @@ describe('PreferencesForm', () => {
         await vi.waitFor(() => {
             expect(mockStoreSettings).toHaveBeenCalledWith(
                 expect.objectContaining({ languageMode: 'js' }),
+            );
+        });
+    });
+
+    it('renders Command Timeout fieldset with default value in seconds', async () => {
+        const screen = await render(<PreferencesForm />);
+        await expect.element(screen.getByText('Command Timeout (seconds):')).toBeInTheDocument();
+        const input = screen.getByRole('group', { name: 'Command Timeout (seconds):' }).getByRole('spinbutton');
+        await expect.element(input).toHaveValue(15);
+    });
+
+    it('calls storeSettings when command timeout changed', async () => {
+        const screen = await render(<PreferencesForm />);
+        const input = screen.getByRole('group', { name: 'Command Timeout (seconds):' }).getByRole('spinbutton');
+        await userEvent.clear(input);
+        await userEvent.type(input, '30');
+        await vi.waitFor(() => {
+            expect(mockStoreSettings).toHaveBeenCalledWith(
+                expect.objectContaining({ commandTimeout: 30000 }),
             );
         });
     });

--- a/packages/extension/test/lib/bridge.test.ts
+++ b/packages/extension/test/lib/bridge.test.ts
@@ -10,6 +10,12 @@ vi.mock('@/lib/execute', () => ({
     detectMode: vi.fn(),
 }));
 
+vi.mock('@/lib/settings', () => ({
+    loadSettings: vi.fn().mockResolvedValue({ commandTimeout: 15000 }),
+}));
+
+import { loadSettings } from '@/lib/settings';
+
 vi.mock('@/lib/commands', async (importOriginal) => {
     const actual = await importOriginal() as any;
     return { ...actual, parseReplCommand: vi.fn(actual.parseReplCommand) };
@@ -149,6 +155,18 @@ describe('executeCommand', () => {
     expect(result.isError).toBe(true);
     expect(result.text).toBeTruthy();
   });
+
+  it('times out using configured commandTimeout', async () => {
+    vi.useFakeTimers();
+    vi.mocked(loadSettings).mockResolvedValue({ commandTimeout: 5000, openAs: 'sidepanel', bridgePort: 9876, languageMode: 'pw' });
+    vi.mocked(swDebugEval).mockReturnValue(new Promise(() => {})); // never resolves
+    const promise = executeCommand('snapshot');
+    await vi.advanceTimersByTimeAsync(5000);
+    const result = await promise;
+    expect(result.isError).toBe(true);
+    expect(result.text).toBe('Command timed out after 5s');
+    vi.useRealTimers();
+  });
 });
 
 // ─── executeCommandForConsole ────────────────────────────────────────────────
@@ -205,5 +223,16 @@ describe('executeCommandForConsole', () => {
     vi.mocked(swDebugEval).mockResolvedValue({ result: obj });
     const result = await executeCommandForConsole('snapshot');
     expect('cdpResult' in result && result.cdpResult).toEqual(obj);
+  });
+
+  it('times out using configured commandTimeout', async () => {
+    vi.useFakeTimers();
+    vi.mocked(loadSettings).mockResolvedValue({ commandTimeout: 10000, openAs: 'sidepanel', bridgePort: 9876, languageMode: 'pw' });
+    vi.mocked(swDebugEval).mockReturnValue(new Promise(() => {})); // never resolves
+    const promise = executeCommandForConsole('snapshot');
+    const assertion = expect(promise).rejects.toThrow('Command timed out after 10s');
+    await vi.advanceTimersByTimeAsync(10000);
+    await assertion;
+    vi.useRealTimers();
   });
 });


### PR DESCRIPTION
## Summary
- Add `commandTimeout` setting to extension preferences (default: 15s, range: 1–300s)
- Both `executeCommand` and `executeCommandForConsole` in `bridge.ts` now read the timeout from settings instead of hardcoding 15000ms
- Add "Command Timeout (seconds)" input to PreferencesForm

Ref #784

## Test plan
- [x] bridge.test.ts: `executeCommand` times out using configured 5s timeout
- [x] bridge.test.ts: `executeCommandForConsole` times out using configured 10s timeout
- [x] PreferencesForm.browser.test.tsx: renders timeout input with default value (15)
- [x] PreferencesForm.browser.test.tsx: stores updated timeout on change (30s → 30000ms)
- [ ] Manual: change timeout in preferences, verify commands use new value

🤖 Generated with [Claude Code](https://claude.com/claude-code)