### PR TITLE
fix: click on <select> uses informal label instead of CSS (#800)

### DIFF
--- a/packages/extension/src/content/locator.ts
+++ b/packages/extension/src/content/locator.ts
@@ -126,13 +126,12 @@ export function getInformalLabel(el: Element): string {
             }
         }
     }
-    // Non-table: parent's text content excluding form elements
-    const parent = el.parentElement;
-    if (parent) {
-        const clone = parent.cloneNode(true) as HTMLElement;
-        clone.querySelectorAll('input, textarea, select, [contenteditable="true"]').forEach(c => c.remove());
-        const text = (clone.textContent || '').trim();
+    // Non-table: preceding sibling's text content
+    let prev = el.previousElementSibling;
+    while (prev) {
+        const text = (prev.textContent || '').trim();
         if (text && text.length <= 80) return text;
+        prev = prev.previousElementSibling;
     }
     return '';
 }
@@ -540,11 +539,25 @@ export function buildCommands(action: string, el: Element, opts?: {
                 js: `await ${jsLoc}.hover();`,
             };
 
-        case 'click':
+        case 'click': {
+            let clickLoc = pwArgs;
+            let clickPrefix = cssPrefix;
+            // For <select> elements, try informal label when CSS fallback or bare role (#800)
+            if (el.tagName === 'SELECT') {
+                const isBareRoleClick = !isCssFallback && /^[a-z]+$/.test(pwArgs);
+                if (isCssFallback || isBareRoleClick) {
+                    const informal = getInformalLabel(el);
+                    if (informal) {
+                        clickLoc = q(informal);
+                        clickPrefix = '';
+                    }
+                }
+            }
             return {
-                pw: `click ${cssPrefix}${pwArgs}${inFlag}`,
+                pw: `click ${clickPrefix}${clickLoc}${inFlag}`,
                 js: `await ${jsLoc}.click();`,
             };
+        }
 
         case 'fill': {
             const val = opts?.value ?? '';

--- a/packages/extension/test/content/locator.test.ts
+++ b/packages/extension/test/content/locator.test.ts
@@ -1028,7 +1028,7 @@ describe('locator', () => {
             expect(cmds!.pw).not.toContain('css');
         });
 
-        it('does not use concatenated option text for select locator (#800)', () => {
+        it('click on select uses informal label, not option text (#800)', () => {
             // Two selects with same options — role is not unique, would previously
             // fall through to textContent and generate broken getByText('option 1\noption 2')
             document.body.innerHTML = `
@@ -1044,14 +1044,12 @@ describe('locator', () => {
                     </select>
                 </td></tr></table>`;
             const selects = document.querySelectorAll('select');
-            // First select: should use informal label from adjacent span, not option text
+            // First select: should use informal label from adjacent span
             const cmds1 = buildCommands('click', selects[0]);
-            expect(cmds1!.pw).not.toContain('option 1');
-            expect(cmds1!.pw).not.toContain('option 2');
+            expect(cmds1!.pw).toBe('click "Select an option"');
             // Second select: should use informal label from table cell
             const cmds2 = buildCommands('click', selects[1]);
-            expect(cmds2!.pw).not.toContain('option 1');
-            expect(cmds2!.pw).not.toContain('option 2');
+            expect(cmds2!.pw).toBe('click "Select an option (table)"');
         });
 
         it('adds --exact for text-based click locator', () => {


### PR DESCRIPTION
## Summary
- **`click` on `<select>` now uses informal labels**: When a `<select>` has no formal label and the role isn't unique, `click` now generates `click "Antragsteller ist*"` instead of `click css "tr.Attribut1 > td:nth-of-type(2) > select"`. Scoped to `<select>` elements only — inputs/textareas have placeholders and other attributes for locating.
- **Refined `getInformalLabel` non-table path**: Uses preceding sibling text instead of entire parent text content, preventing unrelated labels from being included.

Follow-up to #804. Addresses feedback from @mardukbp on #800.

## Test plan
- [x] Unit tests pass (710 extension + 145 core)
- [x] Updated test verifies click on select uses informal label text
- [ ] Manual: record clicking a `<select>` in a table form → verify informal label in command

🤖 Generated with [Claude Code](https://claude.com/claude-code)