### PR TITLE
fix: suppress Chrome-internal 'No SW' error in service worker console

### DIFF
--- a/packages/extension/src/background.ts
+++ b/packages/extension/src/background.ts
@@ -7,6 +7,18 @@ import type { PwReplSettings } from './panel/lib/settings';
 import { parseReplCommand } from './panel/lib/commands';
 import { detectMode } from './panel/lib/execute';
 
+// ─── Suppress Chrome-internal "No SW" error ─────────────────────────────────
+// Chromium's extension_function_dispatcher.cc rejects with "No SW" when the
+// service worker's render process is gone before an in-flight Chrome API call
+// completes. This is a known Chrome bug — purely console noise, no functional
+// impact.  Suppress it so it doesn't pollute the SW console during debugging.
+// https://groups.google.com/a/chromium.org/g/chromium-extensions/c/rHFKotXbm-0
+self.addEventListener('unhandledrejection', (event: PromiseRejectionEvent) => {
+  if (event.reason?.message === 'No SW' || String(event.reason) === 'Error: No SW') {
+    event.preventDefault();
+  }
+});
+
 // ─── Service worker lifecycle logging ────────────────────────────────────────
 
 chrome.runtime.onSuspend.addListener(() => {


### PR DESCRIPTION
## Summary
- Suppress the `Uncaught (in promise) Error: No SW` noise in the service worker console
- The error originates from Chromium's `extension_function_dispatcher.cc` — a [known Chrome bug](https://groups.google.com/a/chromium.org/g/chromium-extensions/c/rHFKotXbm-0) with no functional impact
- Adds a narrowly-scoped `unhandledrejection` listener that only suppresses this specific error

## Test plan
- [ ] Load extension in Chrome, open SW console (chrome://extensions → Inspect views → Service Worker)
- [ ] Use the extension normally — verify "No SW" error no longer appears
- [ ] Verify other errors still surface normally in the console

Closes #793

🤖 Generated with [Claude Code](https://claude.com/claude-code)