### PR TITLE
fix: console autocomplete works after Shift+Enter newline (#799)

### DIFF
--- a/packages/extension/src/panel/lib/pw-completion-source.ts
+++ b/packages/extension/src/panel/lib/pw-completion-source.ts
@@ -285,7 +285,9 @@ export function playwrightCompletions(
 
   // ── Case 2: member completion after a dot ──────────────────────────────────
   // Matches:  page.     page.go     page.locator('#x').
-  const dotMatch = context.matchBefore(/[\w$)'"]+\.[\w$]*/);
+  // Multiline: also match .method() at start of line (after Shift+Enter) (#799)
+  const dotMatch = context.matchBefore(/[\w$)'"]+\.[\w$]*/)
+      || context.matchBefore(/\.[\w$]*/);
 
   if (dotMatch) {
     // Figure out what's typed after the dot (the partial member name)


### PR DESCRIPTION
## Summary
- `context.matchBefore()` is line-scoped, so multiline chains (after Shift+Enter) failed to trigger autocomplete on subsequent lines
- Added fallback match for dots at start of line (`.method()` pattern)
- Chain resolution already handles multiline via `doc.sliceString()`, so the fix is just the initial match

Addresses #799.

## Test plan
- [x] Unit tests pass (710)
- [x] Manual: type `page.locator('#btn')`, press Shift+Enter, type `.` → completions appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)