### PR TITLE
fix: recorder select/combobox locator and option label (#800, #802)

### DIFF
--- a/packages/extension/src/content/locator.ts
+++ b/packages/extension/src/content/locator.ts
@@ -420,8 +420,9 @@ export function generateLocator(el: Element): string {
     if (title) return `getByTitle(${escapeString(title)})`;
 
     // 7. Text content — use exact matching for full text, substring for long text
+    // Skip for <select>: textContent is concatenated option texts, not useful for locating.
     const text = (el.textContent || '').trim();
-    if (text) {
+    if (text && el.tagName !== 'SELECT') {
         if (text.length <= 80) return `getByText(${escapeString(text)}, { exact: true })`;
         const snippet = text.slice(0, 50).replace(/\s+\S*$/, '');
         if (snippet) return `getByText(${escapeString(snippet)})`;

--- a/packages/extension/src/content/recorder.ts
+++ b/packages/extension/src/content/recorder.ts
@@ -162,7 +162,9 @@ export function onChangeCapture(e: Event) {
     // Select
     if (target instanceof HTMLSelectElement) {
         flushPendingFill();
-        const option = target.value;
+        // Use visible option text (label) instead of the value attribute (#802)
+        const selected = target.options[target.selectedIndex];
+        const option = selected ? selected.text.trim() || target.value : target.value;
         const cmds = buildCommands('select', target, { option });
         if (cmds) {
             chrome.runtime.sendMessage({ type: 'recorded-action', action: wrapWithFrameContext(cmds) });

--- a/packages/extension/test/content/locator.test.ts
+++ b/packages/extension/test/content/locator.test.ts
@@ -1028,6 +1028,32 @@ describe('locator', () => {
             expect(cmds!.pw).not.toContain('css');
         });
 
+        it('does not use concatenated option text for select locator (#800)', () => {
+            // Two selects with same options — role is not unique, would previously
+            // fall through to textContent and generate broken getByText('option 1\noption 2')
+            document.body.innerHTML = `
+                <span>Select an option</span>
+                <select name="list1">
+                    <option value="true">option 1</option>
+                    <option value="false">option 2</option>
+                </select>
+                <table><tr><td>Select an option (table)</td><td>
+                    <select name="list2">
+                        <option value="true">option 1</option>
+                        <option value="false">option 2</option>
+                    </select>
+                </td></tr></table>`;
+            const selects = document.querySelectorAll('select');
+            // First select: should use informal label from adjacent span, not option text
+            const cmds1 = buildCommands('click', selects[0]);
+            expect(cmds1!.pw).not.toContain('option 1');
+            expect(cmds1!.pw).not.toContain('option 2');
+            // Second select: should use informal label from table cell
+            const cmds2 = buildCommands('click', selects[1]);
+            expect(cmds2!.pw).not.toContain('option 1');
+            expect(cmds2!.pw).not.toContain('option 2');
+        });
+
         it('adds --exact for text-based click locator', () => {
             document.body.innerHTML = '<div>Bis 45 km/h</div>';
             const div = document.querySelector('div')!;

--- a/packages/extension/test/content/recorder.test.ts
+++ b/packages/extension/test/content/recorder.test.ts
@@ -208,6 +208,21 @@ describe('recorder', () => {
                 })
             );
         });
+
+        it('uses option label text instead of value attribute (#802)', () => {
+            document.body.innerHTML = '<label for="m">Make</label><select id="m"><option value="62: 0255">BUECKER</option><option value="63: 0100">BMW</option></select>';
+            const select = document.querySelector('select')! as HTMLSelectElement;
+            select.value = '62: 0255';
+            const event = new Event('change', { bubbles: true });
+            Object.defineProperty(event, 'target', { value: select });
+            onChangeCapture(event);
+            expect(chrome.runtime.sendMessage).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    type: 'recorded-action',
+                    action: expect.objectContaining({ pw: expect.stringContaining('"BUECKER"') }),
+                })
+            );
+        });
     });
 
     // ─── onKeyDownCapture ────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- **#800 — Broken locator for `<select>` without label**: `generateLocator` step 7 used `el.textContent` which for `<select>` is all option texts concatenated (e.g. `"option 1\noption 2"`), producing broken `getByText` locators. Now skips textContent for `<select>` elements, falling through to role/CSS/informal label instead.
- **#802 — Recorder captures option `value` instead of visible text**: `onChangeCapture` used `target.value` (the HTML `value` attribute, e.g. `"62: 0255"`) instead of the selected option's visible label (`"BUECKER"`). Now uses `selectedOption.text`.

Addresses #800, #802.

## Test plan
- [x] Unit tests pass (710 extension + 145 core)
- [x] New test: select with concatenated option text does not produce getByText locator
- [x] New test: onChangeCapture sends option label text instead of value attribute
- [ ] Manual: record selecting an option with value≠label → verify label appears in command

🤖 Generated with [Claude Code](https://claude.com/claude-code)