### PR TITLE
fix: frame selector, informal label, and role matching (#800, #802)

### DIFF
--- a/packages/core/src/parser.ts
+++ b/packages/core/src/parser.ts
@@ -356,8 +356,9 @@ export function resolveArgs(args: ParsedArgs): ParsedArgs {
   // ── --frame: wrap run-code to operate inside an iframe ──
   if (frameSel && args._[0] === 'run-code' && args._[1]) {
     const inner = args._[1];
-    // Wrap: resolve the frame, then call the inner function with the frame as "page"
-    args = { _: ['run-code', `async (page) => { const __frame = await page.locator(${JSON.stringify(frameSel)}).contentFrame(); return await (${inner})(__frame); }`] };
+    // Wrap: resolve the frame, then call the inner function with the frame as "page".
+    // Try frame name first, fall back to CSS locator for selectors like "#id".
+    args = { _: ['run-code', `async (page) => { const __frame = page.frame(${JSON.stringify(frameSel)}) || await page.locator(${JSON.stringify(frameSel)}).contentFrame(); return await (${inner})(__frame); }`] };
   }
 
   return args;

--- a/packages/extension/e2e/recording/recording.spec.ts
+++ b/packages/extension/e2e/recording/recording.spec.ts
@@ -140,8 +140,7 @@ test.describe('Recording flow', () => {
 
       await sidePanel.waitForEditorText('click button "Arbeitskorb"');
       const editorText = await sidePanel.getEditorText();
-      expect(editorText).toContain('--frame "frame[name=');
-      expect(editorText).not.toContain('iframe');
+      expect(editorText).toContain('--frame "main"');
     });
 
     test('stop recording resets button state', async ({ sidePanel }) => {

--- a/packages/extension/src/content/locator.ts
+++ b/packages/extension/src/content/locator.ts
@@ -47,11 +47,40 @@ export function getImplicitRole(el: Element): string | null {
 
 // ─── Accessible name ─────────────────────────────────────────────────────
 
+/**
+ * Compute accumulated text from an element's children, following the ARIA spec:
+ * for each child, use its accessible name (respecting aria-label etc.) rather
+ * than raw textContent. This matches Playwright's name computation.
+ */
+function accumulatedText(el: Element, exclude?: Element): string {
+    const tokens: string[] = [];
+    for (const child of el.childNodes) {
+        if (exclude && child === exclude) continue;
+        if (child.nodeType === Node.TEXT_NODE) {
+            tokens.push(child.textContent || '');
+        } else if (child.nodeType === Node.ELEMENT_NODE) {
+            const childEl = child as Element;
+            if (exclude && childEl.contains(exclude)) {
+                tokens.push(accumulatedText(childEl, exclude));
+            } else {
+                const name = getAccessibleName(childEl);
+                // If no accessible name, recurse into children (handles
+                // wrapper elements like <pnw-tooltip-toggle> with no role)
+                tokens.push(name || accumulatedText(childEl));
+            }
+        }
+    }
+    return tokens.join('').replace(/\s+/g, ' ').trim();
+}
+
 export function getAccessibleName(el: Element): string {
     // aria-labelledby (highest priority per ARIA spec)
     const labelledBy = el.getAttribute('aria-labelledby');
     if (labelledBy) {
-        const parts = labelledBy.split(/\s+/).map(id => document.getElementById(id)?.textContent?.trim()).filter(Boolean);
+        const parts = labelledBy.split(/\s+/).map(id => {
+            const ref = document.getElementById(id);
+            return ref ? accumulatedText(ref) : '';
+        }).filter(Boolean);
         if (parts.length) return parts.join(' ');
     }
 
@@ -73,7 +102,7 @@ export function getAccessibleName(el: Element): string {
         'columnheader', 'rowheader', 'tooltip', 'treeitem',
     ]);
     if (role && NAME_FROM_CONTENT.has(role)) {
-        const text = (el.textContent || '').trim();
+        const text = accumulatedText(el);
         if (text && text.length <= 80) return text;
     }
 
@@ -90,16 +119,12 @@ export function getLabel(el: HTMLInputElement | HTMLTextAreaElement | HTMLSelect
     // Explicit label via for attribute
     if (el.id) {
         const label = document.querySelector(`label[for="${CSS.escape(el.id)}"]`);
-        if (label) return (label.textContent || '').trim();
+        if (label) return accumulatedText(label, el);
     }
     // Implicit label (ancestor)
     const parentLabel = el.closest('label');
     if (parentLabel) {
-        // Get label text excluding the input's own text
-        const clone = parentLabel.cloneNode(true) as HTMLElement;
-        clone.querySelectorAll('input,textarea,select').forEach(c => c.remove());
-        const text = (clone.textContent || '').trim();
-        if (text) return text;
+        return accumulatedText(parentLabel, el);
     }
     // Informal associations (e.g. preceding table cell) are excluded here because
     // getByRole/getByLabel can't resolve them. See getInformalLabel() for fill/select.

--- a/packages/extension/src/content/locator.ts
+++ b/packages/extension/src/content/locator.ts
@@ -48,16 +48,16 @@ export function getImplicitRole(el: Element): string | null {
 // ─── Accessible name ─────────────────────────────────────────────────────
 
 export function getAccessibleName(el: Element): string {
-    // aria-label
-    const ariaLabel = el.getAttribute('aria-label');
-    if (ariaLabel) return ariaLabel.trim();
-
-    // aria-labelledby
+    // aria-labelledby (highest priority per ARIA spec)
     const labelledBy = el.getAttribute('aria-labelledby');
     if (labelledBy) {
         const parts = labelledBy.split(/\s+/).map(id => document.getElementById(id)?.textContent?.trim()).filter(Boolean);
         if (parts.length) return parts.join(' ');
     }
+
+    // aria-label
+    const ariaLabel = el.getAttribute('aria-label');
+    if (ariaLabel) return ariaLabel.trim();
 
     // For inputs: associated <label>
     if (el instanceof HTMLInputElement || el instanceof HTMLTextAreaElement || el instanceof HTMLSelectElement) {
@@ -113,12 +113,20 @@ export function getLabel(el: HTMLInputElement | HTMLTextAreaElement | HTMLSelect
  * page-scripts.ts which walks up from a getByText match to find a nearby input.
  */
 export function getInformalLabel(el: Element): string {
-    // Table layout: preceding cell's text in the same row
+    // Table layout: check within the same cell first, then preceding cells
     const row = el.closest('tr');
     if (row) {
         const cell = el.closest('td, th');
         if (cell) {
-            let prev = cell.previousElementSibling;
+            // First: preceding siblings within the same cell (e.g. <td><span>Label</span><select>)
+            let prev: Element | null = el.previousElementSibling;
+            while (prev) {
+                const text = (prev.textContent || '').trim();
+                if (text && text.length <= 80) return text;
+                prev = prev.previousElementSibling;
+            }
+            // Then: preceding cell's text in the same row
+            prev = cell.previousElementSibling;
             while (prev) {
                 const text = (prev.textContent || '').trim();
                 if (text && text.length <= 80) return text;

--- a/packages/extension/src/content/recorder.ts
+++ b/packages/extension/src/content/recorder.ts
@@ -34,11 +34,12 @@ function detectFrameSelector(): string | null {
         const frame = window.frameElement;
         if (frame) {
             const tag = frame.tagName.toLowerCase(); // 'frame' or 'iframe'
-            // Prefer id selector
-            if (frame.id) return `#${CSS.escape(frame.id)}`;
-            // Prefer name attribute
+            // Prefer name attribute — works as both a Playwright frame name
+            // and a CSS attribute selector, portable across CLI and extension
             const name = frame.getAttribute('name');
-            if (name) return `${tag}[name="${name}"]`;
+            if (name) return name;
+            // Fall back to id — used as frame identifier (page.frame(id) resolves it)
+            if (frame.id) return frame.id;
             // Prefer src attribute
             const src = frame.getAttribute('src');
             if (src) return `${tag}[src="${src}"]`;

--- a/packages/extension/src/panel/lib/commands.ts
+++ b/packages/extension/src/panel/lib/commands.ts
@@ -768,8 +768,9 @@ export function parseReplCommand(input: string): ParseResult {
     const frameSel = args.frame;
     if (frameSel && typeof frameSel === 'string') {
       // Temporarily shadow `page` with the frame so all page-script functions
-      // operate inside the iframe. The original `page` is used to locate the frame.
-      const frameExpr = `await page.locator(${ser(frameSel)}).contentFrame()`;
+      // operate inside the iframe. Try frame name/title first (works for plain
+      // names like "oevd-iframe"), fall back to CSS locator (for "#id", "iframe[src=...]").
+      const frameExpr = `(page.frame(${ser(frameSel)}) || await page.locator(${ser(frameSel)}).contentFrame())`;
       return { jsExpr: `await (async (__page) => { const page = __page; return ${resolved.jsExpr}; })(${frameExpr})` };
     }
     return resolved;

--- a/packages/extension/src/panel/lib/page-scripts.ts
+++ b/packages/extension/src/panel/lib/page-scripts.ts
@@ -207,6 +207,7 @@ export async function selectByText(page, text, value, nth?, exact?) {
     }
   }
   if (nth !== undefined) loc = loc.filter({ visible: true }).nth(nth);
+  else if (await loc.count() > 1) loc = loc.filter({ visible: true });
   await loc.selectOption(value);
 }
 
@@ -249,6 +250,9 @@ export async function uncheckByText(page, text, nth?, exact?) {
 export async function actionByRole(page, role, name, action, nth, inRole, inText) {
   const roleOpts = name ? { name, exact: true } : {};
   let loc = page.getByRole(role, roleOpts);
+  // Fall back to non-exact if exact match finds nothing (e.g. label includes
+  // extra text from child buttons like "Information anzeigen")
+  if (name && await loc.count() === 0) loc = page.getByRole(role, { name });
   if (inRole !== undefined && inText !== undefined) {
     const cr = ({ list: 'listitem' })[inRole] || inRole;
     loc = page.getByRole(cr).filter({ hasText: inText }).getByRole(role, roleOpts);
@@ -259,12 +263,14 @@ export async function actionByRole(page, role, name, action, nth, inRole, inText
     }
   }
   if (nth !== undefined) loc = loc.nth(nth);
+  else if (await loc.count() > 1) loc = loc.filter({ visible: true });
   await loc[action]();
 }
 
 export async function fillByRole(page, role, name, value, nth, inRole, inText) {
   const roleOpts = name ? { name, exact: true } : {};
   let loc = page.getByRole(role, roleOpts);
+  if (name && await loc.count() === 0) loc = page.getByRole(role, { name });
   if (inRole !== undefined && inText !== undefined) {
     const cr = ({ list: 'listitem' })[inRole] || inRole;
     loc = page.getByRole(cr).filter({ hasText: inText }).getByRole(role, roleOpts);
@@ -275,12 +281,14 @@ export async function fillByRole(page, role, name, value, nth, inRole, inText) {
     }
   }
   if (nth !== undefined) loc = loc.nth(nth);
+  else if (await loc.count() > 1) loc = loc.filter({ visible: true });
   await loc.fill(value);
 }
 
 export async function selectByRole(page, role, name, value, nth, inRole, inText) {
   const roleOpts = name ? { name, exact: true } : {};
   let loc = page.getByRole(role, roleOpts);
+  if (name && await loc.count() === 0) loc = page.getByRole(role, { name });
   if (inRole !== undefined && inText !== undefined) {
     const cr = ({ list: 'listitem' })[inRole] || inRole;
     loc = page.getByRole(cr).filter({ hasText: inText }).getByRole(role, roleOpts);
@@ -291,6 +299,7 @@ export async function selectByRole(page, role, name, value, nth, inRole, inText)
     }
   }
   if (nth !== undefined) loc = loc.nth(nth);
+  else if (await loc.count() > 1) loc = loc.filter({ visible: true });
   await loc.selectOption(value);
 }
 

--- a/packages/extension/src/panel/lib/page-scripts.ts
+++ b/packages/extension/src/panel/lib/page-scripts.ts
@@ -250,9 +250,6 @@ export async function uncheckByText(page, text, nth?, exact?) {
 export async function actionByRole(page, role, name, action, nth, inRole, inText) {
   const roleOpts = name ? { name, exact: true } : {};
   let loc = page.getByRole(role, roleOpts);
-  // Fall back to non-exact if exact match finds nothing (e.g. label includes
-  // extra text from child buttons like "Information anzeigen")
-  if (name && await loc.count() === 0) loc = page.getByRole(role, { name });
   if (inRole !== undefined && inText !== undefined) {
     const cr = ({ list: 'listitem' })[inRole] || inRole;
     loc = page.getByRole(cr).filter({ hasText: inText }).getByRole(role, roleOpts);
@@ -270,7 +267,6 @@ export async function actionByRole(page, role, name, action, nth, inRole, inText
 export async function fillByRole(page, role, name, value, nth, inRole, inText) {
   const roleOpts = name ? { name, exact: true } : {};
   let loc = page.getByRole(role, roleOpts);
-  if (name && await loc.count() === 0) loc = page.getByRole(role, { name });
   if (inRole !== undefined && inText !== undefined) {
     const cr = ({ list: 'listitem' })[inRole] || inRole;
     loc = page.getByRole(cr).filter({ hasText: inText }).getByRole(role, roleOpts);
@@ -288,7 +284,6 @@ export async function fillByRole(page, role, name, value, nth, inRole, inText) {
 export async function selectByRole(page, role, name, value, nth, inRole, inText) {
   const roleOpts = name ? { name, exact: true } : {};
   let loc = page.getByRole(role, roleOpts);
-  if (name && await loc.count() === 0) loc = page.getByRole(role, { name });
   if (inRole !== undefined && inText !== undefined) {
     const cr = ({ list: 'listitem' })[inRole] || inRole;
     loc = page.getByRole(cr).filter({ hasText: inText }).getByRole(role, roleOpts);

--- a/packages/extension/test/content/locator.test.ts
+++ b/packages/extension/test/content/locator.test.ts
@@ -247,6 +247,16 @@ describe('locator', () => {
             expect(getLabel(input)).toBe('Name');
         });
 
+        it('includes aria-label from child elements in label text (#802)', () => {
+            document.body.innerHTML = `
+                <label for="hersteller">Hersteller Ihres Fahrzeuges
+                    <span><a aria-label="Information anzeigen" role="button"></a></span>
+                </label>
+                <select id="hersteller"><option>A</option></select>`;
+            const select = document.querySelector('select') as HTMLSelectElement;
+            expect(getLabel(select)).toBe('Hersteller Ihres Fahrzeuges Information anzeigen');
+        });
+
         it('does not return informal label from preceding table cell (#768)', () => {
             document.body.innerHTML = '<table><tr><td>Benutzerkennung:*</td><td><input type="text"></td></tr></table>';
             const input = document.querySelector('input') as HTMLInputElement;

--- a/packages/extension/test/content/locator.test.ts
+++ b/packages/extension/test/content/locator.test.ts
@@ -1052,6 +1052,20 @@ describe('locator', () => {
             expect(cmds2!.pw).toBe('click "Select an option (table)"');
         });
 
+        it('select in same cell as label uses within-cell sibling, not previous cell (#800)', () => {
+            document.body.innerHTML = `<table><tr>
+                <td><span>Beantragte Währung</span><br><span>Euro</span></td>
+                <td><span>Mittelgeber*</span><br>
+                    <select><option value="AA">AA</option><option value="BB">BB</option></select>
+                </td>
+            </tr></table>`;
+            const select = document.querySelector('select')!;
+            const cmds = buildCommands('click', select);
+            expect(cmds!.pw).toBe('click "Mittelgeber*"');
+            const selCmds = buildCommands('select', select, { option: 'AA' });
+            expect(selCmds!.pw).toBe('select "Mittelgeber*" "AA"');
+        });
+
         it('adds --exact for text-based click locator', () => {
             document.body.innerHTML = '<div>Bis 45 km/h</div>';
             const div = document.querySelector('div')!;


### PR DESCRIPTION
## Summary
- Recorder returns plain frame name/id instead of CSS selector (`#oevd-iframe` → `oevd-iframe`)
- Frame resolution tries `page.frame(name)` first, falls back to `locator().contentFrame()`
- `getInformalLabel` checks within-cell siblings before previous cell (#800)
- `getAccessibleName` fixes `aria-labelledby`/`aria-label` precedence per ARIA spec
- `actionByRole`/`fillByRole`/`selectByRole` fall back to non-exact when exact finds nothing
- Role-based commands filter to visible when multiple elements match

## Test plan
- [x] 138 locator tests pass
- [x] 145 core tests pass
- [x] Verified on provinzial.de: `click combobox "Hersteller Ihres Fahrzeuges" --frame "oevd-iframe"` works
- [ ] Recorder fix for accessible name mismatch (follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)