### PR TITLE
feat: enable line wrapping in Dramaturg editor (#801)

### DIFF
--- a/packages/extension/src/panel/lib/codemirror-setup.ts
+++ b/packages/extension/src/panel/lib/codemirror-setup.ts
@@ -280,6 +280,7 @@ export const jsModeExtension = [
 ];
 
 export const baseExtensions = [
+    EditorView.lineWrapping,                 // wrap long lines (#801)
     languageCompartment.of(pwModeExtension), // dynamic language compartment
     breakpointField,                         // ← breakpoint state (must register before gutter)
     breakpointGutter,                        // ← clickable breakpoint dots (leftmost gutter)


### PR DESCRIPTION
## Summary
- Add `EditorView.lineWrapping` to `baseExtensions` in `codemirror-setup.ts`
- Long lines (e.g. `goto` URLs) now wrap instead of scrolling off-screen

One-line change suggested by @mardukbp. Addresses #801.

## Test plan
- [x] Unit tests pass (710)
- [ ] Manual: record a `goto` with a long URL → verify line wraps in editor

🤖 Generated with [Claude Code](https://claude.com/claude-code)