### PR TITLE
fix: recorder --frame uses CSS id matching pickLocator (#800, #802)

### DIFF
--- a/packages/extension/e2e/recording/recording.spec.ts
+++ b/packages/extension/e2e/recording/recording.spec.ts
@@ -118,7 +118,7 @@ test.describe('Recording flow', () => {
       expect(editorText).not.toContain('css');
     });
 
-    test('clicking inside a <frame> uses frame tag, not iframe (#769)', async ({ sidePanel, testPage }) => {
+    test('clicking inside a <frame> records --frame with CSS selector (#769)', async ({ sidePanel, testPage }) => {
       const ctx = testPage.context();
       // Serve frameset pages via route so they're same-origin (file:// treats frames as cross-origin)
       await ctx.route('https://test.local/frameset.html', route => route.fulfill({
@@ -141,7 +141,34 @@ test.describe('Recording flow', () => {
 
       await sidePanel.waitForEditorText('click button "Arbeitskorb"');
       const editorText = await sidePanel.getEditorText();
-      expect(editorText).toContain('--frame "main"');
+      // No id → falls back to name attribute CSS selector
+      expect(editorText).toContain('--frame "frame[name="main"]"');
+    });
+
+    test('clicking inside an <iframe> with id records --frame with CSS id (#800)', async ({ sidePanel, testPage }) => {
+      const ctx = testPage.context();
+      await ctx.route('https://test.local/iframe-page.html', route => route.fulfill({
+        contentType: 'text/html',
+        body: '<html><body><iframe id="oevd-iframe" name="oevd-iframe" src="https://test.local/iframe-content.html"></iframe></body></html>',
+      }));
+      await ctx.route('https://test.local/iframe-content.html', route => route.fulfill({
+        contentType: 'text/html',
+        body: '<button>Submit</button>',
+      }));
+
+      await testPage.goto('https://test.local/iframe-page.html');
+      await testPage.bringToFront();
+      await sidePanel.attachToActiveTab();
+
+      await sidePanel.startRecording();
+
+      await testPage.bringToFront();
+      await testPage.frameLocator('#oevd-iframe').getByRole('button', { name: 'Submit' }).click();
+
+      await sidePanel.waitForEditorText('click button "Submit"');
+      const editorText = await sidePanel.getEditorText();
+      // CSS id matches pickLocator format
+      expect(editorText).toContain('--frame "#oevd-iframe"');
     });
 
     test('stop recording resets button state', async ({ sidePanel }) => {

--- a/packages/extension/src/content/recorder.ts
+++ b/packages/extension/src/content/recorder.ts
@@ -27,53 +27,48 @@ export const SPECIAL_KEYS = new Set([
  * due to security restrictions — we fall back to using the frame's src URL.
  */
 /**
- * Compute selectors for a single frame element.
- * pw: plain name/id for --frame (resolved by page.frame())
- * css: CSS selector for JS .locator().contentFrame()
+ * Compute CSS selector for a frame element.
+ * Uses the same selector for both --frame flag (PW) and .locator().contentFrame() (JS),
+ * matching pickLocator's output format for consistency.
+ * Priority: CSS id > name attribute > src attribute > nth-of-type fallback.
  */
-function selectorsForFrame(frame: Element): { pw: string; css: string } {
+function selectorForFrame(frame: Element): string {
+    if (frame.id) return `#${CSS.escape(frame.id)}`;
     const tag = frame.tagName.toLowerCase(); // 'frame' or 'iframe'
     const name = frame.getAttribute('name');
-    if (name) return { pw: name, css: `${tag}[name="${name}"]` };
-    if (frame.id) return { pw: frame.id, css: `#${CSS.escape(frame.id)}` };
+    if (name) return `${tag}[name="${name}"]`;
     const src = frame.getAttribute('src');
-    if (src) { const sel = `${tag}[src="${src}"]`; return { pw: sel, css: sel }; }
+    if (src) return `${tag}[src="${src}"]`;
     const parent = frame.parentElement;
     if (parent) {
         const siblings = Array.from(parent.querySelectorAll(`:scope > ${tag}`));
         const idx = siblings.indexOf(frame);
-        const sel = siblings.length === 1 ? tag : `${tag}:nth-of-type(${idx + 1})`;
-        return { pw: sel, css: sel };
+        return siblings.length === 1 ? tag : `${tag}:nth-of-type(${idx + 1})`;
     }
-    return { pw: tag, css: tag };
+    return tag;
 }
 
 /**
  * Detect the full frame chain from this window up to the top frame.
- * Returns arrays of selectors, one per ancestor frame, outermost first.
- * Returns empty arrays if we're in the top frame.
+ * Returns array of CSS selectors, one per ancestor frame, outermost first.
+ * Returns empty array if we're in the top frame.
  */
-function detectFrameChain(): { pw: string[]; css: string[] } {
-    if (window === window.top) return { pw: [], css: [] };
+function detectFrameChain(): string[] {
+    if (window === window.top) return [];
 
-    const pwChain: string[] = [];
-    const cssChain: string[] = [];
+    const chain: string[] = [];
     let win: Window = window;
     while (win !== win.top) {
         try {
             const frame = win.frameElement;
             if (frame) {
-                const sels = selectorsForFrame(frame);
-                pwChain.push(sels.pw);
-                cssChain.push(sels.css);
+                chain.push(selectorForFrame(frame));
             } else {
                 // Cross-origin: frameElement is null, use src fallback
                 try {
                     const src = win.location.href;
-                    const sel = (src && src !== 'about:blank') ? `iframe[src="${src}"]` : 'iframe';
-                    pwChain.push(sel);
-                    cssChain.push(sel);
-                } catch { pwChain.push('iframe'); cssChain.push('iframe'); }
+                    chain.push((src && src !== 'about:blank') ? `iframe[src="${src}"]` : 'iframe');
+                } catch { chain.push('iframe'); }
                 break; // Can't walk further up from cross-origin
             }
         } catch {
@@ -81,24 +76,20 @@ function detectFrameChain(): { pw: string[]; css: string[] } {
         }
         win = win.parent;
     }
-    return { pw: pwChain.reverse(), css: cssChain.reverse() };
+    return chain.reverse();
 }
 
 /** Cached frame chain — computed once on init */
-let framePath: { pw: string[]; css: string[] } = { pw: [], css: [] };
+let framePath: string[] = [];
 
 /**
  * Wrap recorded commands with frame context if we're inside an iframe.
  * Prepends --frame flag(s) to PW and .contentFrame() chain to JS.
  */
 function wrapWithFrameContext(cmds: { pw: string; js: string }): { pw: string; js: string } {
-    if (framePath.pw.length === 0) return cmds;
-    // Single frame: use plain name for PW (page.frame() resolves it)
-    // Nested frames: use CSS selectors for PW (locator().contentFrame() at each level)
-    const frameArg = framePath.pw.length === 1
-        ? framePath.pw[0]
-        : framePath.css.join(' ');
-    const jsChain = framePath.css.map(sel => `.locator(${JSON.stringify(sel)}).contentFrame()`).join('');
+    if (framePath.length === 0) return cmds;
+    const frameArg = framePath.join(' ');
+    const jsChain = framePath.map(sel => `.locator(${JSON.stringify(sel)}).contentFrame()`).join('');
     return {
         pw: `${cmds.pw} --frame "${frameArg}"`,
         js: `await page${jsChain}.${cmds.js.replace(/^await page\./, '')}`,


### PR DESCRIPTION
## Summary
- Recorder's `--frame` value now uses CSS id (`#oevd-iframe`) instead of plain name (`oevd-iframe`), matching pickLocator's output format
- Simplified `selectorsForFrame()` → `selectorForFrame()` — returns a single CSS selector for both PW `--frame` flag and JS `.locator().contentFrame()` chain
- Priority: CSS id > name attribute > src > nth-of-type fallback
- Added E2E test for `<iframe>` with id verifying `--frame "#oevd-iframe"` format

## Context
The original #800/#802 fix incidentally changed the recorder from CSS id to plain name for `--frame`. This caused recorder and pickLocator to produce different frame selectors for the same iframe. Both worked at playback (parser tries `page.frame()` then falls back to `page.locator().contentFrame()`), but the inconsistency was unnecessary.

## Test plan
- [x] Existing `<frame name="main">` E2E test updated — expects `--frame "frame[name="main"]"`
- [x] New `<iframe id="oevd-iframe">` E2E test — verifies `--frame "#oevd-iframe"`
- [x] All 14 recording E2E tests pass
- [x] All 51 pick-info unit tests pass
- [ ] Manual: verify on https://www.provinzial.de/west/versicherung/kfz-versicherung/rollerund-mopedversicherung/rollerundmoped-abschluss.html — recorder and pickLocator produce same `--frame` value

🤖 Generated with [Claude Code](https://claude.com/claude-code)