### PR TITLE
fix: wrap long lines in console output (#814)

### DIFF
--- a/packages/extension/src/panel/panel.css
+++ b/packages/extension/src/panel/panel.css
@@ -236,7 +236,7 @@ html, body {
 
 .ot-key    { color: var(--color-flag); }
 .ot-colon  { color: var(--text-dim); }
-.ot-string { color: var(--color-string); }
+.ot-string { color: var(--color-string); word-break: break-word; }
 .ot-number { color: var(--color-url); }
 .ot-boolean { color: var(--color-url); }
 .ot-null, .ot-undefined { color: var(--text-dim); font-style: italic; }


### PR DESCRIPTION
## Summary
- Add `word-break: break-word` to `.ot-string` so long locator strings wrap in the console

Closes #814

🤖 Generated with [Claude Code](https://claude.com/claude-code)