### PR TITLE
feat: include snapshot ref in pick locator result (#792)

### DIFF
--- a/packages/extension/src/background.ts
+++ b/packages/extension/src/background.ts
@@ -366,7 +366,7 @@ async function pickElement(): Promise<{ ok: boolean; info?: any; error?: string 
   try {
     const locator = await currentPage.pickLocator();
     const locatorStr = locator.toString();
-    const ariaSnapshot = await locator.ariaSnapshot().catch(() => '');
+    const ariaSnapshot = await locator.ariaSnapshot({ mode: 'ai' }).catch(() => '');
     const elementInfo = await locator.evaluate((el: Element) => {
       const attrs: Record<string, string> = {};
       for (const attr of el.attributes) attrs[attr.name] = attr.value;

--- a/packages/extension/src/panel/components/Toolbar.tsx
+++ b/packages/extension/src/panel/components/Toolbar.tsx
@@ -311,7 +311,7 @@ function Toolbar({ editorContent, editorMode, stepLine, attachedUrl, attachedTab
             const info = result.info;
             const pickResult = buildPickResult(info, info.locator, info.ariaSnapshot, info.headingContext);
             if (info.ariaSnapshot)
-                pickResult.ariaSnapshot = info.ariaSnapshot;
+                pickResult.ariaSnapshot = info.ariaSnapshot.replace(/\s*\[(?:ref|cursor)=[^\]]*\]/g, '');
             dispatch({ type: 'ADD_LINE', line: { text: '', type: 'info', pickResult } });
         } catch (e) {
             dispatch({ type: 'ADD_LINE', line: { text: `Pick failed: ${String(e)}`, type: 'error' } });

--- a/packages/extension/src/panel/lib/pick-info.ts
+++ b/packages/extension/src/panel/lib/pick-info.ts
@@ -308,12 +308,17 @@ export function buildPickResult(info: ElementPickInfo, cdpLocator?: string | nul
     if (assertPw && inMatch) assertPw += ` ${inMatch[1]}`;
     if (assertPw) assertPw += extraFlags;
 
+    // Extract snapshot ref from aria snapshot (e.g. [ref=e45] → "e45")
+    const refMatch = ariaSnapshot?.match(/\[ref=(e\d+)\]/);
+    const ref = refMatch?.[1];
+
     return {
         locator,
         pwCommand,
         jsExpression,
         assertJs,
         assertPw,
+        ref,
         details: {
             tag: info.tag,
             text: info.text,
@@ -334,6 +339,9 @@ export function buildPickResult(info: ElementPickInfo, cdpLocator?: string | nul
  */
 export function pickResultToSerialized(data: PickResultData): SerializedValue {
     const props: Record<string, SerializedValue> = {};
+
+    // ref
+    if (data.ref) props.ref = { __type: 'string', v: data.ref };
 
     // locator: { js, pw }
     const locatorProps: Record<string, SerializedValue> = {

--- a/packages/extension/src/panel/types.ts
+++ b/packages/extension/src/panel/types.ts
@@ -19,6 +19,7 @@ export type PickResultData = {
     jsExpression: string;      // "await page.getByRole('button', { name: 'Submit' }).highlight()"
     assertJs?: string;         // "await expect(page.getByRole('button', { name: 'Submit' })).toContainText('Submit')"
     assertPw?: string;         // 'verify-text "Submit"'
+    ref?: string;              // Snapshot ref (e.g. "e45") — page-scoped, usable in commands like `click e45`
     ariaSnapshot?: string;     // YAML aria snapshot of the picked element
     details?: {
         tag: string;


### PR DESCRIPTION
## Summary
- Use `locator.ariaSnapshot({ mode: 'ai' })` to get page-scoped snapshot refs during pick
- Extract ref (e.g. `e45`) from aria snapshot and include in pick result
- Strip `[ref=...]` and `[cursor=...]` noise from displayed aria snapshot

## How it works
`locator.ariaSnapshot({ mode: 'ai' })` uses the same frame-level RPC as `page.ariaSnapshot()` — refs are numbered page-wide, so the ref from pick matches the ref from a full `snapshot` command. No extra call needed.

## Test plan
- [ ] Pick an element → verify `ref: eN` appears in pick result
- [ ] Run `snapshot` → verify the ref matches the picked element
- [ ] Verify aria snapshot display is clean (no `[ref=...]` or `[cursor=...]`)
- [ ] Pick an element without aria snapshot → verify no ref shown

Closes #792

🤖 Generated with [Claude Code](https://claude.com/claude-code)