### PR TITLE
feat: seamless side panel ↔ popup handoff (#820)

### DIFF
--- a/packages/extension/src/background.ts
+++ b/packages/extension/src/background.ts
@@ -749,6 +749,9 @@ async function handleBridgeCommand(msg: {
 // Serialize bridge commands so concurrent messages don't race on currentPage / attachToTab.
 let commandQueue: Promise<void> = Promise.resolve();
 
+// ── Handoff state for side panel ↔ popup transfer (#820) ──
+let handoffState: any = null;
+
 chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
   if (msg.type === 'bridge-command') {
     const execute = () => handleBridgeCommand(msg);
@@ -855,6 +858,41 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
     return true;
   }
   if (msg.type === 'ping') { sendResponse({ pong: true }); return false; }
+
+  // ── Handoff: side panel ↔ popup state transfer (#820) ──
+  if (msg.type === 'handoff-save') { handoffState = msg.state; sendResponse({ ok: true }); return false; }
+  if (msg.type === 'handoff-load') { const s = handoffState; handoffState = null; sendResponse(s); return false; }
+  if (msg.type === 'handoff-to-popup') {
+    const tabId = msg.tabId;
+    chrome.windows.create({
+      url: chrome.runtime.getURL('panel/panel.html') + (tabId ? `?tabId=${tabId}&handoff=1` : '?handoff=1'),
+      type: 'popup',
+      width: 450,
+      height: 700,
+    }).then(() => sendResponse({ ok: true })).catch(e => sendResponse({ ok: false, error: String(e) }));
+    return true;
+  }
+  if (msg.type === 'handoff-to-sidepanel') {
+    (async () => {
+      // Find the main browser window (not the popup window)
+      let windowId: number | undefined;
+      if (msg.tabId) {
+        const tab = await chrome.tabs.get(msg.tabId).catch(() => null);
+        windowId = tab?.windowId;
+      }
+      if (!windowId) {
+        // Find the last focused normal window (not the popup)
+        const windows = await chrome.windows.getAll({ windowTypes: ['normal'] });
+        const focused = windows.find(w => w.focused) ?? windows[0];
+        windowId = focused?.id;
+      }
+      if (!windowId) throw new Error('No browser window found');
+      await chrome.sidePanel.open({ windowId });
+      sendResponse({ ok: true });
+    })().catch(e => sendResponse({ ok: false, error: String(e) }));
+    return true;
+  }
+
   return false;
 });
 

--- a/packages/extension/src/panel/App.tsx
+++ b/packages/extension/src/panel/App.tsx
@@ -35,23 +35,50 @@ function App() {
     return () => onConsoleEvent(null);
   }, [dispatch]);
 
