### PR TITLE
feat: persist panel state across side panel close/reopen (#811)

### DIFF
--- a/packages/extension/e2e/recording/recording.spec.ts
+++ b/packages/extension/e2e/recording/recording.spec.ts
@@ -11,6 +11,7 @@ import { test, expect } from './fixtures.js';
 test.describe('Recording flow', () => {
   test.beforeEach(async ({ sidePanel, extensionId, testPage }) => {
     await sidePanel.goto(extensionId);
+    await sidePanel.clearEditor();
 
     // Bring test page to front and attach the extension to it
     await testPage.bringToFront();

--- a/packages/extension/e2e/shared/SidePanelPage.ts
+++ b/packages/extension/e2e/shared/SidePanelPage.ts
@@ -92,6 +92,16 @@ export class SidePanelPage {
   /** Navigate to the panel HTML page. */
   async goto(extensionId: string) {
     await this.page.goto(`chrome-extension://${extensionId}/panel/panel.html`);
+    // Clear session state after load so restored content doesn't leak between tests.
+    // The panel may have already restored — clearEditor below resets it.
+    await this.page.evaluate(() => (globalThis as any).chrome?.storage?.session?.remove('panelSessionState'));
+  }
+
+  /** Select all editor content and delete it. */
+  async clearEditor() {
+    await this.editor.click();
+    await this.page.keyboard.press('ControlOrMeta+a');
+    await this.page.keyboard.press('Backspace');
   }
 
   // ─── Console Submit ──────────────────────────────────────────────────────

--- a/packages/extension/src/panel/App.tsx
+++ b/packages/extension/src/panel/App.tsx
@@ -8,6 +8,8 @@ import { BottomPane } from './components/BottomPane'
 import DebugBar from './components/DebugBar';
 import { onConsoleEvent } from '@/lib/sw-debugger';
 import { loadSettings } from './lib/settings';
+import { saveSessionState, loadSessionState } from './lib/session-state';
+import { getCommandHistory, addCommand } from './lib/command-history';
 import { SerializedValue } from './components/Console/types'
 import { formatInlineValues } from './lib/inline-values'
 
@@ -33,11 +35,43 @@ function App() {
     return () => onConsoleEvent(null);
   }, [dispatch]);
 
+  // Restore session state on init, then load settings as fallback for mode
   useEffect(() => {
-    loadSettings().then(s => {
-      dispatch({ type: 'SET_EDITOR_MODE', mode: s.languageMode });
+    loadSessionState().then(session => {
+      if (session) {
+        if (session.editorContent) dispatch({ type: 'EDIT_EDITOR_CONTENT', content: session.editorContent });
+        dispatch({ type: 'SET_EDITOR_MODE', mode: session.editorMode });
+        if (session.breakPoints.length) dispatch({ type: 'SET_BREAKPOINTS', breakPoints: new Set(session.breakPoints) });
+        dispatch({ type: 'SET_BOTTOM_TAB', tab: session.bottomTab });
+        if (session.editorPaneHeight && editorPaneRef.current) {
+          editorPaneRef.current.style.flex = `0 0 ${session.editorPaneHeight}px`;
+        }
+        if (session.cursorPos) {
+          // Defer cursor restore until CodeMirror has mounted
+          setTimeout(() => editorRef.current?.setCursorPos(session.cursorPos), 50);
+        }
+        for (const cmd of session.commandHistory) addCommand(cmd);
+      } else {
+        loadSettings().then(s => dispatch({ type: 'SET_EDITOR_MODE', mode: s.languageMode }));
+      }
     });
   }, []);
+
+  // Save session state on every meaningful change (debounced)
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      saveSessionState({
+        editorContent: state.editorContent,
+        editorMode: state.editorMode,
+        breakPoints: [...state.breakPoints],
+        bottomTab: state.bottomTab,
+        cursorPos: editorRef.current?.getCursorPos() ?? 0,
+        editorPaneHeight: editorPaneRef.current?.offsetHeight ?? null,
+        commandHistory: getCommandHistory(),
+      });
+    }, 500);
+    return () => clearTimeout(timer);
+  }, [state.editorContent, state.editorMode, state.breakPoints, state.bottomTab]);
 
   async function doAttach(tabId: number) {
     dispatch({ type: 'ATTACH_START' });

--- a/packages/extension/src/panel/App.tsx
+++ b/packages/extension/src/panel/App.tsx
@@ -35,25 +35,22 @@ function App() {
     return () => onConsoleEvent(null);
   }, [dispatch]);
 
-  // Restore session state on init, then load settings as fallback for mode
+  // Load editor mode from settings, then restore session state
   useEffect(() => {
+    loadSettings().then(s => dispatch({ type: 'SET_EDITOR_MODE', mode: s.languageMode }));
     loadSessionState().then(session => {
-      if (session) {
-        if (session.editorContent) dispatch({ type: 'EDIT_EDITOR_CONTENT', content: session.editorContent });
-        dispatch({ type: 'SET_EDITOR_MODE', mode: session.editorMode });
-        if (session.breakPoints.length) dispatch({ type: 'SET_BREAKPOINTS', breakPoints: new Set(session.breakPoints) });
-        dispatch({ type: 'SET_BOTTOM_TAB', tab: session.bottomTab });
-        if (session.editorPaneHeight && editorPaneRef.current) {
-          editorPaneRef.current.style.flex = `0 0 ${session.editorPaneHeight}px`;
-        }
-        if (session.cursorPos) {
-          // Defer cursor restore until CodeMirror has mounted
-          setTimeout(() => editorRef.current?.setCursorPos(session.cursorPos), 50);
-        }
-        for (const cmd of session.commandHistory) addCommand(cmd);
-      } else {
-        loadSettings().then(s => dispatch({ type: 'SET_EDITOR_MODE', mode: s.languageMode }));
+      if (!session) return;
+      if (session.editorContent) dispatch({ type: 'EDIT_EDITOR_CONTENT', content: session.editorContent });
+      if (session.editorMode) dispatch({ type: 'SET_EDITOR_MODE', mode: session.editorMode });
+      if (session.breakPoints.length) dispatch({ type: 'SET_BREAKPOINTS', breakPoints: new Set(session.breakPoints) });
+      dispatch({ type: 'SET_BOTTOM_TAB', tab: session.bottomTab });
+      if (session.editorPaneHeight && editorPaneRef.current) {
+        editorPaneRef.current.style.flex = `0 0 ${session.editorPaneHeight}px`;
       }
+      if (session.cursorPos) {
+        setTimeout(() => editorRef.current?.setCursorPos(session.cursorPos), 50);
+      }
+      for (const cmd of session.commandHistory) addCommand(cmd);
     });
   }, []);
 

--- a/packages/extension/src/panel/components/CodeMirrorEditorPane.tsx
+++ b/packages/extension/src/panel/components/CodeMirrorEditorPane.tsx
@@ -8,6 +8,8 @@ import { InlineValues } from '@/lib/codemirror-setup';
 export interface EditorHandle {
     insertAtCursor: (text: string) => void;
     replaceLastInsert: (text: string) => void;
+    getCursorPos: () => number;
+    setCursorPos: (pos: number) => void;
 }
 
 interface EditorPaneProps extends Pick<PanelState, 'editorContent' | 'currentRunLine' | 'lineResults' | 'editorMode'> {
@@ -53,6 +55,15 @@ function CodeMirrorEditorPane({ editorContent, editorMode, currentRunLine, lineR
             });
             lastInsertRangeRef.current = { from: range.from, to: range.from + insert.length };
             view.focus();
+        },
+        getCursorPos() {
+            return viewRef.current?.state.selection.main.head ?? 0;
+        },
+        setCursorPos(pos: number) {
+            const view = viewRef.current;
+            if (!view) return;
+            const clamped = Math.min(pos, view.state.doc.length);
+            view.dispatch({ selection: { anchor: clamped }, scrollIntoView: true });
         },
     }));
 

--- a/packages/extension/src/panel/lib/session-state.ts
+++ b/packages/extension/src/panel/lib/session-state.ts
@@ -1,0 +1,35 @@
+/**
+ * Persist and restore panel state across side-panel close/reopen.
+ * Uses chrome.storage.session (cleared when browser closes).
+ */
+
+const KEY = 'panelSessionState';
+
+export interface SessionState {
+  editorContent: string;
+  editorMode: 'pw' | 'js';
+  breakPoints: number[];
+  bottomTab: 'console' | 'variables';
+  cursorPos: number;
+  editorPaneHeight: number | null;
+  commandHistory: string[];
+}
+
+const EMPTY: SessionState = {
+  editorContent: '',
+  editorMode: 'pw',
+  breakPoints: [],
+  bottomTab: 'console',
+  cursorPos: 0,
+  editorPaneHeight: null,
+  commandHistory: [],
+};
+
+export async function saveSessionState(state: SessionState): Promise<void> {
+  await chrome.storage.session.set({ [KEY]: state });
+}
+
+export async function loadSessionState(): Promise<SessionState | null> {
+  const result = await chrome.storage.session.get(KEY);
+  return result[KEY] ?? null;
+}

--- a/packages/extension/src/panel/lib/session-state.ts
+++ b/packages/extension/src/panel/lib/session-state.ts
@@ -15,16 +15,6 @@ export interface SessionState {
   commandHistory: string[];
 }
 
-const EMPTY: SessionState = {
-  editorContent: '',
-  editorMode: 'pw',
-  breakPoints: [],
-  bottomTab: 'console',
-  cursorPos: 0,
-  editorPaneHeight: null,
-  commandHistory: [],
-};
-
 export async function saveSessionState(state: SessionState): Promise<void> {
   await chrome.storage.session.set({ [KEY]: state });
 }


### PR DESCRIPTION
## Summary
- New `session-state.ts` module using `chrome.storage.session`
- Saves on every meaningful state change (debounced 500ms)
- Restores on panel init

## What's persisted
- Editor content
- Editor mode (pw/js)
- Breakpoints
- Cursor position
- Editor pane height
- Bottom tab (console/variables)
- Command history (arrow-up recall)

State clears when browser closes — no stale data.

## Test plan
- [x] Type code, close panel, reopen → editor content restored
- [x] Verified via `chrome.storage.session.get('panelSessionState')` 
- [x] Build succeeds, 139 locator tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)