### PR TITLE
feat: support nested iframes in recorder and playback (#815)

### DIFF
--- a/packages/core/src/parser.ts
+++ b/packages/core/src/parser.ts
@@ -357,8 +357,15 @@ export function resolveArgs(args: ParsedArgs): ParsedArgs {
   if (frameSel && args._[0] === 'run-code' && args._[1]) {
     const inner = args._[1];
     // Wrap: resolve the frame, then call the inner function with the frame as "page".
-    // Try frame name first, fall back to CSS locator for selectors like "#id".
-    args = { _: ['run-code', `async (page) => { const __frame = page.frame(${JSON.stringify(frameSel)}) || await page.locator(${JSON.stringify(frameSel)}).contentFrame(); return await (${inner})(__frame); }`] };
+    // Supports nested frames via space-separated selectors.
+    // Single frame: try page.frame(name) first; nested: locator().contentFrame() at each level.
+    const parts = frameSel.split(' ').filter(Boolean);
+    if (parts.length === 1) {
+      args = { _: ['run-code', `async (page) => { const __frame = page.frame(${JSON.stringify(parts[0])}) || await page.locator(${JSON.stringify(parts[0])}).contentFrame(); return await (${inner})(__frame); }`] };
+    } else {
+      const chain = parts.map(f => `__p = await __p.locator(${JSON.stringify(f)}).contentFrame()`).join('; ');
+      args = { _: ['run-code', `async (page) => { let __p = page; ${chain}; return await (${inner})(__p); }`] };
+    }
   }
 
   return args;

--- a/packages/core/test/parser.test.ts
+++ b/packages/core/test/parser.test.ts
@@ -205,6 +205,7 @@ describe('--frame flag', () => {
     const args = parseInput('click "Submit" --frame "#myframe"');
     const resolved = resolveArgs(args);
     expect(resolved._[0]).toBe('run-code');
+    expect(resolved._[1]).toContain('page.frame("#myframe")');
     expect(resolved._[1]).toContain('page.locator("#myframe").contentFrame()');
     expect(resolved.frame).toBeUndefined();
   });

--- a/packages/extension/src/content/recorder.ts
+++ b/packages/extension/src/content/recorder.ts
@@ -26,57 +26,82 @@ export const SPECIAL_KEYS = new Set([
  * in the parent document. For cross-origin iframes, `window.frameElement` is null
  * due to security restrictions — we fall back to using the frame's src URL.
  */
-function detectFrameSelector(): string | null {
-    if (window === window.top) return null;
-
-    try {
-        // Same-origin: window.frameElement is accessible
-        const frame = window.frameElement;
-        if (frame) {
-            const tag = frame.tagName.toLowerCase(); // 'frame' or 'iframe'
-            // Prefer name attribute — works as both a Playwright frame name
-            // and a CSS attribute selector, portable across CLI and extension
-            const name = frame.getAttribute('name');
-            if (name) return name;
-            // Fall back to id — used as frame identifier (page.frame(id) resolves it)
-            if (frame.id) return frame.id;
-            // Prefer src attribute
-            const src = frame.getAttribute('src');
-            if (src) return `${tag}[src="${src}"]`;
-            // Fall back to tag + nth-of-type
-            const parent = frame.parentElement;
-            if (parent) {
-                const siblings = Array.from(parent.querySelectorAll(`:scope > ${tag}`));
-                const idx = siblings.indexOf(frame);
-                if (siblings.length === 1) return tag;
-                return `${tag}:nth-of-type(${idx + 1})`;
-            }
-            return tag;
-        }
-    } catch { /* cross-origin — frameElement throws */ }
-
-    // Cross-origin fallback: use location to build a src-based selector
-    // This is a best-effort approach — assume iframe (modern standard)
-    try {
-        const src = window.location.href;
-        if (src && src !== 'about:blank') return `iframe[src="${src}"]`;
-    } catch { /* cannot access location */ }
-
-    return 'iframe';
+/**
+ * Compute selectors for a single frame element.
+ * pw: plain name/id for --frame (resolved by page.frame())
+ * css: CSS selector for JS .locator().contentFrame()
+ */
+function selectorsForFrame(frame: Element): { pw: string; css: string } {
+    const tag = frame.tagName.toLowerCase(); // 'frame' or 'iframe'
+    const name = frame.getAttribute('name');
+    if (name) return { pw: name, css: `${tag}[name="${name}"]` };
+    if (frame.id) return { pw: frame.id, css: `#${CSS.escape(frame.id)}` };
+    const src = frame.getAttribute('src');
+    if (src) { const sel = `${tag}[src="${src}"]`; return { pw: sel, css: sel }; }
+    const parent = frame.parentElement;
+    if (parent) {
+        const siblings = Array.from(parent.querySelectorAll(`:scope > ${tag}`));
+        const idx = siblings.indexOf(frame);
+        const sel = siblings.length === 1 ? tag : `${tag}:nth-of-type(${idx + 1})`;
+        return { pw: sel, css: sel };
+    }
+    return { pw: tag, css: tag };
 }
 
-/** Cached frame selector — computed once on init */
-let frameSelector: string | null = null;
+/**
+ * Detect the full frame chain from this window up to the top frame.
+ * Returns arrays of selectors, one per ancestor frame, outermost first.
+ * Returns empty arrays if we're in the top frame.
+ */
+function detectFrameChain(): { pw: string[]; css: string[] } {
+    if (window === window.top) return { pw: [], css: [] };
+
+    const pwChain: string[] = [];
+    const cssChain: string[] = [];
+    let win: Window = window;
+    while (win !== win.top) {
+        try {
+            const frame = win.frameElement;
+            if (frame) {
+                const sels = selectorsForFrame(frame);
+                pwChain.push(sels.pw);
+                cssChain.push(sels.css);
+            } else {
+                // Cross-origin: frameElement is null, use src fallback
+                try {
+                    const src = win.location.href;
+                    const sel = (src && src !== 'about:blank') ? `iframe[src="${src}"]` : 'iframe';
+                    pwChain.push(sel);
+                    cssChain.push(sel);
+                } catch { pwChain.push('iframe'); cssChain.push('iframe'); }
+                break; // Can't walk further up from cross-origin
+            }
+        } catch {
+            break; // cross-origin — frameElement throws
+        }
+        win = win.parent;
+    }
+    return { pw: pwChain.reverse(), css: cssChain.reverse() };
+}
+
+/** Cached frame chain — computed once on init */
+let framePath: { pw: string[]; css: string[] } = { pw: [], css: [] };
 
 /**
  * Wrap recorded commands with frame context if we're inside an iframe.
- * Prepends --frame flag to PW and .contentFrame() to JS.
+ * Prepends --frame flag(s) to PW and .contentFrame() chain to JS.
  */
 function wrapWithFrameContext(cmds: { pw: string; js: string }): { pw: string; js: string } {
-    if (!frameSelector) return cmds;
+    if (framePath.pw.length === 0) return cmds;
+    // Single frame: use plain name for PW (page.frame() resolves it)
+    // Nested frames: use CSS selectors for PW (locator().contentFrame() at each level)
+    const frameArg = framePath.pw.length === 1
+        ? framePath.pw[0]
+        : framePath.css.join(' ');
+    const jsChain = framePath.css.map(sel => `.locator(${JSON.stringify(sel)}).contentFrame()`).join('');
     return {
-        pw: `${cmds.pw} --frame "${frameSelector}"`,
-        js: `await page.locator(${JSON.stringify(frameSelector)}).contentFrame().${cmds.js.replace(/^await page\./, '')}`,
+        pw: `${cmds.pw} --frame "${frameArg}"`,
+        js: `await page${jsChain}.${cmds.js.replace(/^await page\./, '')}`,
     };
 }
 
@@ -228,7 +253,7 @@ export function init() {
     (window as any).__pw_recorder_active = true;
 
     // Detect iframe context once on init
-    frameSelector = detectFrameSelector();
+    framePath = detectFrameChain();
 
     chrome.runtime.onMessage.addListener(onMessage);
     document.addEventListener('click', onClickCapture, true);

--- a/packages/extension/src/panel/lib/commands.ts
+++ b/packages/extension/src/panel/lib/commands.ts
@@ -768,10 +768,21 @@ export function parseReplCommand(input: string): ParseResult {
     const frameSel = args.frame;
     if (frameSel && typeof frameSel === 'string') {
       // Temporarily shadow `page` with the frame so all page-script functions
-      // operate inside the iframe. Try frame name/title first (works for plain
-      // names like "oevd-iframe"), fall back to CSS locator (for "#id", "iframe[src=...]").
-      const frameExpr = `(page.frame(${ser(frameSel)}) || await page.locator(${ser(frameSel)}).contentFrame())`;
-      return { jsExpr: `await (async (__page) => { const page = __page; return ${resolved.jsExpr}; })(${frameExpr})` };
+      // operate inside the iframe. Supports nested frames via space-separated
+      // selectors: --frame "parent child" chains frame resolution.
+      // Use page.frame() for single plain names (fast path), locator().contentFrame()
+      // for CSS selectors and nested frames.
+      const frameParts = frameSel.split(' ').filter(Boolean);
+      if (frameParts.length === 1) {
+        // Single frame — try name first (works for plain names like "oevd-iframe")
+        const frameExpr = `(page.frame(${ser(frameParts[0])}) || await page.locator(${ser(frameParts[0])}).contentFrame())`;
+        return { jsExpr: `await (async (__page) => { const page = __page; return ${resolved.jsExpr}; })(${frameExpr})` };
+      }
+      // Nested frames — chain locator().contentFrame() at each level
+      const frameExpr = frameParts.map(f =>
+        `__p = await __p.locator(${ser(f)}).contentFrame()`
+      ).join('; ');
+      return { jsExpr: `await (async (__p) => { ${frameExpr}; const page = __p; return ${resolved.jsExpr}; })(page)` };
     }
     return resolved;
   }


### PR DESCRIPTION
## Summary
- Recorder walks up ancestor frames to build full frame chain for nested iframes
- Single frame: plain name in `--frame` (backwards compatible)
- Nested frames: space-separated CSS selectors in `--frame`, chained `locator().contentFrame()` in JS
- Both extension and CLI playback paths support nested frames

## Test plan
- [x] Single frame (`--frame "oevd-iframe"`) still works
- [x] Nested frames PW: `click button "Click Here" --frame "iframe[name=\"demo_parent_iframe\"] iframe[name=\"demo_frame1\"]"` works
- [x] Nested frames JS: `page.locator('iframe[name="demo_parent_iframe"]').contentFrame().locator('iframe[name="demo_frame1"]').contentFrame().getByRole('button', { name: 'Click Here' }).click()` works
- [x] Parser tests pass (51/51)
- [x] Locator tests pass (139/139)

🤖 Generated with [Claude Code](https://claude.com/claude-code)