### PR TITLE
feat: enable line wrapping in console input (#801)

### DIFF
--- a/packages/extension/src/panel/lib/cm-console-setup.ts
+++ b/packages/extension/src/panel/lib/cm-console-setup.ts
@@ -77,6 +77,7 @@ export function consoleExtensions(opts: Opts): Extension[] {
     });
 
     return [
+        EditorView.lineWrapping,
         customKeymap,
         javascript(),
         javascriptLanguage.data.of({ autocomplete: playwrightCompletions }),


### PR DESCRIPTION
## Summary
- Add `EditorView.lineWrapping` to `consoleExtensions` in `cm-console-setup.ts`
- Complements #806 which added wrapping to the editor — this does the same for the console input

Addresses #801.

## Test plan
- [x] Unit tests pass (710)
- [ ] Manual: type a long expression in console → verify it wraps

🤖 Generated with [Claude Code](https://claude.com/claude-code)