### PR TITLE
fix: recorder uses informal labels, fix --frame evaluate (#768)

### DIFF
--- a/packages/core/src/page-scripts.ts
+++ b/packages/core/src/page-scripts.ts
@@ -69,7 +69,8 @@ export function buildRunCodeScoped(fn, inText, targetText, ...args) {
   try {
     return await (${fn.toString()})(__scope, ${serialized});
   } finally {
-    await page.evaluate(() => document.querySelectorAll('[data-pw-in]').forEach(el => el.removeAttribute('data-pw-in'))).catch(() => {});
+    if (typeof page.evaluate === 'function')
+      await page.evaluate(() => document.querySelectorAll('[data-pw-in]').forEach(el => el.removeAttribute('data-pw-in'))).catch(() => {});
   }
 }`] };
 }
@@ -213,7 +214,8 @@ export async function fillByText(page, text, value, nth, exact?) {
       if (sel) {
         loc = page.locator(sel);
         await loc.fill(value);
-        await page.evaluate(() => document.querySelectorAll('[data-pw-fill]').forEach(el => el.removeAttribute('data-pw-fill'))).catch(() => {});
+        if (typeof page.evaluate === 'function')
+          await page.evaluate(() => document.querySelectorAll('[data-pw-fill]').forEach(el => el.removeAttribute('data-pw-fill'))).catch(() => {});
         return;
       }
     }
@@ -226,6 +228,29 @@ export async function selectByText(page, text, value, nth, exact?) {
   let loc = page.getByLabel(text);
   if (!exact) {
     if (await loc.count() === 0) loc = page.getByRole('combobox', { name: text });
+    // Informal label fallback: find text, walk up DOM to locate a nearby select
+    if (await loc.count() === 0) {
+      const sel = await page.getByText(text).first().evaluate((el) => {
+        let a = el.closest('tr') || el.parentElement;
+        while (a && a !== document.body) {
+          const s = a.querySelector('select');
+          if (s) {
+            const id = '__pw_fill_' + Math.random().toString(36).slice(2);
+            s.setAttribute('data-pw-fill', id);
+            return '[data-pw-fill="' + id + '"]';
+          }
+          a = a.parentElement;
+        }
+        return null;
+      });
+      if (sel) {
+        loc = page.locator(sel);
+        await loc.selectOption(value);
+        if (typeof page.evaluate === 'function')
+          await page.evaluate(() => document.querySelectorAll('[data-pw-fill]').forEach(el => el.removeAttribute('data-pw-fill'))).catch(() => {});
+        return;
+      }
+    }
   }
   if (nth !== undefined) loc = loc.filter({ visible: true }).nth(nth);
   await loc.selectOption(value);

--- a/packages/extension/e2e/recording/recording.spec.ts
+++ b/packages/extension/e2e/recording/recording.spec.ts
@@ -101,7 +101,7 @@ test.describe('Recording flow', () => {
       expect(editorText).toContain('click');
     });
 
-    test('filling input in legacy table form uses CSS selector, not getByRole (#768)', async ({ sidePanel, testPage }) => {
+    test('filling input in legacy table form uses informal label (#768)', async ({ sidePanel, testPage }) => {
       await sidePanel.startRecording();
 
       await testPage.bringToFront();
@@ -110,11 +110,11 @@ test.describe('Recording flow', () => {
 
       await sidePanel.waitForEditorText('fill');
       const editorText = await sidePanel.getEditorText();
-      // Informal labels (adjacent cell text) can't be resolved by Playwright at runtime.
-      // Should use CSS selector (e.g. input#LoginName) which always works.
+      // Informal label (adjacent cell text) is detected and used for fill.
+      // At runtime, fillByText resolves these via DOM-walking fallback.
       expect(editorText).toContain('"testuser"');
-      expect(editorText).toContain('css');
-      expect(editorText).not.toContain('textbox "Benutzerkennung:*"');
+      expect(editorText).toContain('"Benutzerkennung:*"');
+      expect(editorText).not.toContain('css');
     });
 
     test('clicking inside a <frame> uses frame tag, not iframe (#769)', async ({ sidePanel, testPage }) => {

--- a/packages/extension/src/content/locator.ts
+++ b/packages/extension/src/content/locator.ts
@@ -101,8 +101,39 @@ export function getLabel(el: HTMLInputElement | HTMLTextAreaElement | HTMLSelect
         const text = (clone.textContent || '').trim();
         if (text) return text;
     }
-    // Informal associations (e.g. preceding table cell) are intentionally excluded —
-    // they produce names that Playwright's getByRole/getByLabel can't resolve (#768).
+    // Informal associations (e.g. preceding table cell) are excluded here because
+    // getByRole/getByLabel can't resolve them. See getInformalLabel() for fill/select.
+    return '';
+}
+
+/**
+ * Find informal label text for a form element (e.g. text in an adjacent table
+ * cell). Used by the recorder to generate `fill "Label" "value"` instead of
+ * `fill css "input#id" "value"`. Mirrors the fillByText runtime fallback in
+ * page-scripts.ts which walks up from a getByText match to find a nearby input.
+ */
+export function getInformalLabel(el: Element): string {
+    // Table layout: preceding cell's text in the same row
+    const row = el.closest('tr');
+    if (row) {
+        const cell = el.closest('td, th');
+        if (cell) {
+            let prev = cell.previousElementSibling;
+            while (prev) {
+                const text = (prev.textContent || '').trim();
+                if (text && text.length <= 80) return text;
+                prev = prev.previousElementSibling;
+            }
+        }
+    }
+    // Non-table: parent's text content excluding form elements
+    const parent = el.parentElement;
+    if (parent) {
+        const clone = parent.cloneNode(true) as HTMLElement;
+        clone.querySelectorAll('input, textarea, select, [contenteditable="true"]').forEach(c => c.remove());
+        const text = (clone.textContent || '').trim();
+        if (text && text.length <= 80) return text;
+    }
     return '';
 }
 
@@ -516,14 +547,20 @@ export function buildCommands(action: string, el: Element, opts?: {
 
         case 'fill': {
             const val = opts?.value ?? '';
-            // Bare role without name (e.g. "textbox") makes fill ambiguous:
-            // `fill textbox "val"` parses as fill(role=textbox, name="val", value="")
-            // Fall back to CSS selector which always works at runtime.
             let fillLoc = pwArgs;
             let fillPrefix = cssPrefix;
-            if (!isCssFallback && /^[a-z]+$/.test(pwArgs)) {
-                fillLoc = q(buildCssSelector(el));
-                fillPrefix = 'css ';
+            const isBareRole = !isCssFallback && /^[a-z]+$/.test(pwArgs);
+            if (isCssFallback || isBareRole) {
+                // Try informal label (e.g. adjacent table-cell text) before CSS.
+                // At runtime, fillByText handles these via DOM-walking fallback.
+                const informal = getInformalLabel(el);
+                if (informal) {
+                    fillLoc = q(informal);
+                    fillPrefix = '';
+                } else if (isBareRole) {
+                    fillLoc = q(buildCssSelector(el));
+                    fillPrefix = 'css ';
+                }
             }
             return {
                 pw: `fill ${fillPrefix}${fillLoc} ${q(val)}${inFlag}`,
@@ -545,12 +582,18 @@ export function buildCommands(action: string, el: Element, opts?: {
 
         case 'select': {
             const optVal = opts?.option ?? '';
-            // Same bare-role guard as fill
             let selLoc = pwArgs;
             let selPrefix = cssPrefix;
-            if (!isCssFallback && /^[a-z]+$/.test(pwArgs)) {
-                selLoc = q(buildCssSelector(el));
-                selPrefix = 'css ';
+            const isBareRoleSel = !isCssFallback && /^[a-z]+$/.test(pwArgs);
+            if (isCssFallback || isBareRoleSel) {
+                const informal = getInformalLabel(el);
+                if (informal) {
+                    selLoc = q(informal);
+                    selPrefix = '';
+                } else if (isBareRoleSel) {
+                    selLoc = q(buildCssSelector(el));
+                    selPrefix = 'css ';
+                }
             }
             return {
                 pw: `select ${selPrefix}${selLoc} ${q(optVal)}${inFlag}`,

--- a/packages/extension/src/panel/lib/page-scripts.ts
+++ b/packages/extension/src/panel/lib/page-scripts.ts
@@ -168,7 +168,8 @@ export async function fillByText(page, text, value, nth?, exact?) {
       if (sel) {
         loc = page.locator(sel);
         await loc.fill(value);
-        await page.evaluate(() => document.querySelectorAll('[data-pw-fill]').forEach(el => el.removeAttribute('data-pw-fill'))).catch(() => {});
+        if (typeof page.evaluate === 'function')
+          await page.evaluate(() => document.querySelectorAll('[data-pw-fill]').forEach(el => el.removeAttribute('data-pw-fill'))).catch(() => {});
         return;
       }
     }
@@ -181,6 +182,29 @@ export async function selectByText(page, text, value, nth?, exact?) {
   let loc = page.getByLabel(text);
   if (!exact) {
     if (await loc.count() === 0) loc = page.getByRole('combobox', { name: text });
+    // Informal label fallback: find text, walk up DOM to locate a nearby select
+    if (await loc.count() === 0) {
+      const sel = await page.getByText(text).first().evaluate((el: Element) => {
+        let a: Element | null = el.closest('tr') || el.parentElement;
+        while (a && a !== document.body) {
+          const s = a.querySelector('select');
+          if (s) {
+            const id = '__pw_fill_' + Math.random().toString(36).slice(2);
+            s.setAttribute('data-pw-fill', id);
+            return '[data-pw-fill="' + id + '"]';
+          }
+          a = a.parentElement;
+        }
+        return null;
+      });
+      if (sel) {
+        loc = page.locator(sel);
+        await loc.selectOption(value);
+        if (typeof page.evaluate === 'function')
+          await page.evaluate(() => document.querySelectorAll('[data-pw-fill]').forEach(el => el.removeAttribute('data-pw-fill'))).catch(() => {});
+        return;
+      }
+    }
   }
   if (nth !== undefined) loc = loc.filter({ visible: true }).nth(nth);
   await loc.selectOption(value);

--- a/packages/extension/test/content/locator.test.ts
+++ b/packages/extension/test/content/locator.test.ts
@@ -999,16 +999,33 @@ describe('locator', () => {
             expect(cmds!.js).toContain(".fill('user')");
         });
 
-        it('uses CSS fallback for fill in legacy table form (#768)', () => {
+        it('uses informal label for fill in legacy table form (#768)', () => {
             document.body.innerHTML = '<table><tr><td>Username:</td><td><input type="text"></td></tr></table>';
             const input = document.querySelector('input')!;
             const cmds = buildCommands('fill', input, { value: 'admin' });
-            // Informal labels (adjacent cell) can't be resolved by getByRole or getByLabel.
-            // Should use CSS selector which always works at runtime.
-            expect(cmds!.pw).toContain('css');
-            expect(cmds!.pw).toContain('"admin"');
-            expect(cmds!.pw).not.toContain('textbox');
-            expect(cmds!.pw).not.toContain('Username:');
+            // Informal labels (adjacent cell text) are detected and used for fill.
+            // At runtime, fillByText resolves these via DOM-walking fallback.
+            expect(cmds!.pw).toBe('fill "Username:" "admin"');
+            expect(cmds!.pw).not.toContain('css');
+        });
+
+        it('uses informal label for fill in non-table layout (#768)', () => {
+            document.body.innerHTML = '<div><span>Password:</span><input type="password"></div>';
+            const input = document.querySelector('input')!;
+            const cmds = buildCommands('fill', input, { value: 'secret' });
+            expect(cmds!.pw).toBe('fill "Password:" "secret"');
+            expect(cmds!.pw).not.toContain('css');
+        });
+
+        it('uses informal label for select in legacy table form (#768)', () => {
+            // Options with value-only (no text) — no accessible name, triggers informal label
+            document.body.innerHTML = `<table>
+                <tr><td>Country:</td><td><select><option value="us"></option><option value="uk"></option></select></td></tr>
+            </table>`;
+            const select = document.querySelector('select')!;
+            const cmds = buildCommands('select', select, { option: 'us' });
+            expect(cmds!.pw).toBe('select "Country:" "us"');
+            expect(cmds!.pw).not.toContain('css');
         });
 
         it('adds --exact for text-based click locator', () => {


### PR DESCRIPTION
## Summary
- **Recorder generates text-based locators for informal labels**: For forms where inputs don't have formal `<label>` elements (e.g. table-based layouts with label text in adjacent cells), the recorder now generates `fill "Benutzerkennung:*" "user"` instead of `fill css "input#LoginName" "user"`. Works for both `fill` and `select` commands.
- **Fix `TypeError: page.evaluate is not a function` with `--frame`**: When `--frame` is used, `page` is shadowed with a `FrameLocator` which lacks `.evaluate()`. Added guards to cleanup calls in `fillByText`, `selectByText`, and `buildRunCodeScoped`.
- **Add informal label fallback to `selectByText`**: Mirrors the existing `fillByText` fallback — walks up DOM from label text to find a nearby `<select>`.

Addresses #768.

## Test plan
- [x] Existing tests pass (708 extension + 145 core)
- [x] New tests: informal label for fill (table layout), fill (non-table layout), select (table layout)
- [ ] Manual: record a fill action on a table-based form with informal labels → verify text locator generated
- [ ] Manual: run `fill "Label" "value" --frame "frame[name=...]"` → verify no TypeError in console

🤖 Generated with [Claude Code](https://claude.com/claude-code)