-  // Load editor mode from settings, then restore session state
+  // Restore state: check handoff (mode switch) first, then session state, then settings
   useEffect(() => {
-    loadSettings().then(s => dispatch({ type: 'SET_EDITOR_MODE', mode: s.languageMode }));
-    loadSessionState().then(session => {
-      if (!session) return;
-      if (session.editorContent) dispatch({ type: 'EDIT_EDITOR_CONTENT', content: session.editorContent });
-      if (session.editorMode) dispatch({ type: 'SET_EDITOR_MODE', mode: session.editorMode });
-      if (session.breakPoints.length) dispatch({ type: 'SET_BREAKPOINTS', breakPoints: new Set(session.breakPoints) });
-      dispatch({ type: 'SET_BOTTOM_TAB', tab: session.bottomTab });
-      if (session.editorPaneHeight && editorPaneRef.current) {
-        editorPaneRef.current.style.flex = `0 0 ${session.editorPaneHeight}px`;
+    (async () => {
+      // Handoff from side panel ↔ popup switch (#820)
+      const handoff = await chrome.runtime.sendMessage({ type: 'handoff-load' });
+      if (handoff) {
+        dispatch({ type: 'RESTORE_HANDOFF', state: {
+          editorContent: handoff.editorContent,
+          editorMode: handoff.editorMode,
+          breakPoints: new Set(handoff.breakPoints),
+          bottomTab: handoff.bottomTab,
+          outputLines: handoff.outputLines,
+          passCount: handoff.passCount,
+          failCount: handoff.failCount,
+          lineResults: handoff.lineResults,
+        }});
+        if (handoff.editorPaneHeight && editorPaneRef.current) {
+          editorPaneRef.current.style.flex = `0 0 ${handoff.editorPaneHeight}px`;
+        }
+        if (handoff.cursorPos) {
+          setTimeout(() => editorRef.current?.setCursorPos(handoff.cursorPos), 50);
+        }
+        for (const cmd of handoff.commandHistory ?? []) addCommand(cmd);
+        return; // tab attachment handled by the normal useEffect below
       }
-      if (session.cursorPos) {
-        setTimeout(() => editorRef.current?.setCursorPos(session.cursorPos), 50);
+      // Regular session state restore (#811)
+      const session = await loadSessionState();
+      if (session) {
+        if (session.editorContent) dispatch({ type: 'EDIT_EDITOR_CONTENT', content: session.editorContent });
+        if (session.editorMode) dispatch({ type: 'SET_EDITOR_MODE', mode: session.editorMode });
+        if (session.breakPoints.length) dispatch({ type: 'SET_BREAKPOINTS', breakPoints: new Set(session.breakPoints) });
+        dispatch({ type: 'SET_BOTTOM_TAB', tab: session.bottomTab });
+        if (session.editorPaneHeight && editorPaneRef.current) {
+          editorPaneRef.current.style.flex = `0 0 ${session.editorPaneHeight}px`;
+        }
+        if (session.cursorPos) {
+          setTimeout(() => editorRef.current?.setCursorPos(session.cursorPos), 50);
+        }
+        for (const cmd of session.commandHistory) addCommand(cmd);
+      } else {
+        const s = await loadSettings();
+        dispatch({ type: 'SET_EDITOR_MODE', mode: s.languageMode });
       }
-      for (const cmd of session.commandHistory) addCommand(cmd);
-    });
+    })();
   }, []);
 
   // Save session state on every meaningful change (debounced)
@@ -79,6 +106,49 @@ function App() {
     } else {
       attachedTabRef.current = null;
       dispatch({ type: 'ATTACH_FAIL' });
+    }
+  }
+
+  // Handoff: switch between side panel ↔ popup (#820)
+  async function handleModeSwitch() {
+    const handoffState = {
+      editorContent: state.editorContent,
+      editorMode: state.editorMode,
+      breakPoints: [...state.breakPoints],
+      bottomTab: state.bottomTab,
+      cursorPos: editorRef.current?.getCursorPos() ?? 0,
+      editorPaneHeight: editorPaneRef.current?.offsetHeight ?? null,
+      commandHistory: getCommandHistory(),
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      outputLines: state.outputLines.map(({ getProperties: _gp, ...rest }) => rest),
+      passCount: state.passCount,
+      failCount: state.failCount,
+      lineResults: state.lineResults,
+      attachedTabId: state.attachedTabId,
+    };
+    await chrome.runtime.sendMessage({ type: 'handoff-save', state: handoffState });
+    const isPopup = new URLSearchParams(window.location.search).has('tabId');
+    if (isPopup) {
+      // Open side panel directly from the popup (preserves user gesture)
+      let windowId: number | undefined;
+      if (state.attachedTabId) {
+        const tab = await chrome.tabs.get(state.attachedTabId).catch(() => null);
+        windowId = (tab as any)?.windowId;
+      }
+      if (!windowId) {
+        const windows = await chrome.windows.getAll({ windowTypes: ['normal'] });
+        windowId = ((windows as any[]).find((w: any) => w.focused) ?? windows[0])?.id;
+      }
+      if (windowId) {
+        await (chrome.sidePanel as any).open({ windowId });
+        window.close();
+      }
+    } else {
+      const res = await chrome.runtime.sendMessage({
+        type: 'handoff-to-popup',
+        tabId: state.attachedTabId,
+      });
+      if (res?.ok) window.close();
     }
   }
 
@@ -156,6 +226,7 @@ function App() {
         dispatch={dispatch}
         editorRef={editorRef}
         breakPoints={state.breakPoints}
+        onModeSwitch={handleModeSwitch}
       />
       {state.isStepDebugging && <DebugBar dispatch={dispatch} />}
 

--- a/packages/extension/src/panel/App.tsx
+++ b/packages/extension/src/panel/App.tsx
@@ -129,20 +129,23 @@ function App() {
     await chrome.runtime.sendMessage({ type: 'handoff-save', state: handoffState });
     const isPopup = new URLSearchParams(window.location.search).has('tabId');
     if (isPopup) {
-      // Open side panel directly from the popup (preserves user gesture)
+      // Open side panel directly from the popup (preserves user gesture).
+      // Chrome API types are incomplete for sidePanel/tabs in panel context.
+      /* eslint-disable @typescript-eslint/no-explicit-any */
       let windowId: number | undefined;
       if (state.attachedTabId) {
-        const tab = await chrome.tabs.get(state.attachedTabId).catch(() => null);
-        windowId = (tab as any)?.windowId;
+        const tab = await (chrome as any).tabs.get(state.attachedTabId).catch(() => null);
+        windowId = tab?.windowId;
       }
       if (!windowId) {
-        const windows = await chrome.windows.getAll({ windowTypes: ['normal'] });
-        windowId = ((windows as any[]).find((w: any) => w.focused) ?? windows[0])?.id;
+        const windows = await (chrome as any).windows.getAll({ windowTypes: ['normal'] });
+        windowId = (windows.find((w: any) => w.focused) ?? windows[0])?.id;
       }
       if (windowId) {
-        await (chrome.sidePanel as any).open({ windowId });
+        await (chrome as any).sidePanel.open({ windowId });
         window.close();
       }
+      /* eslint-enable @typescript-eslint/no-explicit-any */
     } else {
       const res = await chrome.runtime.sendMessage({
         type: 'handoff-to-popup',

--- a/packages/extension/src/panel/components/Icons.tsx
+++ b/packages/extension/src/panel/components/Icons.tsx
@@ -181,3 +181,23 @@ export function CrosshairIcon({ size = 16 }: { size?: number }) {
   );
 }
 
+export function PopOutIcon({ size = 16 }: { size?: number }) {
+  return (
+    <svg viewBox="0 0 24 24" width={size} height={size} stroke="currentColor" fill="none" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
+      <polyline points="15 3 21 3 21 9" />
+      <line x1="10" y1="14" x2="21" y2="3" />
+    </svg>
+  );
+}
+
+export function DockIcon({ size = 16 }: { size?: number }) {
+  return (
+    <svg viewBox="0 0 24 24" width={size} height={size} stroke="currentColor" fill="none" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <rect x="3" y="3" width="18" height="18" rx="2" />
+      <line x1="15" y1="3" x2="15" y2="21" />
+      <polyline points="10 8 6 12 10 16" />
+    </svg>
+  );
+}
+

--- a/packages/extension/src/panel/components/Toolbar.tsx
+++ b/packages/extension/src/panel/components/Toolbar.tsx
@@ -3,7 +3,7 @@ import type { PanelState, Action } from "@/reducer";
 import { attachToTab } from '@/lib/bridge';
 import { runAndDispatch, runJsScript, runJsScriptStep } from '@/lib/run';
 import { swTerminateExecution, swDebugResume } from '@/lib/sw-debugger';
-import { SunIcon, MoonIcon, FolderOpenIcon, SaveIcon, RecordIcon, StopIcon, StepForwardIcon, BugIcon, CrosshairIcon, PlugIcon, UnplugIcon, ScreencastIcon } from './Icons';
+import { SunIcon, MoonIcon, FolderOpenIcon, SaveIcon, RecordIcon, StopIcon, StepForwardIcon, BugIcon, CrosshairIcon, PlugIcon, UnplugIcon, ScreencastIcon, PopOutIcon, DockIcon } from './Icons';
 import type { EditorHandle } from './CodeMirrorEditorPane';
 import { buildPickResult } from '@/lib/pick-info';
 import type { ElementPickInfo } from '@/types';
@@ -12,9 +12,11 @@ import { loadSettings, storeSettings } from '@/lib/settings'
 interface ToolbarProps extends Pick<PanelState, 'editorContent' | 'editorMode' | 'stepLine' | 'attachedUrl' | 'attachedTabId' | 'isAttaching' | 'isRunning' | 'isStepDebugging' | 'breakPoints'> {
     dispatch: React.Dispatch<Action>,
     editorRef: React.RefObject<EditorHandle | null>,
+    onModeSwitch: () => void,
 };
 
-function Toolbar({ editorContent, editorMode, stepLine, attachedUrl, attachedTabId, isAttaching, isRunning, isStepDebugging, breakPoints, dispatch, editorRef }: ToolbarProps) {
+function Toolbar({ editorContent, editorMode, stepLine, attachedUrl, attachedTabId, isAttaching, isRunning, isStepDebugging, breakPoints, dispatch, editorRef, onModeSwitch }: ToolbarProps) {
+    const isPopup = useMemo(() => new URLSearchParams(window.location.search).has('tabId'), []);
     const fileInputRef = useRef<HTMLInputElement>(null);
     const cancelRunRef = useRef(false);
     const [isRecording, setIsRecording] = useState(false);
@@ -459,6 +461,9 @@ function Toolbar({ editorContent, editorMode, stepLine, attachedUrl, attachedTab
                 <button id="save-btn" title="Save as .pw file" disabled={!editorContent.trim()} onClick={handleSave}><SaveIcon /></button>
                 <button onClick={() => setIsDarkMode(prev => !prev)} title={isDarkMode ? 'Switch to light mode' : 'Switch to dark mode'}>
                     {isDarkMode ? <SunIcon /> : <MoonIcon />}
+                </button>
+                <button onClick={onModeSwitch} disabled={isRunning || isRecording || isVideoRecording} title={isPopup ? 'Dock to side panel' : 'Open as popup'}>
+                    {isPopup ? <DockIcon /> : <PopOutIcon />}
                 </button>
             </div>
             <div id="toolbar-right" className="flex items-center gap-2">

--- a/packages/extension/src/panel/reducer.ts
+++ b/packages/extension/src/panel/reducer.ts
@@ -43,6 +43,7 @@ export type Action =
    | { type: 'SET_BREAKPOINTS', breakPoints: Set<number>}
    | { type: 'SET_SCOPE_DATA', scopes: ScopeInfo[]}
    | { type: 'SET_BOTTOM_TAB', tab: 'console' | 'variables'}
+   | { type: 'RESTORE_HANDOFF', state: Partial<PanelState> }
 
 export const initialState : PanelState = {
     outputLines: [],
@@ -140,6 +141,8 @@ export function panelReducer(state: PanelState, action: Action): PanelState {
             return { ...state, bottomTab: action.tab }
         case 'SET_SCOPE_DATA':
             return { ...state, scopeData: action.scopes, bottomTab: action.scopes.length > 0 ? 'variables' : state.bottomTab }
+        case 'RESTORE_HANDOFF':
+            return { ...state, ...action.state }
         default:
             return state
     }


### PR DESCRIPTION
## Summary
- Pop-out button in side panel toolbar → opens popup with full state
- Dock button in popup toolbar → opens side panel with full state
- State transferred via service worker in-memory (no storage, no serialization issues)
- Button disabled during running/recording/video

## What transfers
- Editor content, mode, cursor position, pane height
- Console output (getProperties stripped — non-serializable)
- Breakpoints, pass/fail results, line results
- Command history
- Attached tab (re-attaches automatically)

## What resets
- Recording/picker state (tied to content scripts)
- Step debugging (CDP handles are stale)

## Files changed
- `background.ts` — handoff-save/load/to-popup message handlers + in-memory state
- `reducer.ts` — RESTORE_HANDOFF action
- `App.tsx` — handleModeSwitch + handoff restore on init
- `Toolbar.tsx` — toggle button with PopOut/Dock icons
- `Icons.tsx` — PopOutIcon, DockIcon

## Test plan
- [x] Side panel → pop out → popup has same editor + console + cursor
- [x] Popup → dock → side panel has same state
- [x] Round trip works multiple times
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)