### PR TITLE
fix: enable @typescript-eslint/no-explicit-any as error in extension

### DIFF
--- a/packages/extension/e2e/bridge/bridge.spec.ts
+++ b/packages/extension/e2e/bridge/bridge.spec.ts
@@ -209,7 +209,7 @@ test.describe("Bridge command tests", () => {
 
     test('tab-list returns valid JSON array with tab details', async ({ bridge }) => {
       const r = await bridge.run('tab-list');
-      const tabs = expectJSON(r) as any[];
+      const tabs = expectJSON(r) as Record<string, unknown>[];
       expect(Array.isArray(tabs)).toBe(true);
       expect(tabs.length).toBeGreaterThan(0);
       expect(tabs[0]).toHaveProperty('index');
@@ -219,19 +219,19 @@ test.describe("Bridge command tests", () => {
 
     test('tab-new opens a new tab and tab-close closes it', async ({ bridge, testUrl }) => {
       const r1 = await bridge.run('tab-list');
-      const before = (expectJSON(r1) as any[]).length;
+      const before = (expectJSON(r1) as unknown[]).length;
 
       const r = await bridge.run(`tab-new ${testUrl}?tab=new`);
       expectOk(r);
       const r2 = await bridge.run('tab-list');
-      const after = (expectJSON(r2) as any[]).length;
+      const after = (expectJSON(r2) as unknown[]).length;
       expect(after).toBe(before + 1);
 
       // Clean up: close the tab we just opened
       const r3 = await bridge.run(`tab-close ${after - 1}`);
       expectOk(r3);
       const r4 = await bridge.run('tab-list');
-      const final = (expectJSON(r4) as any[]).length;
+      const final = (expectJSON(r4) as unknown[]).length;
       expect(final).toBeLessThan(after);
     });
 

--- a/packages/extension/e2e/bridge/fixtures.ts
+++ b/packages/extension/e2e/bridge/fixtures.ts
@@ -45,7 +45,7 @@ export const test = base.extend<
       res.end(html);
     });
     await new Promise<void>(resolve => httpServer.listen(0, resolve));
-    const httpPort = (httpServer.address() as any).port;
+    const httpPort = (httpServer.address() as { port: number }).port;
     const testUrl = `http://localhost:${httpPort}`;
 
     // 2. Start BridgeServer BEFORE the browser so the offscreen doc connects on init
@@ -100,7 +100,8 @@ export const test = base.extend<
     ]);
     if (!closed) {
       // Force-kill: terminate lingering connections so the port is freed
-      (bridge as any).wss?.clients?.forEach((ws: any) => ws.terminate());
+      const wss = (bridge as unknown as { wss?: { clients?: Set<{ terminate: () => void }> } }).wss;
+      wss?.clients?.forEach(ws => ws.terminate());
       await bridge.close().catch(() => {});
     }
     httpServer.close();

--- a/packages/extension/e2e/page-scripts/page-scripts.spec.ts
+++ b/packages/extension/e2e/page-scripts/page-scripts.spec.ts
@@ -175,11 +175,11 @@ test.describe('actionByText', () => {
     test('clicks a button by text', async ({ page }) => {
         await page.evaluate(() => {
             document.querySelector('button')!.addEventListener('click', () => {
-                (window as any).__clicked = true;
+                (window as unknown as Record<string, unknown>).__clicked = true;
             });
         });
         await actionByText(page, 'Submit', 'click', undefined);
-        const clicked = await page.evaluate(() => (window as any).__clicked);
+        const clicked = await page.evaluate(() => (window as unknown as Record<string, unknown>).__clicked);
         expect(clicked).toBe(true);
     });
 });

--- a/packages/extension/e2e/panel/panel.spec.ts
+++ b/packages/extension/e2e/panel/panel.spec.ts
@@ -15,21 +15,23 @@ test.describe("Panel page test", () => {
     // Intercept onMessage.addListener before React mounts so recording tests
     // can dispatch recorded-action messages to the Toolbar listener
     await panelPage.addInitScript(() => {
-      const listeners: any[] = [];
+      type Listener = (msg: unknown, sender: unknown, sendResponse: () => void) => void;
+      const listeners: Listener[] = [];
       const origAdd = chrome.runtime.onMessage.addListener.bind(chrome.runtime.onMessage);
       const origRemove = chrome.runtime.onMessage.removeListener.bind(chrome.runtime.onMessage);
-      chrome.runtime.onMessage.addListener = ((fn: any) => { listeners.push(fn); return origAdd(fn); }) as any;
-      chrome.runtime.onMessage.removeListener = ((fn: any) => {
+      chrome.runtime.onMessage.addListener = ((fn: Listener) => { listeners.push(fn); return origAdd(fn); }) as typeof chrome.runtime.onMessage.addListener;
+      chrome.runtime.onMessage.removeListener = ((fn: Listener) => {
         const i = listeners.indexOf(fn); if (i >= 0) listeners.splice(i, 1); return origRemove(fn);
-      }) as any;
-      (window as any).__fireRecorderMsg = (msg: any) => { for (const fn of listeners) fn(msg, {}, () => {}); };
+      }) as typeof chrome.runtime.onMessage.removeListener;
+      (window as unknown as Record<string, unknown>).__fireRecorderMsg = (msg: unknown) => { for (const fn of listeners) fn(msg, {}, () => {}); };
     });
     await sidePanel.goto(extensionId);
 
     // Stub health + attach — App.tsx sends these on mount
     await panelPage.evaluate(() => {
-      const orig = (chrome.runtime.sendMessage as any).bind(chrome.runtime);
-      (chrome.runtime as any).sendMessage = async (msg: any) => {
+      const cr = chrome.runtime as unknown as Record<string, unknown>;
+      const orig = (cr.sendMessage as (...a: unknown[]) => unknown).bind(chrome.runtime);
+      cr.sendMessage = async (msg: Record<string, unknown>) => {
         if (msg.type === 'health') return { ok: true };
         if (msg.type === 'attach') return { ok: true, url: 'https://example.com' };
         return orig(msg);
@@ -167,8 +169,9 @@ test.describe("Panel page test", () => {
 
   test('record button shows error when record-start fails', async ({ sidePanel }) => {
     await sidePanel.raw.evaluate(() => {
-      const origSend = (chrome.runtime.sendMessage as any).bind(chrome.runtime);
-      (chrome.runtime as any).sendMessage = async (msg: any) => {
+      const cr = chrome.runtime as unknown as Record<string, unknown>;
+      const origSend = (cr.sendMessage as (...a: unknown[]) => unknown).bind(chrome.runtime);
+      cr.sendMessage = async (msg: Record<string, unknown>) => {
         if (msg.type === 'record-start') return { ok: false, error: 'Cannot access chrome:// URLs' };
         return origSend(msg);
       };

--- a/packages/extension/e2e/shared/SidePanelPage.ts
+++ b/packages/extension/e2e/shared/SidePanelPage.ts
@@ -94,7 +94,7 @@ export class SidePanelPage {
     await this.page.goto(`chrome-extension://${extensionId}/panel/panel.html`);
     // Clear session state after load so restored content doesn't leak between tests.
     // The panel may have already restored — clearEditor below resets it.
-    await this.page.evaluate(() => (globalThis as any).chrome?.storage?.session?.remove('panelSessionState'));
+    await this.page.evaluate(() => (globalThis as unknown as Record<string, { storage?: { session?: { remove: (key: string) => void } } }>).chrome?.storage?.session?.remove('panelSessionState'));
   }
 
   /** Select all editor content and delete it. */
@@ -118,12 +118,15 @@ export class SidePanelPage {
   /** Stub record-start, record-stop, health, and attach messages. */
   async mockRecordingApis() {
     await this.page.evaluate(() => {
-      const orig = (chrome.runtime.sendMessage as any).bind(chrome.runtime);
-      (chrome.runtime as any).sendMessage = async (msg: any) => {
-        if (msg.type === 'health') return { ok: true };
-        if (msg.type === 'attach') return { ok: true, url: 'https://example.com' };
-        if (msg.type === 'record-start') return { ok: true, url: 'https://example.com' };
-        if (msg.type === 'record-stop') return { ok: true };
+      const chromeObj = chrome as unknown as { runtime: Record<string, unknown> };
+      const cr = chromeObj.runtime;
+      const orig = (cr.sendMessage as (...args: unknown[]) => unknown).bind(chromeObj.runtime);
+      cr.sendMessage = async (msg: unknown) => {
+        const m = msg as { type: string };
+        if (m.type === 'health') return { ok: true };
+        if (m.type === 'attach') return { ok: true, url: 'https://example.com' };
+        if (m.type === 'record-start') return { ok: true, url: 'https://example.com' };
+        if (m.type === 'record-stop') return { ok: true };
         return orig(msg);
       };
     });
@@ -132,7 +135,7 @@ export class SidePanelPage {
   /** Fire a recorded-action message to the Toolbar's onMessage listener. */
   async fireRecordedAction(action: { pw: string; js: string }) {
     await this.page.evaluate(
-      (a) => (window as any).__fireRecorderMsg({ type: 'recorded-action', action: a }),
+      (a) => (window as unknown as Record<string, (msg: unknown) => void>).__fireRecorderMsg({ type: 'recorded-action', action: a }),
       action,
     );
   }

--- a/packages/extension/eslint.config.js
+++ b/packages/extension/eslint.config.js
@@ -10,9 +10,15 @@ export default tseslint.config(
   {
     files: ["src/**/*.ts", "test/**/*.ts", "e2e/**/*.ts"],
     rules: {
-      "@typescript-eslint/no-explicit-any": "off",
+      "@typescript-eslint/no-explicit-any": "error",
       "@typescript-eslint/no-unused-vars": ["error", { argsIgnorePattern: "^_", caughtErrorsIgnorePattern: "^_" }],
       "no-empty-pattern": "off",
+    },
+  },
+  {
+    files: ["types.d.ts"],
+    rules: {
+      "no-var": "off",
     },
   },
   {

--- a/packages/extension/src/background.ts
+++ b/packages/extension/src/background.ts
@@ -46,11 +46,12 @@ function dedentSnapshot(snapshot: string) {
   return lines.map(line => line.substring(prefix)).join('\n');
 }
 
-function makeAriaSnapshotMatcher(locator: any, isNot: boolean) {
+function makeAriaSnapshotMatcher(locator: unknown, isNot: boolean) {
+  const loc = locator as { _expect: (type: string, opts: { expectedValue: string; isNot: boolean; timeout: number }) => Promise<{ matches: boolean; received?: { raw?: string } }> };
   return async (expected: string, options?: { timeout?: number }) => {
     const timeout = options?.timeout ?? 5000;
     const normalized = dedentSnapshot(expected);
-    const { matches: pass, received } = await locator._expect(
+    const { matches: pass, received } = await loc._expect(
       'to.match.aria',
       { expectedValue: normalized, isNot, timeout },
     );
@@ -67,7 +68,7 @@ function makeAriaSnapshotMatcher(locator: any, isNot: boolean) {
   };
 }
 
-function wrapExpectResult(e: any, locator: any, isNot = false) {
+function wrapExpectResult(e: object, locator: unknown, isNot = false) {
   return new Proxy(e, {
     get(obj, prop) {
       if (prop === 'toMatchAriaSnapshot')
@@ -81,7 +82,7 @@ function wrapExpectResult(e: any, locator: any, isNot = false) {
 
 const _origExpect = expect;
 const patchedExpect: typeof expect = Object.assign(
-  (target: any) => wrapExpectResult(_origExpect(target), target),
+  (target: unknown) => wrapExpectResult(_origExpect(target) as object, target),
   _origExpect,
 );
 
@@ -172,7 +173,7 @@ function resetCrxState() {
 async function ensureCrxApp(): Promise<CrxApplication> {
   if (crxApp) return crxApp;
   crxApp = await crx.start();
-  (crxApp as any).on('close', () => resetCrxState());
+  (crxApp as unknown as { on: (event: string, cb: () => void) => void }).on('close', () => resetCrxState());
   return crxApp;
 }
 
@@ -236,20 +237,20 @@ async function attachToTab(tabId: number): Promise<{ ok: boolean; url?: string; 
     Object.assign(globalThis, { page: currentPage, context: app.context(), crxApp: app, activeTabId, expect: patchedExpect });
 
     // Set up event listeners on globalThis so page-scripts can read them
-    (globalThis as any).__consoleMessages = [];
-    (globalThis as any).__networkRequests = [];
-    (globalThis as any).__activeRoutes = [];
-    currentPage.on('console', (msg: any) => {
-      (globalThis as any).__consoleMessages.push('[' + msg.type() + '] ' + msg.text());
+    globalThis.__consoleMessages = [];
+    globalThis.__networkRequests = [];
+    globalThis.__activeRoutes = [];
+    currentPage.on('console', (msg) => {
+      globalThis.__consoleMessages.push('[' + msg.type() + '] ' + msg.text());
     });
-    currentPage.on('response', (resp: any) => {
+    currentPage.on('response', (resp) => {
       const url = resp.url();
       if (url.startsWith('chrome-extension://')) return;
       const req = resp.request();
-      (globalThis as any).__networkRequests.push({ status: resp.status(), method: req.method(), url, type: req.resourceType() });
+      globalThis.__networkRequests.push({ status: resp.status(), method: req.method(), url, type: req.resourceType() });
     });
-    currentPage.on('dialog', async (dialog: any) => {
-      const mode = (globalThis as any).__dialogMode;
+    currentPage.on('dialog', async (dialog) => {
+      const mode = globalThis.__dialogMode;
       if (mode === 'accept') await dialog.accept();
       else if (mode === 'dismiss') await dialog.dismiss();
     });
@@ -357,7 +358,7 @@ let lastTraceData: Uint8Array | null = null;
 
 // ─── Pick Element ────────────────────────────────────────────────────────────
 
-async function pickElement(): Promise<{ ok: boolean; info?: any; error?: string }> {
+async function pickElement(): Promise<{ ok: boolean; info?: Record<string, unknown>; error?: string }> {
   if (!currentPage) {
     const tabId = await getActiveTabId();
     if (tabId) await attachToTab(tabId);
@@ -440,9 +441,10 @@ async function pickElement(): Promise<{ ok: boolean; info?: any; error?: string 
         ...(elementInfo || {}),
       },
     };
-  } catch (e: any) {
-    if (e?.message?.includes('cancelled')) return { ok: false, error: 'cancelled' };
-    return { ok: false, error: e?.message ?? String(e) };
+  } catch (e: unknown) {
+    const msg = e instanceof Error ? e.message : String(e);
+    if (msg.includes('cancelled')) return { ok: false, error: 'cancelled' };
+    return { ok: false, error: msg };
   }
 }
 
@@ -458,27 +460,31 @@ async function cancelPick(): Promise<{ ok: boolean }> {
 import { cdpEval, cdpCallFunctionOn } from './lib/sw-debugger-core';
 
 /** Format a CDP ObjectPreview into a readable string (similar to Node.js REPL output). */
-function formatCdpPreview(preview: any, depth = 0): string {
+interface CdpPreviewProp { name: string; type: string; value?: string; subtype?: string; valuePreview?: CdpPreviewObj }
+interface CdpPreviewEntry { key?: { description?: string; value?: string; type?: string }; value: { description?: string; value?: string; type?: string } }
+interface CdpPreviewObj { description?: string; subtype?: string; overflow?: boolean; properties?: CdpPreviewProp[]; entries?: CdpPreviewEntry[] }
+
+function formatCdpPreview(preview: CdpPreviewObj, depth = 0): string {
   if (!preview || !preview.properties) return preview?.description ?? '';
   const isArray = preview.subtype === 'array';
-  const props: any[] = preview.properties;
+  const props = preview.properties;
 
   // Promise: show "Promise" for pending, "Promise {<fulfilled>: value}" for resolved
   if (preview.description === 'Promise') {
-    const stateP = props.find((p: any) => p.name === '[[PromiseState]]');
+    const stateP = props.find(p => p.name === '[[PromiseState]]');
     const state = stateP?.value ?? 'pending';
     if (state === 'pending') return 'Promise';
-    const resultP = props.find((p: any) => p.name === '[[PromiseResult]]');
+    const resultP = props.find(p => p.name === '[[PromiseResult]]');
     const val = resultP?.type === 'string' ? `'${resultP.value}'`
       : resultP?.value !== undefined ? resultP.value : resultP?.type ?? '';
     return val ? `Promise {<${state}>: ${val}}` : `Promise {<${state}>}`;
   }
 
   // Map/Set: use entries field (key=>value for Map, value for Set)
-  const cdpEntries: any[] = preview.entries;
+  const cdpEntries = preview.entries;
   if (cdpEntries && cdpEntries.length > 0) {
     const isMap = preview.subtype === 'map';
-    const items = cdpEntries.map((e: any) => {
+    const items = cdpEntries.map(e => {
       const val = e.value?.description ?? e.value?.value ?? e.value?.type ?? '';
       if (isMap) {
         const key = e.key?.description ?? e.key?.value ?? e.key?.type ?? '';
@@ -495,7 +501,7 @@ function formatCdpPreview(preview: any, depth = 0): string {
     return preview.description ?? '';
   }
 
-  const entries = props.map((p: any) => {
+  const entries = props.map(p => {
     let val: string;
     if (p.type === 'string') val = `'${p.value}'`;
     else if (p.valuePreview && depth < 2) val = formatCdpPreview(p.valuePreview, depth + 1);
@@ -513,7 +519,7 @@ function formatCdpPreview(preview: any, depth = 0): string {
 
 async function executeBridgeExpr(jsExpr: string): Promise<{ text: string; isError: boolean; image?: string }> {
   try {
-    const r = await cdpEval(jsExpr, 'bridge');
+    const r = await cdpEval(jsExpr, 'bridge') as { type?: string; value?: unknown; description?: string; objectId?: string; preview?: CdpPreviewObj } | undefined;
     if (!r || r.type === 'undefined') return formatBridgeResult(undefined);
     if (r.type === 'string' || r.type === 'number' || r.type === 'boolean') return formatBridgeResult(r.value);
 
@@ -523,7 +529,7 @@ async function executeBridgeExpr(jsExpr: string): Promise<{ text: string; isErro
       const fn = isMap
         ? 'function(){return [...this].map(([k,v])=>JSON.stringify(k)+" => "+JSON.stringify(v)).join(", ")}'
         : 'function(){return [...this].map(v=>JSON.stringify(v)).join(", ")}';
-      const res = await cdpCallFunctionOn(r.objectId, fn);
+      const res = await cdpCallFunctionOn(r.objectId, fn) as { result?: { value?: string } } | undefined;
       const inner = res?.result?.value ?? null;
       if (inner !== null) return formatBridgeResult(`${r.description} {${inner}}`);
     }
@@ -531,7 +537,7 @@ async function executeBridgeExpr(jsExpr: string): Promise<{ text: string; isErro
     // Playwright Response: extract status + url via method calls
     if (r.objectId && /^Response\d*$/.test(r.description ?? '')) {
       const res = await cdpCallFunctionOn(r.objectId,
-        'function(){try{return this.status()+" "+this.url()}catch{return null}}');
+        'function(){try{return this.status()+" "+this.url()}catch{return null}}') as { result?: { value?: string } } | undefined;
       const summary = res?.result?.value;
       if (summary) return formatBridgeResult(`Response: ${summary}`);
     }
@@ -539,7 +545,7 @@ async function executeBridgeExpr(jsExpr: string): Promise<{ text: string; isErro
     // Plain objects/arrays: use JSON.stringify for full nested representation
     if (r.objectId && (r.description === 'Object' || /^Array\(\d+\)$/.test(r.description ?? ''))) {
       const res = await cdpCallFunctionOn(r.objectId,
-        'function(){try{return JSON.stringify(this)}catch{return null}}');
+        'function(){try{return JSON.stringify(this)}catch{return null}}') as { result?: { value?: string } } | undefined;
       const json = res?.result?.value ?? null;
       if (json) return formatBridgeResult(json);
     }
@@ -547,8 +553,8 @@ async function executeBridgeExpr(jsExpr: string): Promise<{ text: string; isErro
     // Other objects (Date, RegExp, Promise, etc.): use description directly
     if (r.preview) return formatBridgeResult(formatCdpPreview(r.preview));
     return formatBridgeResult(r.description ?? 'Done');
-  } catch (e: any) {
-    return { text: e?.message ?? String(e), isError: true };
+  } catch (e: unknown) {
+    return { text: e instanceof Error ? e.message : String(e), isError: true };
   }
 }
 
@@ -676,8 +682,8 @@ async function handleBridgeCommand(msg: {
       const app = await ensureCrxApp();
       await app.context().tracing.start({ screenshots: true, snapshots: true });
       return { text: 'Tracing started', isError: false };
-    } catch (e: any) {
-      return { text: e?.message ?? String(e), isError: true };
+    } catch (e: unknown) {
+      return { text: e instanceof Error ? e.message : String(e), isError: true };
     }
   }
   if (cmd === 'tracing-stop') {
@@ -687,7 +693,7 @@ async function handleBridgeCommand(msg: {
       await app.context().tracing.stop({ path: tracePath });
       // Read trace from memfs and download via chrome.downloads
       const data = crx.fs.readFileSync(tracePath);
-      const bytes = data instanceof Uint8Array ? data : new Uint8Array(data as any);
+      const bytes = data instanceof Uint8Array ? data : new Uint8Array(data as unknown as ArrayBufferLike);
       // Keep a copy for "View Trace" in browser
       lastTraceData = bytes;
       let binary = '';
@@ -702,8 +708,8 @@ async function handleBridgeCommand(msg: {
       const size = bytes.length;
       const sizeStr = size < 1024 * 1024 ? `${(size / 1024).toFixed(0)} KB` : `${(size / (1024 * 1024)).toFixed(1)} MB`;
       return { text: `Trace saved to Downloads/${filename} (${sizeStr})`, isError: false };
-    } catch (e: any) {
-      return { text: e?.message ?? String(e), isError: true };
+    } catch (e: unknown) {
+      return { text: e instanceof Error ? e.message : String(e), isError: true };
     }
   }
 
@@ -742,7 +748,7 @@ async function handleBridgeCommand(msg: {
 }
 
 // Expose for serviceWorker.evaluate() and VS Code CDP injection
-(self as any).handleBridgeCommand = handleBridgeCommand;
+globalThis.handleBridgeCommand = handleBridgeCommand;
 
 // ─── Message Handler ─────────────────────────────────────────────────────────
 
@@ -750,7 +756,7 @@ async function handleBridgeCommand(msg: {
 let commandQueue: Promise<void> = Promise.resolve();
 
 // ── Handoff state for side panel ↔ popup transfer (#820) ──
-let handoffState: any = null;
+let handoffState: unknown = null;
 
 chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
   if (msg.type === 'bridge-command') {
@@ -799,7 +805,7 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
       const tracePath = `/tmp/trace-${Date.now()}.zip`;
       await app.context().tracing.stop({ path: tracePath });
       const data = crx.fs.readFileSync(tracePath);
-      const bytes = data instanceof Uint8Array ? data : new Uint8Array(data as any);
+      const bytes = data instanceof Uint8Array ? data : new Uint8Array(data as unknown as ArrayBufferLike);
       lastTraceData = bytes;
       let binary = '';
       for (let i = 0; i < bytes.length; i++) binary += String.fromCharCode(bytes[i]);
@@ -897,4 +903,4 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
 });
 
 // Expose stable globals for swDebugEval — functions that never change go here, not inside attachToTab
-(globalThis as any).attachToTab = attachToTab;
+globalThis.attachToTab = attachToTab;

--- a/packages/extension/src/content/recorder.ts
+++ b/packages/extension/src/content/recorder.ts
@@ -101,7 +101,7 @@ function wrapWithFrameContext(cmds: { pw: string; js: string }): { pw: string; j
  * has been invalidated (e.g. extension reloaded), clean up event listeners
  * instead of throwing an uncaught error (#823).
  */
-function safeSendMessage(msg: any) {
+function safeSendMessage(msg: { type: string; action?: { pw: string; js: string } }) {
     try {
         chrome.runtime.sendMessage(msg);
     } catch {
@@ -236,7 +236,7 @@ export function onFocusOutCapture(e: FocusEvent) {
 
 export function cleanup() {
     flushPendingFill();
-    (window as any).__pw_recorder_active = false;
+    window.__pw_recorder_active = false;
     document.removeEventListener('click', onClickCapture, true);
     document.removeEventListener('input', onInputCapture, true);
     document.removeEventListener('change', onChangeCapture, true);
@@ -245,7 +245,7 @@ export function cleanup() {
     chrome.runtime.onMessage.removeListener(onMessage);
 }
 
-function onMessage(msg: any) {
+function onMessage(msg: { type: string }) {
     if (msg.type === 'record-stop') cleanup();
 }
 
@@ -253,8 +253,8 @@ function onMessage(msg: any) {
 
 export function init() {
     // Guard against double-injection
-    if ((window as any).__pw_recorder_active) return;
-    (window as any).__pw_recorder_active = true;
+    if (window.__pw_recorder_active) return;
+    window.__pw_recorder_active = true;
 
     // Detect iframe context once on init
     framePath = detectFrameChain();

--- a/packages/extension/src/lib/sw-debugger-core.ts
+++ b/packages/extension/src/lib/sw-debugger-core.ts
@@ -6,6 +6,14 @@
  * Vite bundles a copy into each entry point.
  */
 
+export type CdpEvalResult = {
+    result?: unknown;
+    exceptionDetails?: {
+        exception?: { description?: string };
+        text?: string;
+    };
+};
+
 let swTargetId: string | null = null;
 
 if (typeof chrome !== 'undefined' && chrome.debugger) {
@@ -66,10 +74,10 @@ export function getTargetId() { return swTargetId; }
 
 // ─── Generic CDP Command ─────────────────────────────────────────────────────
 
-export async function cdpSendCommand(method: string, params: Record<string, unknown> = {}): Promise<any> {
+export async function cdpSendCommand(method: string, params: Record<string, unknown> = {}): Promise<unknown> {
     const targetId = await ensureAttached();
     return new Promise((resolve, reject) => {
-        chrome.debugger.sendCommand({ targetId }, method, params, (result: any) => {
+        chrome.debugger.sendCommand({ targetId }, method, params, (result: unknown) => {
             if (chrome.runtime.lastError) {
                 reject(new Error(chrome.runtime.lastError.message));
             } else {
@@ -86,20 +94,20 @@ export async function cdpSendCommand(method: string, params: Record<string, unkn
  * Wraps `{…}` in parens so V8 parses object literals correctly.
  * Returns the raw CDP result object (not exceptionDetails — those throw).
  */
-export async function cdpEval(expression: string, objectGroup = 'console'): Promise<any> {
+export async function cdpEval(expression: string, objectGroup = 'console'): Promise<unknown> {
     const expr = expression.trimStart().startsWith('{') ? `(${expression})` : expression;
     const targetId = await ensureAttached();
-    const result = await new Promise<any>((resolve, reject) => {
+    const result = await new Promise<CdpEvalResult | undefined>((resolve, reject) => {
         chrome.debugger.sendCommand(
             { targetId },
             'Runtime.evaluate',
             { expression: expr, awaitPromise: true, returnByValue: false, generatePreview: true, objectGroup, replMode: true },
-            (res: any) => {
+            (res: unknown) => {
                 if (chrome.runtime.lastError) {
                     swTargetId = null;
                     reject(new Error(chrome.runtime.lastError.message));
                 } else {
-                    resolve(res);
+                    resolve(res as CdpEvalResult | undefined);
                 }
             }
         );
@@ -118,7 +126,7 @@ export async function cdpCallFunctionOn(
     objectId: string,
     functionDeclaration: string,
     returnByValue = true,
-): Promise<any> {
+): Promise<unknown> {
     return cdpSendCommand('Runtime.callFunctionOn', {
         objectId, functionDeclaration, returnByValue,
     });
@@ -126,7 +134,7 @@ export async function cdpCallFunctionOn(
 
 // ─── Runtime.getProperties ───────────────────────────────────────────────────
 
-export async function cdpGetProperties(objectId: string): Promise<any> {
+export async function cdpGetProperties(objectId: string): Promise<unknown> {
     return cdpSendCommand('Runtime.getProperties', {
         objectId, ownProperties: true, generatePreview: true,
     });

--- a/packages/extension/src/offscreen/offscreen.ts
+++ b/packages/extension/src/offscreen/offscreen.ts
@@ -32,20 +32,12 @@ async function startVideoCapture(streamId: string) {
     }
     revokeLastBlob();
 
-    const media = await navigator.mediaDevices.getUserMedia({
-        audio: {
-            mandatory: {
-                chromeMediaSource: 'tab',
-                chromeMediaSourceId: streamId,
-            },
-        } as any,
-        video: {
-            mandatory: {
-                chromeMediaSource: 'tab',
-                chromeMediaSourceId: streamId,
-            },
-        } as any,
-    });
+    // Chrome extension tab capture uses non-standard `mandatory` constraint
+    const constraints = {
+        audio: { mandatory: { chromeMediaSource: 'tab', chromeMediaSourceId: streamId } },
+        video: { mandatory: { chromeMediaSource: 'tab', chromeMediaSourceId: streamId } },
+    } as unknown as MediaStreamConstraints;
+    const media = await navigator.mediaDevices.getUserMedia(constraints);
 
     // Continue playing captured audio to the user
     const output = new AudioContext();
@@ -137,7 +129,7 @@ function connect(port: number) {
             console.debug(`[pw-repl] bridge connected to port ${port}`);
             retryCount = 0;
             // Trigger auto-attach so the CLI knows which tab is connected
-            chrome.runtime.sendMessage({ type: 'bridge-attach' }).then((result: any) => {
+            chrome.runtime.sendMessage({ type: 'bridge-attach' }).then((result: { url?: string }) => {
                 if (ws?.readyState === WebSocket.OPEN && result?.url)
                     ws.send(JSON.stringify({ _event: true, type: 'tab-attached', url: result.url }));
             }).catch(() => {});
@@ -191,7 +183,7 @@ chrome.runtime.sendMessage({ type: 'get-bridge-port' }).then((port: number) => {
 
 // ─── Message routing from background SW ─────────────────────────────────────
 
-chrome.runtime.onMessage.addListener((msg: any, _sender: any, sendResponse: any) => {
+chrome.runtime.onMessage.addListener((msg: { type: string; port?: number; streamId?: string }, _sender, sendResponse) => {
     if (msg.type === 'bridge-port-changed') {
         lastPort = msg.port as number;
         if (reconnectTimer) clearTimeout(reconnectTimer);

--- a/packages/extension/src/panel/App.tsx
+++ b/packages/extension/src/panel/App.tsx
@@ -130,22 +130,21 @@ function App() {
     const isPopup = new URLSearchParams(window.location.search).has('tabId');
     if (isPopup) {
       // Open side panel directly from the popup (preserves user gesture).
-      // Chrome API types are incomplete for sidePanel/tabs in panel context.
-      /* eslint-disable @typescript-eslint/no-explicit-any */
+      // Chrome API types are incomplete for tabs/windows in panel context.
+      const chromeExt = chrome as unknown as { tabs: { get: (id: number) => Promise<{ windowId?: number }> }; windows: { getAll: (opts: { windowTypes: string[] }) => Promise<Array<{ id?: number; focused?: boolean }>> } };
       let windowId: number | undefined;
       if (state.attachedTabId) {
-        const tab = await (chrome as any).tabs.get(state.attachedTabId).catch(() => null);
+        const tab = await chromeExt.tabs.get(state.attachedTabId).catch(() => null);
         windowId = tab?.windowId;
       }
       if (!windowId) {
-        const windows = await (chrome as any).windows.getAll({ windowTypes: ['normal'] });
-        windowId = (windows.find((w: any) => w.focused) ?? windows[0])?.id;
+        const windows = await chromeExt.windows.getAll({ windowTypes: ['normal'] });
+        windowId = (windows.find(w => w.focused) ?? windows[0])?.id;
       }
       if (windowId) {
-        await (chrome as any).sidePanel.open({ windowId });
+        await chrome.sidePanel.open({ windowId });
         window.close();
       }
-      /* eslint-enable @typescript-eslint/no-explicit-any */
     } else {
       const res = await chrome.runtime.sendMessage({
         type: 'handoff-to-popup',

--- a/packages/extension/src/panel/components/Console/cdpToSerialized.ts
+++ b/packages/extension/src/panel/components/Console/cdpToSerialized.ts
@@ -120,7 +120,7 @@ export function fromCdpRemoteObject(obj: CdpRemoteObject): SerializedValue {
 
 /** Convert Runtime.getProperties response into SerializedValue props map. */
 export function fromCdpGetProperties(raw: unknown): Record<string, SerializedValue> {
-    const data = raw as any;
+    const data = raw as { result?: CdpPropertyDescriptor[]; internalProperties?: CdpPropertyDescriptor[] };
     const result = data?.result as CdpPropertyDescriptor[] | undefined;
     const props: Record<string, SerializedValue> = {};
     if (result) {

--- a/packages/extension/src/panel/components/Console/useConsole.ts
+++ b/packages/extension/src/panel/components/Console/useConsole.ts
@@ -128,8 +128,8 @@ export function useConsole(dispatch: React.Dispatch<Action>) {
             } else {
                 dispatch({ type: 'COMMAND_SUCCESS', line: { text: result.text ?? 'Done', type: 'success', time } });
             }
-        } catch (e: any) {
-            const raw = e?.message ?? String(e);
+        } catch (e: unknown) {
+            const raw = e instanceof Error ? e.message : String(e);
             const errorText = raw.split('\n    at ')[0].split('\nCall log:')[0].trim();
             dispatch({ type: 'COMMAND_ERROR', line: { text: errorText, type: 'error' } });
         }

--- a/packages/extension/src/panel/components/Toolbar.tsx
+++ b/packages/extension/src/panel/components/Toolbar.tsx
@@ -239,12 +239,11 @@ function Toolbar({ editorContent, editorMode, stepLine, attachedUrl, attachedTab
 
     useEffect(() => {
         if (!chrome.runtime?.onMessage) return;
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const listener = (msg: any) => {
-            if (msg.type === 'recorded-action') {
+        const listener = (msg: { type: string; action?: { pw: string; js: string } }) => {
+            if (msg.type === 'recorded-action' && msg.action) {
                 editorRef.current?.insertAtCursor(editorMode === 'pw' ? msg.action.pw : msg.action.js);
             }
-            if (msg.type === 'recorded-fill-update') {
+            if (msg.type === 'recorded-fill-update' && msg.action) {
                 editorRef.current?.replaceLastInsert(editorMode === 'pw' ? msg.action.pw : msg.action.js);
             }
         };

--- a/packages/extension/src/panel/lib/bridge.ts
+++ b/packages/extension/src/panel/lib/bridge.ts
@@ -45,7 +45,8 @@ export async function executeCommand(command: string): Promise<CommandResult> {
       try {
         const obj = JSON.parse(val);
         if (obj && typeof obj === 'object' && '__image' in obj) {
-          return { text: '', image: `data:${(obj as any).mimeType};base64,${(obj as any).__image}`, isError: false };
+          const img = obj as { mimeType: string; __image: string };
+          return { text: '', image: `data:${img.mimeType};base64,${img.__image}`, isError: false };
         }
       } catch { /* not JSON — treat as plain text */ }
       return { text: val, isError: false };
@@ -55,8 +56,8 @@ export async function executeCommand(command: string): Promise<CommandResult> {
       try {
         const s = await swCallFunctionOn(r.objectId,
           'function() { try { return JSON.stringify(this, null, 2); } catch(e) { return String(this); } }'
-        ) as any;
-        const val: string = s?.result?.value;
+        ) as { result?: { value?: string } };
+        const val = s?.result?.value;
         if (val) return { text: val, isError: false };
       } catch { /* fall through */ }
     }
@@ -74,8 +75,8 @@ export async function executeCommand(command: string): Promise<CommandResult> {
       try {
         const raw = await withTimeout(swDebugEval(expr)) as { result?: CdpResult };
         return formatResult(raw?.result);
-      } catch (e: any) {
-        return { text: e?.message ?? String(e), isError: true };
+      } catch (e: unknown) {
+        return { text: e instanceof Error ? e.message : String(e), isError: true };
       }
     }
 
@@ -87,8 +88,8 @@ export async function executeCommand(command: string): Promise<CommandResult> {
   try {
     const raw = await withTimeout(swDebugEval(parsed.jsExpr)) as { result?: CdpResult };
     return formatResult(raw?.result);
-  } catch (e: any) {
-    return { text: e?.message ?? String(e), isError: true };
+  } catch (e: unknown) {
+    return { text: e instanceof Error ? e.message : String(e), isError: true };
   }
 }
 
@@ -142,7 +143,8 @@ export async function executeCommandForConsole(command: string): Promise<Console
     try {
       const obj = JSON.parse(val);
       if (obj && typeof obj === 'object' && '__image' in obj) {
-        return { text: '', image: `data:${(obj as any).mimeType};base64,${(obj as any).__image}` };
+        const img = obj as { mimeType: string; __image: string };
+        return { text: '', image: `data:${img.mimeType};base64,${img.__image}` };
       }
     } catch { /* not JSON — treat as plain text */ }
     return { text: val };

--- a/packages/extension/src/panel/lib/codemirror-setup.ts
+++ b/packages/extension/src/panel/lib/codemirror-setup.ts
@@ -204,7 +204,7 @@ const resultGutter = gutter({
     class: 'cm-result-gutter',
     markers(view) {
         const results = view.state.field(lineResultsField);
-        const markers: any[] = [];
+        const markers: Range<GutterMarker>[] = [];
         for (let i = 0; i < results.length && i < view.state.doc.lines; i++) {
             if (results[i]) {
                 const line = view.state.doc.line(i + 1);
@@ -219,7 +219,7 @@ const breakpointGutter = gutter({
     class: 'cm-breakpoint-gutter',
     markers(view) {
         const bps = view.state.field(breakpointField);
-        const markers: any[] = [];
+        const markers: Range<GutterMarker>[] = [];
         for (const lineNum of bps) {
             if (lineNum < view.state.doc.lines) {
                 const line = view.state.doc.line(lineNum + 1);

--- a/packages/extension/src/panel/lib/commands.ts
+++ b/packages/extension/src/panel/lib/commands.ts
@@ -177,7 +177,7 @@ function ser(v: unknown): string {
 }
 
 /** Build a JS expression that calls a page-script function in the SW context (where `page` is global) */
-function call(fn: any, ...args: unknown[]): string {
+function call(fn: (...args: unknown[]) => unknown, ...args: unknown[]): string {
   return `await (${fn.toString()})(page, ${args.map(ser).join(', ')})`;
 }
 
@@ -186,7 +186,7 @@ function call(fn: any, ...args: unknown[]): string {
  * then calls fn with the scoped locator as `page`.
  * First tries role-based scoping, then falls back to DOM proximity via locator.evaluate().
  */
-function callScoped(fn: any, inText: string, _targetText: string, ...args: unknown[]): string {
+function callScoped(fn: (...args: unknown[]) => unknown, inText: string, _targetText: string, ...args: unknown[]): string {
   // Try exact match first, then fall back to substring (consistent with actionByText)
   const anchorCode = `(async () => { const __e = page.getByText(${ser(inText)}, { exact: true }); return (await __e.count()) > 0 ? __e : page.getByText(${ser(inText)}); })()`;
   const fallbackCheck = `(await ${anchorCode}).first().evaluate((el) => {
@@ -379,7 +379,7 @@ function resolveArgs(args: ParsedArgs): ParsedArgs | DirectExecution {
   }
 
   // ── Verify css subcommand (verify-visible css ".sel", verify-element css ".sel") ─
-  const CSS_VERIFY: Record<string, any> = {
+  const CSS_VERIFY: Record<string, (...args: unknown[]) => unknown> = {
     'verify-visible': verifyCssVisible,
     'verify-element': verifyCssElement,
     'verify-no-element': verifyCssNoElement,
@@ -397,7 +397,7 @@ function resolveArgs(args: ParsedArgs): ParsedArgs | DirectExecution {
   // ── Legacy verify-* commands ────────────────────────────────
   const TEXT_VERIFY_CMDS = new Set(['verify-text', 'verify-no-text', 'verify-title', 'verify-url']);
   const ELEMENT_VERIFY_CMDS = new Set(['verify-element', 'verify-no-element', 'verify-visible']);
-  const verifyFns: Record<string, any> = {
+  const verifyFns: Record<string, (...args: unknown[]) => unknown> = {
     'verify-text': verifyText,
     'verify-element': verifyElement,
     'verify-visible': verifyVisible,
@@ -579,7 +579,7 @@ function resolveArgs(args: ParsedArgs): ParsedArgs | DirectExecution {
   }
 
   // ── Text locators ───────────────────────────────────────────
-  const textFns: Record<string, any> = {
+  const textFns: Record<string, (...args: unknown[]) => unknown> = {
     click: actionByText, dblclick: actionByText, hover: actionByText,
     fill: fillByText, select: selectByText,
     check: checkByText, uncheck: uncheckByText,

--- a/packages/extension/src/panel/lib/pw-completion-source.ts
+++ b/packages/extension/src/panel/lib/pw-completion-source.ts
@@ -18,7 +18,7 @@ import type {
 //
 // Inserts "()" after method completions and places cursor between the parens.
 
-function applyMethod(view: any, completion: Completion, from: number, to: number) {
+function applyMethod(view: { dispatch: (spec: { changes: { from: number; to: number; insert: string }; selection: { anchor: number } }) => void }, completion: Completion, from: number, to: number) {
   const insert = completion.label + "()";
   view.dispatch({
     changes: { from, to, insert },
@@ -215,7 +215,7 @@ function toCompletions(interfaceName: InterfaceName): Completion[] {
     return completionCache.get(interfaceName)!;
   }
 
-  const raw: RawCompletion[] = (PW_COMPLETIONS as any)[interfaceName] ?? [];
+  const raw: RawCompletion[] = (PW_COMPLETIONS as Record<string, RawCompletion[]>)[interfaceName] ?? [];
 
   const completions: Completion[] = raw.map((item) => ({
     label: item.label,

--- a/packages/extension/src/panel/lib/run.ts
+++ b/packages/extension/src/panel/lib/run.ts
@@ -105,8 +105,8 @@ export async function runJsScript(code: string, dispatch: React.Dispatch<Action>
             const value = fromCdpRemoteObject(r);
             dispatch({ type: 'COMMAND_SUCCESS', line: { text: '', type: 'success', time, value, getProperties: swGetProperties } });
         }
-    } catch (e: any) {
-        const text = trimStack(e?.message ?? String(e));
+    } catch (e: unknown) {
+        const text = trimStack(e instanceof Error ? e.message : String(e));
         dispatch({ type: 'COMMAND_ERROR', line: { text, type: 'error' } });
     }
 }
@@ -174,8 +174,8 @@ export async function runJsScriptStep(code: string, dispatch: React.Dispatch<Act
                 dispatch({ type: 'COMMAND_SUCCESS', line: { text: '', type: 'success', value, getProperties: swGetProperties } });
             }
         }
-    } catch (e: any) {
-        dispatch({ type: 'COMMAND_ERROR', line: { text: trimStack(e?.message ?? String(e)), type: 'error' } });
+    } catch (e: unknown) {
+        dispatch({ type: 'COMMAND_ERROR', line: { text: trimStack(e instanceof Error ? e.message : String(e)), type: 'error' } });
     } finally {
         onDebugPaused(null);
         await swDebuggerDisable().catch(e => console.debug('[debug] disable:', e));
@@ -205,8 +205,8 @@ export async function runAndDispatch(command: string, dispatch: React.Dispatch<A
             const isError = !r?.ok;
             dispatch({ type: isError ? 'COMMAND_ERROR' : 'COMMAND_SUCCESS', line: { text, type: isError ? 'error' : 'success', time } });
             return { text, isError };
-        } catch (e: any) {
-            const text = e?.message ?? String(e);
+        } catch (e: unknown) {
+            const text = e instanceof Error ? e.message : String(e);
             dispatch({ type: 'COMMAND_ERROR', line: { text, type: 'error' } });
             return { text, isError: true };
         }
@@ -227,8 +227,8 @@ export async function runAndDispatch(command: string, dispatch: React.Dispatch<A
             else text = 'Done';
             dispatch({ type: 'COMMAND_SUCCESS', line: { text, type: 'success', time } });
             return { text, isError: false };
-        } catch (e: any) {
-            const text = trimStack(e?.message ?? String(e));
+        } catch (e: unknown) {
+            const text = trimStack(e instanceof Error ? e.message : String(e));
             dispatch({ type: 'COMMAND_SUCCESS', line: { text, type: 'error' } });
             return { text, isError: true };
         }

--- a/packages/extension/src/panel/lib/sw-debugger.ts
+++ b/packages/extension/src/panel/lib/sw-debugger.ts
@@ -4,6 +4,7 @@
 import { SerializedValue } from '@/components/Console/types';
 import { CdpRemoteObject, fromCdpRemoteObject, CdpPropertyDescriptor } from '@/components/Console/cdpToSerialized';
 import { cdpSendCommand, cdpGetProperties, cdpCallFunctionOn, cdpEval, getTargetId } from '../../lib/sw-debugger-core';
+import type { CdpEvalResult } from '../../lib/sw-debugger-core';
 export { swDebugTargets } from '../../lib/sw-debugger-core';
 
 export type ScopeInfo = {
@@ -27,7 +28,7 @@ export async function swDebugEval(expression: string): Promise<unknown> {
         const result = await cdpSendCommand('Debugger.evaluateOnCallFrame', {
             callFrameId: pausedCallFrameId,
             expression: expr, awaitPromise: true, returnByValue: false, generatePreview: true, objectGroup: 'console',
-        });
+        }) as CdpEvalResult | undefined;
         if (result?.exceptionDetails) {
             const msg = result.exceptionDetails.exception?.description
                 ?? result.exceptionDetails.text ?? 'Unknown error';
@@ -68,15 +69,15 @@ export async function swDebuggerDisable(): Promise<void> {
 }
 
 export async function swSetBreakpointByUrl(url: string, lineNumber: number): Promise<string> {
-    const result = await cdpSendCommand('Debugger.setBreakpointByUrl', { url, lineNumber });
+    const result = await cdpSendCommand('Debugger.setBreakpointByUrl', { url, lineNumber }) as { breakpointId?: string } | undefined;
     return result?.breakpointId ?? '';
 }
 
 /** Like swDebugEval but returns raw result (doesn't reject on exceptions). */
-export async function swDebugEvalRaw(expression: string): Promise<{ result?: any; exceptionDetails?: any }> {
+export async function swDebugEvalRaw(expression: string): Promise<{ result?: CdpRemoteObject; exceptionDetails?: { exception?: { description?: string }; text?: string } }> {
     return cdpSendCommand('Runtime.evaluate', {
         expression, awaitPromise: true, returnByValue: false, generatePreview: true, replMode: true,
-    });
+    }) as Promise<{ result?: CdpRemoteObject; exceptionDetails?: { exception?: { description?: string }; text?: string } }>;
 }
 
 const activeBreakpointIds: string[] = [];
@@ -127,7 +128,7 @@ async function eagerSerialize(obj: CdpRemoteObject, depth = 0, visited = new Set
 
     // Fetch own properties eagerly
     const raw = await swGetProperties(obj.objectId);
-    const descriptors = (raw as any)?.result as CdpPropertyDescriptor[];
+    const descriptors = (raw as { result?: CdpPropertyDescriptor[] })?.result;
     if (!descriptors) return fromCdpRemoteObject(obj);
 
     const props: Record<string, SerializedValue> = {};
@@ -144,16 +145,19 @@ async function eagerSerialize(obj: CdpRemoteObject, depth = 0, visited = new Set
     return { __type: 'object', cls, props };
 }
 
-chrome.debugger.onEvent.addListener(async (source, method, params: any) => {
+// chrome.debugger types aren't visible in panel context — cast to access the API
+type DebuggerEvent = { addListener: (cb: (source: { targetId?: string }, method: string, params: Record<string, unknown>) => void) => void };
+((chrome as unknown as { debugger: { onEvent: DebuggerEvent } }).debugger.onEvent).addListener(async (source, method, params) => {
     if (source.targetId !== getTargetId()) return;
 
     if (method === 'Debugger.paused') {
-        if (params.callFrames?.length > 0) {
-            pausedCallFrameId = params.callFrames[0].callFrameId;
-            const scopes: ScopeInfo[] = (params.callFrames[0].scopeChain ?? [])
-            .filter((s:any) => s.type !== 'global')
-            .map((s:any) => ({ type: s.type, name: s.name, objectId: s.object.objectId }));
-            pauseCallback?.(params.callFrames[0].location.lineNumber, scopes);
+        const callFrames = params?.callFrames as Array<{ callFrameId: string; location: { lineNumber: number }; scopeChain?: Array<{ type: string; name?: string; object: { objectId: string } }> }> | undefined;
+        if (callFrames && callFrames.length > 0) {
+            pausedCallFrameId = callFrames[0].callFrameId;
+            const scopes: ScopeInfo[] = (callFrames[0].scopeChain ?? [])
+            .filter(s => s.type !== 'global')
+            .map(s => ({ type: s.type, name: s.name, objectId: s.object.objectId }));
+            pauseCallback?.(callFrames[0].location.lineNumber, scopes);
         }
         return;
     }
@@ -165,10 +169,10 @@ chrome.debugger.onEvent.addListener(async (source, method, params: any) => {
     if (method !== 'Runtime.consoleAPICalled') return;
     if (!consoleCallback) return;
 
-    const level = params.type; // 'log', 'error', 'warn', 'info', etc.
+    const level = params.type as string; // 'log', 'error', 'warn', 'info', etc.
     try {
         const serialized: SerializedValue[] = [];
-        for (const arg of params.args) {
+        for (const arg of params.args as CdpRemoteObject[]) {
             try {
                 serialized.push(await eagerSerialize(arg));
             } catch {

--- a/packages/extension/src/test-framework.ts
+++ b/packages/extension/src/test-framework.ts
@@ -59,9 +59,9 @@ test.only = (name: string, fnOrOpts: TestFn | Record<string, unknown>, maybeFn?:
 };
 
 class SkipError extends Error { constructor() { super('SKIP'); this.name = 'SkipError'; } }
-test.skip = (nameOrCond: any, fnOrOpts?: any, maybeFn?: any) => {
+test.skip = (nameOrCond: string | boolean | undefined, fnOrOpts?: TestFn | Record<string, unknown>, maybeFn?: TestFn) => {
   if (typeof nameOrCond === 'string') {
-    const fn = typeof fnOrOpts === 'function' ? fnOrOpts : maybeFn;
+    const fn = typeof fnOrOpts === 'function' ? fnOrOpts : maybeFn!;
     currentSuite.tests.push({ name: nameOrCond, fn, only: false, skip: true });
   } else if (nameOrCond) {
     throw new SkipError();
@@ -79,30 +79,38 @@ test.describe = (name: string, fn: () => void) => {
   fn();
   currentSuite = parent;
 };
-(test.describe as any).configure = () => {};
-(test as any).fixme = (condOrName?: any, fn?: any) => {
+interface TestDescribeFn { (name: string, fn: () => void): void; configure: () => void; }
+(test.describe as TestDescribeFn).configure = () => {};
+
+interface TestExt {
+  fixme: (condOrName?: string | boolean, fn?: TestFn) => void;
+  slow: () => void;
+  info: () => { annotations: unknown[] };
+}
+const testExt = test as typeof test & TestExt;
+testExt.fixme = (condOrName?: string | boolean, fn?: TestFn) => {
   if (typeof condOrName === 'string') return test.skip(condOrName, fn);
   if (condOrName) throw new SkipError();
 };
-(test as any).slow = () => {};
-(test as any).info = () => ({ annotations: [] });
+testExt.slow = () => {};
+testExt.info = () => ({ annotations: [] });
 
 test.beforeAll = (fn: HookFn) => { currentSuite.beforeAll.push(fn); };
 test.afterAll = (fn: HookFn) => { currentSuite.afterAll.push(fn); };
 test.beforeEach = (fn: HookFn) => { currentSuite.beforeEach.push(fn); };
 test.afterEach = (fn: HookFn) => { currentSuite.afterEach.push(fn); };
 
-test.extend = (fixtures: Record<string, any>) => {
+test.extend = (fixtures: Record<string, unknown>) => {
   const extendedTest = (name: string, fnOrOpts: TestFn | Record<string, unknown>, maybeFn?: TestFn) => {
     const fn = typeof fnOrOpts === 'function' ? fnOrOpts : maybeFn!;
     currentSuite.tests.push({
       name, only: false, skip: false,
-      fn: async (baseFixtures: any) => {
+      fn: async (baseFixtures: Record<string, unknown>) => {
         const extended = { ...baseFixtures };
         for (const [key, fixtureFn] of Object.entries(fixtures)) {
           if (typeof fixtureFn === 'function') {
             await new Promise<void>((resolve, reject) => {
-              const useCallback = async (value: any) => {
+              const useCallback = async (value: unknown) => {
                 extended[key] = value;
                 resolve();
               };
@@ -113,7 +121,7 @@ test.extend = (fixtures: Record<string, any>) => {
             });
           }
         }
-        await fn(extended);
+        await fn(extended as { page: unknown; context: unknown; expect: unknown });
       },
     });
   };
@@ -125,9 +133,9 @@ test.extend = (fixtures: Record<string, any>) => {
   extendedTest.beforeEach = test.beforeEach;
   extendedTest.afterEach = test.afterEach;
   extendedTest.extend = test.extend;
-  extendedTest.fixme = (test as any).fixme;
-  extendedTest.slow = (test as any).slow;
-  extendedTest.info = (test as any).info;
+  extendedTest.fixme = testExt.fixme;
+  extendedTest.slow = testExt.slow;
+  extendedTest.info = testExt.info;
   return extendedTest;
 };
 
@@ -137,8 +145,9 @@ async function runSuite(
   suite: Suite, parentBeforeEach: HookFn[], parentAfterEach: HookFn[], prefix: string,
 ): Promise<TestResult[]> {
   const results: TestResult[] = [];
-  const _g = globalThis as any;
-  const fixtures = { page: _g.__proxyPage ?? _g.page, context: null, expect: _g.__proxyExpect ?? _g.expect };
+  const _g = globalThis as typeof globalThis & Record<string, unknown>;
+  const page = _g.__proxyPage ?? _g.page;
+  const fixtures = { page, context: null, expect: _g.__proxyExpect ?? _g.expect };
   const allBeforeEach = [...parentBeforeEach, ...suite.beforeEach];
   const allAfterEach = [...suite.afterEach, ...parentAfterEach];
 
@@ -152,9 +161,10 @@ async function runSuite(
     }
     const start = Date.now();
     try {
-      if (fixtures.page?.unrouteAll) {
-        try { await fixtures.page.unrouteAll({ behavior: 'wait' }); }
-        catch { await fixtures.page.unrouteAll(); }
+      const p = page as Record<string, unknown> | null | undefined;
+      if (p?.unrouteAll) {
+        try { await (p.unrouteAll as (opts?: unknown) => Promise<void>)({ behavior: 'wait' }); }
+        catch { await (p.unrouteAll as () => Promise<void>)(); }
       }
       for (const fn of allBeforeEach) await fn(fixtures);
       await Promise.race([
@@ -207,16 +217,16 @@ async function __runTests(): Promise<string> {
 
 function smartExpect(target: unknown): unknown {
   // In browser context, just use the real expect
-  const _g = globalThis as any;
+  const _g = globalThis as typeof globalThis & Record<string, unknown>;
   const realExpect = _g.__proxyExpect ?? _g.expect;
-  if (realExpect) return realExpect(target);
+  if (realExpect) return (realExpect as (target: unknown) => unknown)(target);
   throw new Error('expect() not available');
 }
 
 // ─── Install ───────────────────────────────────────────────────────────────
 
 export function installFramework() {
-  const _g = globalThis as any;
+  const _g = globalThis;
   _g.__test = test;
   _g.__expect = smartExpect;
   _g.__runTests = __runTests;

--- a/packages/extension/test/background.test.ts
+++ b/packages/extension/test/background.test.ts
@@ -1,9 +1,39 @@
 import { describe, it, expect, vi, beforeEach, type Mock } from "vitest";
 
+// ─── Mock types ──────────────────────────────────────────────────────────────
+
+interface MockPage {
+  url: ReturnType<typeof vi.fn>;
+  on: ReturnType<typeof vi.fn>;
+}
+
+interface MockCrxApp {
+  attach: ReturnType<typeof vi.fn>;
+  detach: ReturnType<typeof vi.fn>;
+  detachAll: ReturnType<typeof vi.fn>;
+  on: ReturnType<typeof vi.fn>;
+  context: ReturnType<typeof vi.fn>;
+  recorder: {
+    show: ReturnType<typeof vi.fn>;
+    hide: ReturnType<typeof vi.fn>;
+  };
+}
+
+/** Cast a chrome namespace to allow assigning mock properties */
+function asMock<T>(obj: T): Record<string, unknown> {
+  return obj as unknown as Record<string, unknown>;
+}
+
+type DebuggerTarget = { targetId: string };
+type DebuggerCallback = (...args: unknown[]) => void;
+type MessageSender = Record<string, unknown>;
+type SendResponseFn = (response: unknown) => void;
+type MessageListener = (msg: Record<string, unknown>, sender: MessageSender, sendResponse: SendResponseFn) => boolean | void;
+
 // ─── Shared mock state ────────────────────────────────────────────────────────
 
-let mockPage: any;
-let mockCrxApp: any;
+let mockPage: MockPage;
+let mockCrxApp: MockCrxApp;
 let mockParseReplCommand: Mock;
 let mockDetectMode: Mock;
 
@@ -12,14 +42,14 @@ vi.mock('@playwright-repl/playwright-crx/test', () => ({
 }));
 
 vi.mock('@playwright-repl/playwright-crx', () => {
-  mockPage = { url: vi.fn().mockReturnValue('https://example.com'), on: vi.fn() };
+  mockPage = { url: vi.fn().mockReturnValue('https://example.com'), on: vi.fn() } as MockPage;
   const mockContext = { pages: vi.fn().mockReturnValue([mockPage]) };
   mockCrxApp = {
     attach: vi.fn().mockResolvedValue(mockPage),
     detach: vi.fn().mockResolvedValue(undefined),
     on: vi.fn(),
     context: vi.fn().mockReturnValue(mockContext),
-  };
+  } as unknown as MockCrxApp;
   return { crx: { start: vi.fn().mockResolvedValue(mockCrxApp) } };
 });
 
@@ -28,20 +58,20 @@ vi.mock('../src/panel/lib/settings', () => ({
 }));
 
 vi.mock('../src/panel/lib/commands', () => ({
-  parseReplCommand: (...args: any[]) => mockParseReplCommand(...args),
+  parseReplCommand: (input: string) => mockParseReplCommand(input),
 }));
 
 vi.mock('../src/panel/lib/execute', () => ({
-  detectMode: (...args: any[]) => mockDetectMode(...args),
+  detectMode: (input: string) => mockDetectMode(input),
 }));
 
 // ─── Test suite ───────────────────────────────────────────────────────────────
 
 describe("background.ts message handlers", () => {
-  let onMessageListener: (msg: any, sender: any, sendResponse: (r: any) => void) => boolean | void;
-  let onStorageChanged: (...args: any[]) => void;
-  let onActionClicked: (...args: any[]) => void;
-  let onDebuggerDetach: (...args: any[]) => void;
+  let onMessageListener: MessageListener;
+  let onStorageChanged: (changes: Record<string, { newValue?: unknown }>, areaName: string) => void;
+  let onActionClicked: (tab: { id?: number; windowId?: number }) => void;
+  let onDebuggerDetach: (source: DebuggerTarget) => void;
   let onTabRemoved: (tabId: number) => void;
 
   beforeEach(async () => {
@@ -65,48 +95,50 @@ describe("background.ts message handlers", () => {
         show: vi.fn().mockResolvedValue(undefined),
         hide: vi.fn().mockResolvedValue(undefined),
       },
-    };
+    } as MockCrxApp;
 
     // Override factory for this test
     const { crx } = await import('@playwright-repl/playwright-crx');
     (crx.start as ReturnType<typeof vi.fn>).mockResolvedValue(mockCrxApp);
 
     // Set up chrome stubs
-    (chrome.management as any).getSelf = vi.fn().mockResolvedValue({ installType: 'development' });
-    (chrome.storage.local.get as any).mockResolvedValue({});
-    (chrome.tabs as any).get = vi.fn().mockResolvedValue({ id: 42, url: 'https://example.com' });
-    (chrome.tabs as any).query = vi.fn().mockResolvedValue([{ id: 42, url: 'https://example.com' }]);
-    (chrome.tabs as any).onActivated = { addListener: vi.fn() };
-    (chrome.tabs as any).onUpdated = { addListener: vi.fn() };
-    const tabRemovedListeners: any[] = [];
-    (chrome.tabs as any).onRemoved = { addListener: vi.fn((fn: any) => tabRemovedListeners.push(fn)) };
-    (chrome.tabs as any).sendMessage = vi.fn().mockResolvedValue(undefined);
-    (chrome.scripting as any).executeScript = vi.fn().mockResolvedValue([]);
+    asMock(chrome.management).getSelf = vi.fn().mockResolvedValue({ installType: 'development' });
+    (chrome.storage.local.get as ReturnType<typeof vi.fn>).mockResolvedValue({});
+    const tabs = asMock(chrome.tabs);
+    tabs.get = vi.fn().mockResolvedValue({ id: 42, url: 'https://example.com' });
+    tabs.query = vi.fn().mockResolvedValue([{ id: 42, url: 'https://example.com' }]);
+    tabs.onActivated = { addListener: vi.fn() };
+    tabs.onUpdated = { addListener: vi.fn() };
+    const tabRemovedListeners: ((tabId: number) => void)[] = [];
+    tabs.onRemoved = { addListener: vi.fn((fn: (tabId: number) => void) => tabRemovedListeners.push(fn)) };
+    tabs.sendMessage = vi.fn().mockResolvedValue(undefined);
+    asMock(chrome.scripting).executeScript = vi.fn().mockResolvedValue([]);
 
     // Capture chrome event listeners
-    const messageListeners: typeof onMessageListener[] = [];
-    (chrome.runtime as any).onMessage = { addListener: vi.fn((fn: any) => messageListeners.push(fn)) };
-    (chrome.runtime as any).sendMessage = vi.fn().mockResolvedValue(undefined);
+    const messageListeners: MessageListener[] = [];
+    const runtime = asMock(chrome.runtime);
+    runtime.onMessage = { addListener: vi.fn((fn: MessageListener) => messageListeners.push(fn)) };
+    runtime.sendMessage = vi.fn().mockResolvedValue(undefined);
 
-    const storageListeners: any[] = [];
-    (chrome.storage as any).onChanged = { addListener: vi.fn((fn: any) => storageListeners.push(fn)) };
+    const storageListeners: typeof onStorageChanged[] = [];
+    asMock(chrome.storage).onChanged = { addListener: vi.fn((fn: typeof onStorageChanged) => storageListeners.push(fn)) };
 
-    const actionListeners: any[] = [];
-    (chrome.action as any).onClicked = { addListener: vi.fn((fn: any) => actionListeners.push(fn)) };
+    const actionListeners: typeof onActionClicked[] = [];
+    asMock(chrome.action).onClicked = { addListener: vi.fn((fn: typeof onActionClicked) => actionListeners.push(fn)) };
 
-    const detachListeners: any[] = [];
-    (chrome.debugger as any).onDetach = { addListener: vi.fn((fn: any) => detachListeners.push(fn)) };
+    const detachListeners: ((source: DebuggerTarget) => void)[] = [];
+    asMock(chrome.debugger).onDetach = { addListener: vi.fn((fn: (source: DebuggerTarget) => void) => detachListeners.push(fn)) };
 
     // Offscreen mock
-    (chrome.offscreen as any).hasDocument = vi.fn().mockResolvedValue(false);
-    (chrome.offscreen as any).createDocument = vi.fn().mockResolvedValue(undefined);
+    asMock(chrome.offscreen).hasDocument = vi.fn().mockResolvedValue(false);
+    asMock(chrome.offscreen).createDocument = vi.fn().mockResolvedValue(undefined);
 
     // sidePanel mock
-    (chrome.sidePanel as any).setPanelBehavior = vi.fn().mockResolvedValue(undefined);
-    (chrome.sidePanel as any).open = vi.fn().mockResolvedValue(undefined);
+    asMock(chrome.sidePanel).setPanelBehavior = vi.fn().mockResolvedValue(undefined);
+    asMock(chrome.sidePanel).open = vi.fn().mockResolvedValue(undefined);
 
     // windows mock
-    (chrome.windows as any).create = vi.fn().mockResolvedValue({});
+    asMock(chrome.windows).create = vi.fn().mockResolvedValue({});
 
     vi.resetModules();
 
@@ -118,9 +150,9 @@ describe("background.ts message handlers", () => {
     onTabRemoved = tabRemovedListeners[0];
   });
 
-  function sendMessage(msg: any): Promise<any> {
+  function sendMessage(msg: Record<string, unknown>): Promise<Record<string, unknown>> {
     return new Promise((resolve) => {
-      const ret = onMessageListener(msg, {}, resolve);
+      const ret = onMessageListener(msg, {}, resolve as SendResponseFn);
       if (ret === false) {
         // synchronous — resolve has already been called
       }
@@ -128,16 +160,17 @@ describe("background.ts message handlers", () => {
   }
 
   /** Set up chrome.debugger mocks for bridge-command / ensureSelfAttached */
-  function setupDebuggerMocks(swId = 'sw-1', evalResult: any = { result: { type: 'undefined' } }) {
-    (chrome.debugger as any).getTargets = vi.fn((cb: any) => cb([
+  function setupDebuggerMocks(swId = 'sw-1', evalResult: Record<string, unknown> = { result: { type: 'undefined' } }) {
+    const dbg = asMock(chrome.debugger);
+    dbg.getTargets = vi.fn((cb: DebuggerCallback) => cb([
       { type: 'worker', url: `chrome-extension://${chrome.runtime.id}/background.js`, id: swId },
     ]));
-    (chrome.debugger as any).attach = vi.fn((_t: any, _v: string, cb: any) => cb());
-    (chrome.debugger as any).sendCommand = vi.fn((_t: any, method: string, _p: any, cb: any) => {
+    dbg.attach = vi.fn((_t: unknown, _v: string, cb: DebuggerCallback) => cb());
+    dbg.sendCommand = vi.fn((_t: unknown, method: string, _p: unknown, cb: DebuggerCallback) => {
       if (method === 'Runtime.enable') { cb(); return; }
       cb(evalResult);
     });
-    (chrome.debugger as any).onDetach = { addListener: vi.fn() };
+    dbg.onDetach = { addListener: vi.fn() };
   }
 
   // ─── health ───────────────────────────────────────────────────────────────
@@ -164,7 +197,7 @@ describe("background.ts message handlers", () => {
   });
 
   it("attach rejects chrome:// URLs", async () => {
-    (chrome.tabs as any).get = vi.fn().mockResolvedValue({ id: 1, url: 'chrome://settings' });
+    asMock(chrome.tabs).get = vi.fn().mockResolvedValue({ id: 1, url: 'chrome://settings' });
     const result = await sendMessage({ type: 'attach', tabId: 1 });
     expect(result.ok).toBe(false);
     expect(result.error).toContain('Cannot attach to this page');
@@ -189,7 +222,7 @@ describe("background.ts message handlers", () => {
   it("attach switches to new tab without detaching previous tab", async () => {
     await sendMessage({ type: 'attach', tabId: 42 });
     mockCrxApp.attach.mockResolvedValue({ url: vi.fn().mockReturnValue('https://new.com'), on: vi.fn() });
-    (chrome.tabs as any).get = vi.fn().mockResolvedValue({ id: 99, url: 'https://new.com' });
+    asMock(chrome.tabs).get = vi.fn().mockResolvedValue({ id: 99, url: 'https://new.com' });
     await sendMessage({ type: 'attach', tabId: 99 });
     // playwright-crx supports multiple attached pages, so we don't detach when switching tabs
     expect(mockCrxApp.detach).not.toHaveBeenCalled();
@@ -221,7 +254,7 @@ describe("background.ts message handlers", () => {
   it("record-stop sends record-stop message to tab and returns ok:true", async () => {
     await sendMessage({ type: 'record-start' });
     const result = await sendMessage({ type: 'record-stop' });
-    expect((chrome.tabs as any).sendMessage).toHaveBeenCalledWith(42, { type: 'record-stop' });
+    expect(asMock(chrome.tabs).sendMessage).toHaveBeenCalledWith(42, { type: 'record-stop' });
     expect(result).toEqual({ ok: true });
   });
 
@@ -235,13 +268,13 @@ describe("background.ts message handlers", () => {
   // ─── get-bridge-port ──────────────────────────────────────────────────────
 
   it("get-bridge-port returns stored port", async () => {
-    (chrome.storage.local.get as any).mockResolvedValue({ bridgePort: 1234 });
+    (chrome.storage.local.get as ReturnType<typeof vi.fn>).mockResolvedValue({ bridgePort: 1234 });
     const result = await sendMessage({ type: 'get-bridge-port' });
     expect(result).toBe(1234);
   });
 
   it("get-bridge-port returns default 9876 when not set", async () => {
-    (chrome.storage.local.get as any).mockResolvedValue({});
+    (chrome.storage.local.get as ReturnType<typeof vi.fn>).mockResolvedValue({});
     const result = await sendMessage({ type: 'get-bridge-port' });
     expect(result).toBe(9876);
   });
@@ -266,7 +299,7 @@ describe("background.ts message handlers", () => {
   // ─── bridge-command ───────────────────────────────────────────────────────
 
   it("bridge-command returns error when no page attached and no active tab", async () => {
-    (chrome.tabs as any).query = vi.fn().mockResolvedValue([]);
+    asMock(chrome.tabs).query = vi.fn().mockResolvedValue([]);
     const result = await sendMessage({ type: 'bridge-command', command: 'snapshot' });
     expect(result.isError).toBe(true);
     expect(result.text).toContain('No active tab');
@@ -274,18 +307,18 @@ describe("background.ts message handlers", () => {
 
   it("bridge-command auto-attaches to active tab", async () => {
     // Set up debugger mock for executeBridgeExpr (ensureSelfAttached + eval)
-    (chrome.debugger as any).getTargets = vi.fn((cb: any) => cb([
+    asMock(chrome.debugger).getTargets = vi.fn((cb: DebuggerCallback) => cb([
       { type: 'worker', url: `chrome-extension://${chrome.runtime.id}/background.js`, id: 'sw-1' },
     ]));
-    (chrome.debugger as any).attach = vi.fn((_target: any, _ver: string, cb: any) => {
+    asMock(chrome.debugger).attach = vi.fn((_target: unknown, _ver: string, cb: DebuggerCallback) => {
       cb();
     });
-    (chrome.debugger as any).sendCommand = vi.fn((_target: any, method: string, _params: any, cb: any) => {
+    asMock(chrome.debugger).sendCommand = vi.fn((_target: unknown, method: string, _params: unknown, cb: DebuggerCallback) => {
       if (method === 'Runtime.enable') { cb(); return; }
       // Return undefined result for the eval
       cb({ result: { type: 'undefined' } });
     });
-    (chrome.debugger as any).onDetach = { addListener: vi.fn() };
+    asMock(chrome.debugger).onDetach = { addListener: vi.fn() };
 
     const result = await sendMessage({ type: 'bridge-command', command: 'snapshot' });
     // Should have auto-attached to tab 42
@@ -298,17 +331,17 @@ describe("background.ts message handlers", () => {
   it("bridge-command script executes lines sequentially", async () => {
     await sendMessage({ type: 'attach', tabId: 42 });
 
-    (chrome.debugger as any).getTargets = vi.fn((cb: any) => cb([
+    asMock(chrome.debugger).getTargets = vi.fn((cb: DebuggerCallback) => cb([
       { type: 'worker', url: `chrome-extension://${chrome.runtime.id}/background.js`, id: 'sw-1' },
     ]));
-    (chrome.debugger as any).attach = vi.fn((_target: any, _ver: string, cb: any) => {
+    asMock(chrome.debugger).attach = vi.fn((_target: unknown, _ver: string, cb: DebuggerCallback) => {
       cb();
     });
-    (chrome.debugger as any).sendCommand = vi.fn((_target: any, method: string, _params: any, cb: any) => {
+    asMock(chrome.debugger).sendCommand = vi.fn((_target: unknown, method: string, _params: unknown, cb: DebuggerCallback) => {
       if (method === 'Runtime.enable') { cb(); return; }
       cb({ result: { type: 'string', value: 'ok' } });
     });
-    (chrome.debugger as any).onDetach = { addListener: vi.fn() };
+    asMock(chrome.debugger).onDetach = { addListener: vi.fn() };
 
     const result = await sendMessage({
       type: 'bridge-command',
@@ -326,17 +359,17 @@ describe("background.ts message handlers", () => {
   it("bridge-command returns Done for undefined result", async () => {
     await sendMessage({ type: 'attach', tabId: 42 });
 
-    (chrome.debugger as any).getTargets = vi.fn((cb: any) => cb([
+    asMock(chrome.debugger).getTargets = vi.fn((cb: DebuggerCallback) => cb([
       { type: 'worker', url: `chrome-extension://${chrome.runtime.id}/background.js`, id: 'sw-1' },
     ]));
-    (chrome.debugger as any).attach = vi.fn((_target: any, _ver: string, cb: any) => {
+    asMock(chrome.debugger).attach = vi.fn((_target: unknown, _ver: string, cb: DebuggerCallback) => {
       cb();
     });
-    (chrome.debugger as any).sendCommand = vi.fn((_target: any, method: string, _params: any, cb: any) => {
+    asMock(chrome.debugger).sendCommand = vi.fn((_target: unknown, method: string, _params: unknown, cb: DebuggerCallback) => {
       if (method === 'Runtime.enable') { cb(); return; }
       cb({ result: { type: 'undefined' } });
     });
-    (chrome.debugger as any).onDetach = { addListener: vi.fn() };
+    asMock(chrome.debugger).onDetach = { addListener: vi.fn() };
 
     const result = await sendMessage({ type: 'bridge-command', command: 'snapshot' });
     expect(result).toEqual({ text: 'Done', isError: false });
@@ -345,17 +378,17 @@ describe("background.ts message handlers", () => {
   it("bridge-command returns string result", async () => {
     await sendMessage({ type: 'attach', tabId: 42 });
 
-    (chrome.debugger as any).getTargets = vi.fn((cb: any) => cb([
+    asMock(chrome.debugger).getTargets = vi.fn((cb: DebuggerCallback) => cb([
       { type: 'worker', url: `chrome-extension://${chrome.runtime.id}/background.js`, id: 'sw-1' },
     ]));
-    (chrome.debugger as any).attach = vi.fn((_target: any, _ver: string, cb: any) => {
+    asMock(chrome.debugger).attach = vi.fn((_target: unknown, _ver: string, cb: DebuggerCallback) => {
       cb();
     });
-    (chrome.debugger as any).sendCommand = vi.fn((_target: any, method: string, _params: any, cb: any) => {
+    asMock(chrome.debugger).sendCommand = vi.fn((_target: unknown, method: string, _params: unknown, cb: DebuggerCallback) => {
       if (method === 'Runtime.enable') { cb(); return; }
       cb({ result: { type: 'string', value: 'hello world' } });
     });
-    (chrome.debugger as any).onDetach = { addListener: vi.fn() };
+    asMock(chrome.debugger).onDetach = { addListener: vi.fn() };
 
     const result = await sendMessage({ type: 'bridge-command', command: 'snapshot' });
     expect(result).toEqual({ text: 'hello world', isError: false });
@@ -365,17 +398,17 @@ describe("background.ts message handlers", () => {
     await sendMessage({ type: 'attach', tabId: 42 });
 
     const imgJson = JSON.stringify({ __image: 'abc123', mimeType: 'image/png' });
-    (chrome.debugger as any).getTargets = vi.fn((cb: any) => cb([
+    asMock(chrome.debugger).getTargets = vi.fn((cb: DebuggerCallback) => cb([
       { type: 'worker', url: `chrome-extension://${chrome.runtime.id}/background.js`, id: 'sw-1' },
     ]));
-    (chrome.debugger as any).attach = vi.fn((_target: any, _ver: string, cb: any) => {
+    asMock(chrome.debugger).attach = vi.fn((_target: unknown, _ver: string, cb: DebuggerCallback) => {
       cb();
     });
-    (chrome.debugger as any).sendCommand = vi.fn((_target: any, method: string, _params: any, cb: any) => {
+    asMock(chrome.debugger).sendCommand = vi.fn((_target: unknown, method: string, _params: unknown, cb: DebuggerCallback) => {
       if (method === 'Runtime.enable') { cb(); return; }
       cb({ result: { type: 'string', value: imgJson } });
     });
-    (chrome.debugger as any).onDetach = { addListener: vi.fn() };
+    asMock(chrome.debugger).onDetach = { addListener: vi.fn() };
 
     const result = await sendMessage({ type: 'bridge-command', command: 'screenshot' });
     expect(result.isError).toBe(false);
@@ -385,17 +418,17 @@ describe("background.ts message handlers", () => {
   it("bridge-command returns error on eval exception", async () => {
     await sendMessage({ type: 'attach', tabId: 42 });
 
-    (chrome.debugger as any).getTargets = vi.fn((cb: any) => cb([
+    asMock(chrome.debugger).getTargets = vi.fn((cb: DebuggerCallback) => cb([
       { type: 'worker', url: `chrome-extension://${chrome.runtime.id}/background.js`, id: 'sw-1' },
     ]));
-    (chrome.debugger as any).attach = vi.fn((_target: any, _ver: string, cb: any) => {
+    asMock(chrome.debugger).attach = vi.fn((_target: unknown, _ver: string, cb: DebuggerCallback) => {
       cb();
     });
-    (chrome.debugger as any).sendCommand = vi.fn((_target: any, method: string, _params: any, cb: any) => {
+    asMock(chrome.debugger).sendCommand = vi.fn((_target: unknown, method: string, _params: unknown, cb: DebuggerCallback) => {
       if (method === 'Runtime.enable') { cb(); return; }
       cb({ exceptionDetails: { exception: { description: 'ReferenceError: x is not defined' } } });
     });
-    (chrome.debugger as any).onDetach = { addListener: vi.fn() };
+    asMock(chrome.debugger).onDetach = { addListener: vi.fn() };
 
     const result = await sendMessage({ type: 'bridge-command', command: 'snapshot' });
     expect(result.isError).toBe(true);
@@ -405,7 +438,7 @@ describe("background.ts message handlers", () => {
   // ─── attach: chrome-extension:// URL rejection ────────────────────────────
 
   it("attach rejects chrome-extension:// URLs", async () => {
-    (chrome.tabs as any).get = vi.fn().mockResolvedValue({ id: 1, url: 'chrome-extension://abc/panel.html' });
+    asMock(chrome.tabs).get = vi.fn().mockResolvedValue({ id: 1, url: 'chrome-extension://abc/panel.html' });
     const result = await sendMessage({ type: 'attach', tabId: 1 });
     expect(result.ok).toBe(false);
     expect(result.error).toContain('Cannot attach to this page');
@@ -482,11 +515,11 @@ describe("background.ts message handlers", () => {
     onDebuggerDetach({ targetId: 'sw-1' });
 
     // Next bridge-command should re-attach (getTargets called again)
-    (chrome.debugger as any).getTargets = vi.fn((cb: any) => cb([
+    asMock(chrome.debugger).getTargets = vi.fn((cb: DebuggerCallback) => cb([
       { type: 'worker', url: `chrome-extension://${chrome.runtime.id}/background.js`, id: 'sw-2' },
     ]));
-    (chrome.debugger as any).attach = vi.fn((_t: any, _v: string, cb: any) => cb());
-    (chrome.debugger as any).sendCommand = vi.fn((_t: any, method: string, _p: any, cb: any) => {
+    asMock(chrome.debugger).attach = vi.fn((_t: unknown, _v: string, cb: DebuggerCallback) => cb());
+    asMock(chrome.debugger).sendCommand = vi.fn((_t: unknown, method: string, _p: unknown, cb: DebuggerCallback) => {
       if (method === 'Runtime.enable') { cb(); return; }
       cb({ result: { type: 'undefined' } });
     });
@@ -504,18 +537,18 @@ describe("background.ts message handlers", () => {
   it("ensureOffscreen skips creation when document already exists", async () => {
     // Reset and re-import with hasDocument returning true
     vi.resetModules();
-    (chrome.offscreen as any).hasDocument = vi.fn().mockResolvedValue(true);
-    (chrome.offscreen as any).createDocument = vi.fn();
-    const listeners: any[] = [];
-    (chrome.runtime as any).onMessage = { addListener: vi.fn((fn: any) => listeners.push(fn)) };
-    (chrome.storage as any).onChanged = { addListener: vi.fn() };
-    (chrome.action as any).onClicked = { addListener: vi.fn() };
-    (chrome.debugger as any).onDetach = { addListener: vi.fn() };
-    (chrome.sidePanel as any).setPanelBehavior = vi.fn().mockResolvedValue(undefined);
-    (chrome.tabs as any).onActivated = { addListener: vi.fn() };
-    (chrome.tabs as any).onUpdated = { addListener: vi.fn() };
-    (chrome.tabs as any).onRemoved = { addListener: vi.fn() };
-    (chrome.tabs as any).sendMessage = vi.fn().mockResolvedValue(undefined);
+    asMock(chrome.offscreen).hasDocument = vi.fn().mockResolvedValue(true);
+    asMock(chrome.offscreen).createDocument = vi.fn();
+    const listeners: MessageListener[] = [];
+    asMock(chrome.runtime).onMessage = { addListener: vi.fn((fn: MessageListener) => listeners.push(fn)) };
+    asMock(chrome.storage).onChanged = { addListener: vi.fn() };
+    asMock(chrome.action).onClicked = { addListener: vi.fn() };
+    asMock(chrome.debugger).onDetach = { addListener: vi.fn() };
+    asMock(chrome.sidePanel).setPanelBehavior = vi.fn().mockResolvedValue(undefined);
+    asMock(chrome.tabs).onActivated = { addListener: vi.fn() };
+    asMock(chrome.tabs).onUpdated = { addListener: vi.fn() };
+    asMock(chrome.tabs).onRemoved = { addListener: vi.fn() };
+    asMock(chrome.tabs).sendMessage = vi.fn().mockResolvedValue(undefined);
 
     await import('../src/background.js');
     // Wait for the async ensureOffscreen call
@@ -534,7 +567,7 @@ describe("background.ts message handlers", () => {
   // ─── startRecording without active tab ─────────────────────────────────────
 
   it("record-start returns ok:false when no active tab", async () => {
-    (chrome.tabs as any).query = vi.fn().mockResolvedValue([]);
+    asMock(chrome.tabs).query = vi.fn().mockResolvedValue([]);
     const result = await sendMessage({ type: 'record-start' });
     expect(result.ok).toBe(false);
     expect(result.error).toContain('No active tab');
@@ -544,8 +577,8 @@ describe("background.ts message handlers", () => {
 
   it("bridge-command throws when background worker target not found", async () => {
     await sendMessage({ type: 'attach', tabId: 42 });
-    (chrome.debugger as any).getTargets = vi.fn((cb: any) => cb([]));
-    (chrome.debugger as any).onDetach = { addListener: vi.fn() };
+    asMock(chrome.debugger).getTargets = vi.fn((cb: DebuggerCallback) => cb([]));
+    asMock(chrome.debugger).onDetach = { addListener: vi.fn() };
 
     const result = await sendMessage({ type: 'bridge-command', command: 'snapshot' });
     expect(result.isError).toBe(true);
@@ -559,26 +592,26 @@ describe("background.ts message handlers", () => {
     // First call sets selfTargetId
     await sendMessage({ type: 'bridge-command', command: 'snapshot' });
     // Second call should reuse cached selfTargetId (no new attach)
-    (chrome.debugger as any).attach = vi.fn();
+    asMock(chrome.debugger).attach = vi.fn();
     await sendMessage({ type: 'bridge-command', command: 'snapshot' });
     expect(chrome.debugger.attach).not.toHaveBeenCalled();
   });
 
   it("bridge-command handles 'already attached' debugger error gracefully", async () => {
     await sendMessage({ type: 'attach', tabId: 42 });
-    (chrome.debugger as any).getTargets = vi.fn((cb: any) => cb([
+    asMock(chrome.debugger).getTargets = vi.fn((cb: DebuggerCallback) => cb([
       { type: 'worker', url: `chrome-extension://${chrome.runtime.id}/background.js`, id: 'sw-1' },
     ]));
-    (chrome.debugger as any).attach = vi.fn((_t: any, _v: string, cb: any) => {
-      (chrome.runtime as any).lastError = { message: 'Already attached' };
+    asMock(chrome.debugger).attach = vi.fn((_t: unknown, _v: string, cb: DebuggerCallback) => {
+      asMock(chrome.runtime).lastError = { message: 'Already attached' };
       cb();
-      delete (chrome.runtime as any).lastError;
+      delete asMock(chrome.runtime).lastError;
     });
-    (chrome.debugger as any).sendCommand = vi.fn((_t: any, method: string, _p: any, cb: any) => {
+    asMock(chrome.debugger).sendCommand = vi.fn((_t: unknown, method: string, _p: unknown, cb: DebuggerCallback) => {
       if (method === 'Runtime.enable') { cb(); return; }
       cb({ result: { type: 'undefined' } });
     });
-    (chrome.debugger as any).onDetach = { addListener: vi.fn() };
+    asMock(chrome.debugger).onDetach = { addListener: vi.fn() };
 
     const result = await sendMessage({ type: 'bridge-command', command: 'snapshot' });
     expect(result.isError).toBe(false);
@@ -586,15 +619,15 @@ describe("background.ts message handlers", () => {
 
   it("bridge-command rejects on non-'already attached' debugger error", async () => {
     await sendMessage({ type: 'attach', tabId: 42 });
-    (chrome.debugger as any).getTargets = vi.fn((cb: any) => cb([
+    asMock(chrome.debugger).getTargets = vi.fn((cb: DebuggerCallback) => cb([
       { type: 'worker', url: `chrome-extension://${chrome.runtime.id}/background.js`, id: 'sw-1' },
     ]));
-    (chrome.debugger as any).attach = vi.fn((_t: any, _v: string, cb: any) => {
-      (chrome.runtime as any).lastError = { message: 'Permission denied' };
+    asMock(chrome.debugger).attach = vi.fn((_t: unknown, _v: string, cb: DebuggerCallback) => {
+      asMock(chrome.runtime).lastError = { message: 'Permission denied' };
       cb();
-      delete (chrome.runtime as any).lastError;
+      delete asMock(chrome.runtime).lastError;
     });
-    (chrome.debugger as any).onDetach = { addListener: vi.fn() };
+    asMock(chrome.debugger).onDetach = { addListener: vi.fn() };
 
     const result = await sendMessage({ type: 'bridge-command', command: 'snapshot' });
     expect(result.isError).toBe(true);
@@ -610,10 +643,10 @@ describe("background.ts message handlers", () => {
     mockParseReplCommand.mockReturnValue({ jsExpr: 'const x = 1\nx' });
     const result = await sendMessage({ type: 'bridge-command', command: 'const x = 1\nx' });
     expect(result.isError).toBe(false);
-    const sendCmdCalls = (chrome.debugger.sendCommand as any).mock.calls;
-    const evalCall = sendCmdCalls.find((c: any) => c[1] === 'Runtime.evaluate');
-    expect(evalCall[2].expression).toBe('const x = 1\nx');
-    expect(evalCall[2].replMode).toBe(true);
+    const sendCmdCalls = vi.mocked(chrome.debugger.sendCommand).mock.calls;
+    const evalCall = sendCmdCalls.find((c: unknown[]) => c[1] === 'Runtime.evaluate');
+    expect((evalCall![2] as Record<string, unknown>).expression).toBe('const x = 1\nx');
+    expect((evalCall![2] as Record<string, unknown>).replMode).toBe(true);
   });
 
   it("bridge-command handles lastError in sendCommand (clears selfTargetId)", async () => {
@@ -624,10 +657,10 @@ describe("background.ts message handlers", () => {
     await sendMessage({ type: 'bridge-command', command: 'snapshot' });
 
     // Now make sendCommand fail with lastError
-    (chrome.debugger as any).sendCommand = vi.fn((_t: any, _method: string, _p: any, cb: any) => {
-      (chrome.runtime as any).lastError = { message: 'Target closed' };
+    asMock(chrome.debugger).sendCommand = vi.fn((_t: unknown, _method: string, _p: unknown, cb: DebuggerCallback) => {
+      asMock(chrome.runtime).lastError = { message: 'Target closed' };
       cb(undefined);
-      delete (chrome.runtime as any).lastError;
+      delete asMock(chrome.runtime).lastError;
     });
 
     const result = await sendMessage({ type: 'bridge-command', command: 'snapshot' });
@@ -727,7 +760,7 @@ describe("background.ts message handlers", () => {
   it("bridge-command returns parsed error for unrecognized mode", async () => {
     await sendMessage({ type: 'attach', tabId: 42 });
     mockParseReplCommand.mockReturnValue({ error: 'Unknown command: foo' });
-    mockDetectMode.mockReturnValue('other' as any);
+    mockDetectMode.mockReturnValue('other');
 
     const result = await sendMessage({ type: 'bridge-command', command: 'foo' });
     expect(result.isError).toBe(true);
@@ -747,7 +780,7 @@ describe("background.ts message handlers", () => {
       if (callCount === 1) return { jsExpr: 'page.title()' };
       return { error: 'Unknown command: badcmd' };
     });
-    mockDetectMode.mockReturnValue('other' as any);
+    mockDetectMode.mockReturnValue('other');
 
     const result = await sendMessage({
       type: 'bridge-command',
@@ -780,9 +813,9 @@ describe("background.ts message handlers", () => {
     mockDetectMode.mockReturnValue('js');
     await sendMessage({ type: 'bridge-command', command: '{a: 1}' });
 
-    const sendCmdCalls = (chrome.debugger.sendCommand as any).mock.calls;
-    const evalCall = sendCmdCalls.find((c: any) => c[1] === 'Runtime.evaluate');
-    expect(evalCall[2].expression).toBe('({a: 1})');
+    const sendCmdCalls = vi.mocked(chrome.debugger.sendCommand).mock.calls;
+    const evalCall = sendCmdCalls.find((c: unknown[]) => c[1] === 'Runtime.evaluate');
+    expect((evalCall![2] as Record<string, unknown>).expression).toBe('({a: 1})');
   });
 
   it("bridge-command passes non-brace expression directly", async () => {
@@ -793,29 +826,29 @@ describe("background.ts message handlers", () => {
     mockDetectMode.mockReturnValue('js');
     await sendMessage({ type: 'bridge-command', command: 'page.title();' });
 
-    const sendCmdCalls = (chrome.debugger.sendCommand as any).mock.calls;
-    const evalCall = sendCmdCalls.find((c: any) => c[1] === 'Runtime.evaluate');
-    expect(evalCall[2].expression).toBe('page.title();');
-    expect(evalCall[2].replMode).toBe(true);
+    const sendCmdCalls = vi.mocked(chrome.debugger.sendCommand).mock.calls;
+    const evalCall = sendCmdCalls.find((c: unknown[]) => c[1] === 'Runtime.evaluate');
+    expect((evalCall![2] as Record<string, unknown>).expression).toBe('page.title();');
+    expect((evalCall![2] as Record<string, unknown>).replMode).toBe(true);
   });
 
   // ─── Fire-and-forget .catch() callbacks ────────────────────────────────────
 
   it("ensureOffscreen catch is exercised when createDocument rejects", async () => {
     vi.resetModules();
-    (chrome.offscreen as any).hasDocument = vi.fn().mockResolvedValue(false);
-    (chrome.offscreen as any).createDocument = vi.fn().mockRejectedValue(new Error('fail'));
-    const listeners: any[] = [];
-    (chrome.runtime as any).onMessage = { addListener: vi.fn((fn: any) => listeners.push(fn)) };
-    (chrome.runtime as any).sendMessage = vi.fn().mockResolvedValue(undefined);
-    (chrome.storage as any).onChanged = { addListener: vi.fn() };
-    (chrome.action as any).onClicked = { addListener: vi.fn() };
-    (chrome.debugger as any).onDetach = { addListener: vi.fn() };
-    (chrome.sidePanel as any).setPanelBehavior = vi.fn().mockResolvedValue(undefined);
-    (chrome.tabs as any).onActivated = { addListener: vi.fn() };
-    (chrome.tabs as any).onUpdated = { addListener: vi.fn() };
-    (chrome.tabs as any).onRemoved = { addListener: vi.fn() };
-    (chrome.tabs as any).sendMessage = vi.fn().mockResolvedValue(undefined);
+    asMock(chrome.offscreen).hasDocument = vi.fn().mockResolvedValue(false);
+    asMock(chrome.offscreen).createDocument = vi.fn().mockRejectedValue(new Error('fail'));
+    const listeners: MessageListener[] = [];
+    asMock(chrome.runtime).onMessage = { addListener: vi.fn((fn: MessageListener) => listeners.push(fn)) };
+    asMock(chrome.runtime).sendMessage = vi.fn().mockResolvedValue(undefined);
+    asMock(chrome.storage).onChanged = { addListener: vi.fn() };
+    asMock(chrome.action).onClicked = { addListener: vi.fn() };
+    asMock(chrome.debugger).onDetach = { addListener: vi.fn() };
+    asMock(chrome.sidePanel).setPanelBehavior = vi.fn().mockResolvedValue(undefined);
+    asMock(chrome.tabs).onActivated = { addListener: vi.fn() };
+    asMock(chrome.tabs).onUpdated = { addListener: vi.fn() };
+    asMock(chrome.tabs).onRemoved = { addListener: vi.fn() };
+    asMock(chrome.tabs).sendMessage = vi.fn().mockResolvedValue(undefined);
 
     await import('../src/background.js');
     await new Promise(r => setTimeout(r, 20));
@@ -824,18 +857,18 @@ describe("background.ts message handlers", () => {
 
   it("setPanelBehavior catch is exercised when it rejects", async () => {
     vi.resetModules();
-    (chrome.offscreen as any).hasDocument = vi.fn().mockResolvedValue(true);
-    (chrome.sidePanel as any).setPanelBehavior = vi.fn().mockRejectedValue(new Error('fail'));
-    const listeners: any[] = [];
-    (chrome.runtime as any).onMessage = { addListener: vi.fn((fn: any) => listeners.push(fn)) };
-    (chrome.runtime as any).sendMessage = vi.fn().mockResolvedValue(undefined);
-    (chrome.storage as any).onChanged = { addListener: vi.fn() };
-    (chrome.action as any).onClicked = { addListener: vi.fn() };
-    (chrome.debugger as any).onDetach = { addListener: vi.fn() };
-    (chrome.tabs as any).onActivated = { addListener: vi.fn() };
-    (chrome.tabs as any).onUpdated = { addListener: vi.fn() };
-    (chrome.tabs as any).onRemoved = { addListener: vi.fn() };
-    (chrome.tabs as any).sendMessage = vi.fn().mockResolvedValue(undefined);
+    asMock(chrome.offscreen).hasDocument = vi.fn().mockResolvedValue(true);
+    asMock(chrome.sidePanel).setPanelBehavior = vi.fn().mockRejectedValue(new Error('fail'));
+    const listeners: MessageListener[] = [];
+    asMock(chrome.runtime).onMessage = { addListener: vi.fn((fn: MessageListener) => listeners.push(fn)) };
+    asMock(chrome.runtime).sendMessage = vi.fn().mockResolvedValue(undefined);
+    asMock(chrome.storage).onChanged = { addListener: vi.fn() };
+    asMock(chrome.action).onClicked = { addListener: vi.fn() };
+    asMock(chrome.debugger).onDetach = { addListener: vi.fn() };
+    asMock(chrome.tabs).onActivated = { addListener: vi.fn() };
+    asMock(chrome.tabs).onUpdated = { addListener: vi.fn() };
+    asMock(chrome.tabs).onRemoved = { addListener: vi.fn() };
+    asMock(chrome.tabs).sendMessage = vi.fn().mockResolvedValue(undefined);
 
     await import('../src/background.js');
     await new Promise(r => setTimeout(r, 20));
@@ -844,19 +877,19 @@ describe("background.ts message handlers", () => {
   it("loadSettings catch is exercised when it rejects", async () => {
     vi.resetModules();
     const { loadSettings } = await import('../src/panel/lib/settings');
-    (loadSettings as any).mockImplementation(() => Promise.reject(new Error('fail')));
+    (loadSettings as ReturnType<typeof vi.fn>).mockImplementation(() => Promise.reject(new Error('fail')));
 
-    (chrome.offscreen as any).hasDocument = vi.fn().mockResolvedValue(true);
-    (chrome.sidePanel as any).setPanelBehavior = vi.fn().mockResolvedValue(undefined);
-    const listeners: any[] = [];
-    (chrome.runtime as any).onMessage = { addListener: vi.fn((fn: any) => listeners.push(fn)) };
-    (chrome.runtime as any).sendMessage = vi.fn().mockResolvedValue(undefined);
-    (chrome.storage as any).onChanged = { addListener: vi.fn() };
-    (chrome.action as any).onClicked = { addListener: vi.fn() };
-    (chrome.debugger as any).onDetach = { addListener: vi.fn() };
-    (chrome.tabs as any).onActivated = { addListener: vi.fn() };
-    (chrome.tabs as any).onUpdated = { addListener: vi.fn() };
-    (chrome.tabs as any).onRemoved = { addListener: vi.fn() };
+    asMock(chrome.offscreen).hasDocument = vi.fn().mockResolvedValue(true);
+    asMock(chrome.sidePanel).setPanelBehavior = vi.fn().mockResolvedValue(undefined);
+    const listeners: MessageListener[] = [];
+    asMock(chrome.runtime).onMessage = { addListener: vi.fn((fn: MessageListener) => listeners.push(fn)) };
+    asMock(chrome.runtime).sendMessage = vi.fn().mockResolvedValue(undefined);
+    asMock(chrome.storage).onChanged = { addListener: vi.fn() };
+    asMock(chrome.action).onClicked = { addListener: vi.fn() };
+    asMock(chrome.debugger).onDetach = { addListener: vi.fn() };
+    asMock(chrome.tabs).onActivated = { addListener: vi.fn() };
+    asMock(chrome.tabs).onUpdated = { addListener: vi.fn() };
+    asMock(chrome.tabs).onRemoved = { addListener: vi.fn() };
 
     vi.resetModules();
     await import('../src/background.js');
@@ -864,7 +897,7 @@ describe("background.ts message handlers", () => {
   });
 
   it("storage onChanged bridgePort catch is exercised when sendMessage rejects", async () => {
-    (chrome.runtime as any).sendMessage = vi.fn().mockRejectedValue(new Error('no receiver'));
+    asMock(chrome.runtime).sendMessage = vi.fn().mockRejectedValue(new Error('no receiver'));
     onStorageChanged({ bridgePort: { newValue: 9999 } }, 'local');
     await new Promise(r => setTimeout(r, 10));
     // The .catch(() => {}) should swallow the rejection
@@ -882,13 +915,13 @@ describe("background.ts message handlers", () => {
 
   it("record-stop is safe when no recording is active", async () => {
     const result = await sendMessage({ type: 'record-stop' });
-    expect((chrome.tabs as any).sendMessage).not.toHaveBeenCalled();
+    expect(asMock(chrome.tabs).sendMessage).not.toHaveBeenCalled();
     expect(result).toEqual({ ok: true });
   });
 
   it("record-stop swallows sendMessage errors", async () => {
     await sendMessage({ type: 'record-start' });
-    (chrome.tabs as any).sendMessage = vi.fn().mockRejectedValue(new Error('tab closed'));
+    asMock(chrome.tabs).sendMessage = vi.fn().mockRejectedValue(new Error('tab closed'));
     const result = await sendMessage({ type: 'record-stop' });
     expect(result).toEqual({ ok: true });
   });
@@ -929,24 +962,24 @@ describe("background.ts message handlers", () => {
     setupDebuggerMocks('sw-1');
 
     // Make sendCommand throw with a non-Error object
-    (chrome.debugger as any).sendCommand = vi.fn((_t: any, _method: string, _p: any, cb: any) => {
-      (chrome.runtime as any).lastError = { message: '' };
+    asMock(chrome.debugger).sendCommand = vi.fn((_t: unknown, _method: string, _p: unknown, cb: DebuggerCallback) => {
+      asMock(chrome.runtime).lastError = { message: '' };
       cb(undefined);
-      delete (chrome.runtime as any).lastError;
+      delete asMock(chrome.runtime).lastError;
     });
     // Need to clear selfTargetId first so ensureSelfAttached runs
     onDebuggerDetach({ targetId: 'sw-1' });
     setupDebuggerMocks('sw-2');
     // After re-attach, make the EVAL sendCommand fail with empty message
     let callIdx = 0;
-    (chrome.debugger as any).sendCommand = vi.fn((_t: any, method: string, _p: any, cb: any) => {
+    asMock(chrome.debugger).sendCommand = vi.fn((_t: unknown, method: string, _p: unknown, cb: DebuggerCallback) => {
       if (method === 'Runtime.enable') { cb(); return; }
       callIdx++;
       if (callIdx === 1) {
         // This is the eval sendCommand — trigger lastError with empty message
-        (chrome.runtime as any).lastError = { message: '' };
+        asMock(chrome.runtime).lastError = { message: '' };
         cb(undefined);
-        delete (chrome.runtime as any).lastError;
+        delete asMock(chrome.runtime).lastError;
       }
     });
     const result = await sendMessage({ type: 'bridge-command', command: 'snapshot' });
@@ -966,16 +999,16 @@ describe("background.ts message handlers", () => {
 
   it("bridge-command handles already-attached error with undefined message", async () => {
     await sendMessage({ type: 'attach', tabId: 42 });
-    (chrome.debugger as any).getTargets = vi.fn((cb: any) => cb([
+    asMock(chrome.debugger).getTargets = vi.fn((cb: DebuggerCallback) => cb([
       { type: 'worker', url: `chrome-extension://${chrome.runtime.id}/background.js`, id: 'sw-1' },
     ]));
-    (chrome.debugger as any).attach = vi.fn((_t: any, _v: string, cb: any) => {
+    asMock(chrome.debugger).attach = vi.fn((_t: unknown, _v: string, cb: DebuggerCallback) => {
       // lastError without message property → ?? '' → doesn't match /already attached/
-      (chrome.runtime as any).lastError = {};
+      asMock(chrome.runtime).lastError = {};
       cb();
-      delete (chrome.runtime as any).lastError;
+      delete asMock(chrome.runtime).lastError;
     });
-    (chrome.debugger as any).onDetach = { addListener: vi.fn() };
+    asMock(chrome.debugger).onDetach = { addListener: vi.fn() };
 
     const result = await sendMessage({ type: 'bridge-command', command: 'snapshot' });
     expect(result.isError).toBe(true);
@@ -1000,7 +1033,7 @@ describe("background.ts message handlers", () => {
     setupDebuggerMocks('sw-1');
 
     // Make ensureSelfAttached throw a non-Error value
-    (chrome.debugger as any).getTargets = vi.fn((cb: any) => cb([]));
+    asMock(chrome.debugger).getTargets = vi.fn((cb: DebuggerCallback) => cb([]));
 
     const result = await sendMessage({ type: 'bridge-command', command: 'snapshot' });
     expect(result.isError).toBe(true);
@@ -1037,14 +1070,14 @@ describe("background.ts message handlers", () => {
 
   it("bridge-command catch falls back to String(e) when error has no message prop", async () => {
     await sendMessage({ type: 'attach', tabId: 42 });
-    (chrome.debugger as any).getTargets = vi.fn((cb: any) => cb([
+    asMock(chrome.debugger).getTargets = vi.fn((cb: DebuggerCallback) => cb([
       { type: 'worker', url: `chrome-extension://${chrome.runtime.id}/background.js`, id: 'sw-1' },
     ]));
     // attach callback throws a non-Error (string)
-    (chrome.debugger as any).attach = vi.fn((_t: any, _v: string, _cb: any) => {
+    asMock(chrome.debugger).attach = vi.fn((_t: unknown, _v: string, _cb: DebuggerCallback) => {
       throw 'raw string error';
     });
-    (chrome.debugger as any).onDetach = { addListener: vi.fn() };
+    asMock(chrome.debugger).onDetach = { addListener: vi.fn() };
 
     const result = await sendMessage({ type: 'bridge-command', command: 'snapshot' });
     expect(result.isError).toBe(true);
@@ -1067,7 +1100,7 @@ describe("background.ts message handlers", () => {
   it("bridge-command formats object falling back to String when JSON.stringify fails", async () => {
     await sendMessage({ type: 'attach', tabId: 42 });
     // Create a circular object that JSON.stringify can't handle
-    const circular: any = {};
+    const circular: Record<string, unknown> = {};
     circular.self = circular;
     setupDebuggerMocks('sw-1', { result: { type: 'function', description: circular } });
 
@@ -1081,8 +1114,8 @@ describe("background.ts message handlers", () => {
   it("bridge-command executeBridgeExpr catch uses String(e) for non-Error throw", async () => {
     await sendMessage({ type: 'attach', tabId: 42 });
     // Make ensureSelfAttached throw a non-Error (string)
-    (chrome.debugger as any).getTargets = vi.fn(() => { throw 'getTargets failed'; });
-    (chrome.debugger as any).onDetach = { addListener: vi.fn() };
+    asMock(chrome.debugger).getTargets = vi.fn(() => { throw 'getTargets failed'; });
+    asMock(chrome.debugger).onDetach = { addListener: vi.fn() };
 
     const result = await sendMessage({ type: 'bridge-command', command: 'snapshot' });
     expect(result.isError).toBe(true);
@@ -1111,7 +1144,7 @@ describe("background.ts message handlers", () => {
     onTabRemoved(42);
     // record-stop should not try to sendMessage (recordingTabId was cleared)
     const result = await sendMessage({ type: 'record-stop' });
-    expect((chrome.tabs as any).sendMessage).not.toHaveBeenCalledWith(42, { type: 'record-stop' });
+    expect(asMock(chrome.tabs).sendMessage).not.toHaveBeenCalledWith(42, { type: 'record-stop' });
     expect(result).toEqual({ ok: true });
   });
 
@@ -1137,7 +1170,7 @@ describe("background.ts message handlers", () => {
 
     // First call returns TargetClosedError, second succeeds
     let callCount = 0;
-    (chrome.debugger as any).sendCommand = vi.fn((_t: any, method: string, _p: any, cb: any) => {
+    asMock(chrome.debugger).sendCommand = vi.fn((_t: unknown, method: string, _p: unknown, cb: DebuggerCallback) => {
       if (method === 'Runtime.enable') { cb(); return; }
       callCount++;
       if (callCount === 1) {
@@ -1164,7 +1197,7 @@ describe("background.ts message handlers", () => {
 
     // First command takes 50ms, second is instant
     let callCount = 0;
-    (chrome.debugger as any).sendCommand = vi.fn((_t: any, method: string, _p: any, cb: any) => {
+    asMock(chrome.debugger).sendCommand = vi.fn((_t: unknown, method: string, _p: unknown, cb: DebuggerCallback) => {
       if (method === 'Runtime.enable') { cb(); return; }
       callCount++;
       const idx = callCount;
@@ -1195,11 +1228,11 @@ describe("background.ts message handlers", () => {
 
     // Track eval calls: first returns command result, second returns snapshot
     let evalCount = 0;
-    (chrome.debugger as any).getTargets = vi.fn((cb: any) => cb([
+    asMock(chrome.debugger).getTargets = vi.fn((cb: DebuggerCallback) => cb([
       { type: 'worker', url: `chrome-extension://${chrome.runtime.id}/background.js`, id: 'sw-1' },
     ]));
-    (chrome.debugger as any).attach = vi.fn((_t: any, _v: string, cb: any) => cb());
-    (chrome.debugger as any).sendCommand = vi.fn((_t: any, method: string, _p: any, cb: any) => {
+    asMock(chrome.debugger).attach = vi.fn((_t: unknown, _v: string, cb: DebuggerCallback) => cb());
+    asMock(chrome.debugger).sendCommand = vi.fn((_t: unknown, method: string, _p: unknown, cb: DebuggerCallback) => {
       if (method === 'Runtime.enable') { cb(); return; }
       evalCount++;
       if (evalCount === 1) {
@@ -1210,7 +1243,7 @@ describe("background.ts message handlers", () => {
         cb({ result: { type: 'string', value: '- heading "Hello" [ref=e1]' } });
       }
     });
-    (chrome.debugger as any).onDetach = { addListener: vi.fn() };
+    asMock(chrome.debugger).onDetach = { addListener: vi.fn() };
 
     // parseReplCommand returns jsExpr for both calls
     mockParseReplCommand.mockReturnValue({ jsExpr: 'page.title()' });
@@ -1281,11 +1314,11 @@ describe("background.ts message handlers", () => {
     await sendMessage({ type: 'attach', tabId: 42 });
 
     let evalCount = 0;
-    (chrome.debugger as any).getTargets = vi.fn((cb: any) => cb([
+    asMock(chrome.debugger).getTargets = vi.fn((cb: DebuggerCallback) => cb([
       { type: 'worker', url: `chrome-extension://${chrome.runtime.id}/background.js`, id: 'sw-1' },
     ]));
-    (chrome.debugger as any).attach = vi.fn((_t: any, _v: string, cb: any) => cb());
-    (chrome.debugger as any).sendCommand = vi.fn((_t: any, method: string, _p: any, cb: any) => {
+    asMock(chrome.debugger).attach = vi.fn((_t: unknown, _v: string, cb: DebuggerCallback) => cb());
+    asMock(chrome.debugger).sendCommand = vi.fn((_t: unknown, method: string, _p: unknown, cb: DebuggerCallback) => {
       if (method === 'Runtime.enable') { cb(); return; }
       evalCount++;
       if (evalCount === 1) {
@@ -1296,7 +1329,7 @@ describe("background.ts message handlers", () => {
         cb({ result: { type: 'string', value: '- button "OK" [ref=e2]' } });
       }
     });
-    (chrome.debugger as any).onDetach = { addListener: vi.fn() };
+    asMock(chrome.debugger).onDetach = { addListener: vi.fn() };
     mockParseReplCommand.mockReturnValue({ jsExpr: 'page.title()' });
 
     const result = await sendMessage({
@@ -1316,11 +1349,11 @@ describe("background.ts message handlers", () => {
     await sendMessage({ type: 'attach', tabId: 42 });
 
     let evalCount = 0;
-    (chrome.debugger as any).getTargets = vi.fn((cb: any) => cb([
+    asMock(chrome.debugger).getTargets = vi.fn((cb: DebuggerCallback) => cb([
       { type: 'worker', url: `chrome-extension://${chrome.runtime.id}/background.js`, id: 'sw-1' },
     ]));
-    (chrome.debugger as any).attach = vi.fn((_t: any, _v: string, cb: any) => cb());
-    (chrome.debugger as any).sendCommand = vi.fn((_t: any, method: string, _p: any, cb: any) => {
+    asMock(chrome.debugger).attach = vi.fn((_t: unknown, _v: string, cb: DebuggerCallback) => cb());
+    asMock(chrome.debugger).sendCommand = vi.fn((_t: unknown, method: string, _p: unknown, cb: DebuggerCallback) => {
       if (method === 'Runtime.enable') { cb(); return; }
       evalCount++;
       if (evalCount === 1) {
@@ -1330,7 +1363,7 @@ describe("background.ts message handlers", () => {
         cb({ exceptionDetails: { exception: { description: 'Snapshot error' } } });
       }
     });
-    (chrome.debugger as any).onDetach = { addListener: vi.fn() };
+    asMock(chrome.debugger).onDetach = { addListener: vi.fn() };
     mockParseReplCommand.mockReturnValue({ jsExpr: 'page.title()' });
 
     const result = await sendMessage({

--- a/packages/extension/test/components/CodeMirrorEditorPane.browser.test.tsx
+++ b/packages/extension/test/components/CodeMirrorEditorPane.browser.test.tsx
@@ -16,6 +16,7 @@ describe('CodeMirrorEditorPane component tests', () => {
                     editorMode={state.editorMode}
                     currentRunLine={state.currentRunLine}
                     lineResults={state.lineResults}
+                    inlineValues={new Map()}
                     dispatch={dispatch}
                 />
             </div>

--- a/packages/extension/test/components/PreferencesForm.browser.test.tsx
+++ b/packages/extension/test/components/PreferencesForm.browser.test.tsx
@@ -7,8 +7,7 @@ const mockStoreSettings = vi.fn();
 
 vi.mock('../../src/panel/lib/settings', () => ({
     loadSettings: () => mockLoadSettings(),
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    storeSettings: (...args: any[]) => mockStoreSettings(...args),
+    storeSettings: (...args: unknown[]) => mockStoreSettings(...args),
 }));
 
 import PreferencesForm from '../../src/preferences/PreferencesForm';

--- a/packages/extension/test/components/Toolbar.browser.test.tsx
+++ b/packages/extension/test/components/Toolbar.browser.test.tsx
@@ -55,6 +55,7 @@ function renderToolbar(overrides: Partial<Parameters<typeof Toolbar>[0]> = {}) {
     breakPoints={new Set()}
     dispatch={vi.fn()}
     editorRef={editorRef}
+    onModeSwitch={vi.fn()}
     {...overrides}
   />);
 }

--- a/packages/extension/test/components/Toolbar.browser.test.tsx
+++ b/packages/extension/test/components/Toolbar.browser.test.tsx
@@ -1,9 +1,9 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render } from 'vitest-browser-react';
 import { userEvent } from 'vitest/browser';
 
 import Toolbar from '@/components/Toolbar';
+import type { EditorHandle } from '@/components/CodeMirrorEditorPane';
 
 // ─── Bridge mock ──────────────────────────────────────────────────────────────
 
@@ -166,7 +166,7 @@ describe('Toolbar component tests', () => {
       name: 'saved.pw',
       createWritable: vi.fn().mockResolvedValue(mockWritable),
     };
-    window.showSaveFilePicker = vi.fn().mockResolvedValue(mockFileHandle) as any;
+    window.showSaveFilePicker = vi.fn().mockResolvedValue(mockFileHandle) as typeof window.showSaveFilePicker;
 
     const saveBtn = screen.container.querySelector('#save-btn') as HTMLButtonElement;
     saveBtn.click();
@@ -181,7 +181,7 @@ describe('Toolbar component tests', () => {
     const dispatch = vi.fn();
     const screen = await renderToolbar({ editorContent: 'some content', dispatch });
 
-    window.showSaveFilePicker = vi.fn().mockRejectedValue(new Error('Disk full')) as any;
+    window.showSaveFilePicker = vi.fn().mockRejectedValue(new Error('Disk full')) as typeof window.showSaveFilePicker;
 
     const saveBtn = screen.container.querySelector('#save-btn') as HTMLButtonElement;
     saveBtn.click();
@@ -200,7 +200,7 @@ describe('Toolbar component tests', () => {
 
     const abortError = new Error('User cancelled');
     abortError.name = 'AbortError';
-    window.showSaveFilePicker = vi.fn().mockRejectedValue(abortError) as any;
+    window.showSaveFilePicker = vi.fn().mockRejectedValue(abortError) as typeof window.showSaveFilePicker;
 
     dispatch.mockClear();
     const saveBtn = screen.container.querySelector('#save-btn') as HTMLButtonElement;
@@ -423,7 +423,7 @@ describe('Toolbar component tests', () => {
   });
 
   it('should not record when chrome.tabs.query is unavailable', async () => {
-    window.chrome.tabs.query = null as any;
+    (window.chrome.tabs as unknown as Record<string, unknown>).query = null;
 
     const screen = await renderToolbar();
     await screen.getByRole('button', { name: 'Record' }).click();
@@ -454,13 +454,14 @@ describe('Toolbar component tests', () => {
     const editorRef = { current: { insertAtCursor, replaceLastInsert: vi.fn() } };
 
     // Set up chrome.runtime.onMessage to capture the listener
-    const listeners: ((msg: any) => void)[] = [];
+    type MsgListener = (msg: Record<string, unknown>) => void;
+    const listeners: MsgListener[] = [];
     window.chrome.runtime.onMessage = {
-      addListener: vi.fn((fn: any) => listeners.push(fn)),
+      addListener: vi.fn((fn: MsgListener) => listeners.push(fn)),
       removeListener: vi.fn(),
-    } as any;
+    } as unknown as typeof chrome.runtime.onMessage;
 
-    await renderToolbar({ editorRef: editorRef as any });
+    await renderToolbar({ editorRef: editorRef as unknown as React.RefObject<EditorHandle | null> });
 
     // Simulate a recorded-action message from content script
     for (const listener of listeners) {
@@ -480,7 +481,7 @@ describe('Toolbar component tests', () => {
     const insertAtCursor = vi.fn();
     const editorRef = { current: { insertAtCursor, replaceLastInsert: vi.fn() } };
 
-    const screen = await renderToolbar({ editorContent: '', editorRef: editorRef as any });
+    const screen = await renderToolbar({ editorContent: '', editorRef: editorRef as unknown as React.RefObject<EditorHandle | null> });
     await screen.getByRole('button', { name: 'Record' }).click();
 
     await vi.waitFor(() => {
@@ -493,7 +494,7 @@ describe('Toolbar component tests', () => {
     const insertAtCursor = vi.fn();
     const editorRef = { current: { insertAtCursor, replaceLastInsert: vi.fn() } };
 
-    const screen = await renderToolbar({ editorContent: '# this is a comment\n\n# another', editorMode: 'pw', editorRef: editorRef as any });
+    const screen = await renderToolbar({ editorContent: '# this is a comment\n\n# another', editorMode: 'pw', editorRef: editorRef as unknown as React.RefObject<EditorHandle | null> });
     await screen.getByRole('button', { name: 'Record' }).click();
 
     await vi.waitFor(() => {
@@ -506,7 +507,7 @@ describe('Toolbar component tests', () => {
     const insertAtCursor = vi.fn();
     const editorRef = { current: { insertAtCursor, replaceLastInsert: vi.fn() } };
 
-    const screen = await renderToolbar({ editorContent: '// comment\n/* block */', editorMode: 'js', editorRef: editorRef as any });
+    const screen = await renderToolbar({ editorContent: '// comment\n/* block */', editorMode: 'js', editorRef: editorRef as unknown as React.RefObject<EditorHandle | null> });
     await screen.getByRole('button', { name: 'Record' }).click();
 
     await vi.waitFor(() => {
@@ -519,7 +520,7 @@ describe('Toolbar component tests', () => {
     const insertAtCursor = vi.fn();
     const editorRef = { current: { insertAtCursor, replaceLastInsert: vi.fn() } };
 
-    const screen = await renderToolbar({ editorContent: 'click "Submit"', editorMode: 'pw', editorRef: editorRef as any });
+    const screen = await renderToolbar({ editorContent: 'click "Submit"', editorMode: 'pw', editorRef: editorRef as unknown as React.RefObject<EditorHandle | null> });
     await screen.getByRole('button', { name: 'Record' }).click();
 
     await vi.waitFor(() => {
@@ -533,7 +534,7 @@ describe('Toolbar component tests', () => {
     const insertAtCursor = vi.fn();
     const editorRef = { current: { insertAtCursor, replaceLastInsert: vi.fn() } };
 
-    const screen = await renderToolbar({ editorContent: 'document.title', editorMode: 'js', editorRef: editorRef as any });
+    const screen = await renderToolbar({ editorContent: 'document.title', editorMode: 'js', editorRef: editorRef as unknown as React.RefObject<EditorHandle | null> });
     await screen.getByRole('button', { name: 'Record' }).click();
 
     await vi.waitFor(() => {
@@ -903,7 +904,7 @@ describe('Toolbar component tests', () => {
 
       const mockWritable = { write: vi.fn(), close: vi.fn() };
       const mockFileHandle = { name: 'commands.js', createWritable: vi.fn().mockResolvedValue(mockWritable) };
-      window.showSaveFilePicker = vi.fn().mockResolvedValue(mockFileHandle) as any;
+      window.showSaveFilePicker = vi.fn().mockResolvedValue(mockFileHandle) as typeof window.showSaveFilePicker;
 
       const saveBtn = screen.container.querySelector('#save-btn') as HTMLButtonElement;
       saveBtn.click();
@@ -920,7 +921,7 @@ describe('Toolbar component tests', () => {
 
       const mockWritable = { write: vi.fn(), close: vi.fn() };
       const mockFileHandle = { name: 'script.js', createWritable: vi.fn().mockResolvedValue(mockWritable) };
-      window.showSaveFilePicker = vi.fn().mockResolvedValue(mockFileHandle) as any;
+      window.showSaveFilePicker = vi.fn().mockResolvedValue(mockFileHandle) as typeof window.showSaveFilePicker;
 
       const saveBtn = screen.container.querySelector('#save-btn') as HTMLButtonElement;
       saveBtn.click();

--- a/packages/extension/test/content/locator.test.ts
+++ b/packages/extension/test/content/locator.test.ts
@@ -296,9 +296,9 @@ describe('locator', () => {
             document.body.innerHTML = '<button>Delete</button><button>Delete</button><button>Delete</button>';
             const buttons = document.querySelectorAll('button');
             // Stub checkVisibility: only first button visible (like TodoMVC hover-revealed delete)
-            (buttons[0] as any).checkVisibility = () => true;
-            (buttons[1] as any).checkVisibility = () => false;
-            (buttons[2] as any).checkVisibility = () => false;
+            (buttons[0] as unknown as Record<string, unknown>).checkVisibility = () => true;
+            (buttons[1] as unknown as Record<string, unknown>).checkVisibility = () => false;
+            (buttons[2] as unknown as Record<string, unknown>).checkVisibility = () => false;
             const matches = findByRoleAndName('button', 'Delete');
             expect(matches).toHaveLength(1);
             expect(matches[0]).toBe(buttons[0]);
@@ -313,9 +313,9 @@ describe('locator', () => {
         it('includes hidden elements (ignores checkVisibility)', () => {
             document.body.innerHTML = '<button>Delete</button><button>Delete</button><button>Delete</button>';
             const buttons = document.querySelectorAll('button');
-            (buttons[0] as any).checkVisibility = () => true;
-            (buttons[1] as any).checkVisibility = () => false;
-            (buttons[2] as any).checkVisibility = () => false;
+            (buttons[0] as unknown as Record<string, unknown>).checkVisibility = () => true;
+            (buttons[1] as unknown as Record<string, unknown>).checkVisibility = () => false;
+            (buttons[2] as unknown as Record<string, unknown>).checkVisibility = () => false;
             // findByRoleAndName returns only visible
             expect(findByRoleAndName('button', 'Delete')).toHaveLength(1);
             // findAllByRoleAndName returns all regardless of visibility

--- a/packages/extension/test/content/recorder.test.ts
+++ b/packages/extension/test/content/recorder.test.ts
@@ -71,7 +71,7 @@ describe('recorder', () => {
         it('sends recorded-action for button click', () => {
             document.body.innerHTML = '<button>Submit</button>';
             const btn = document.querySelector('button')!;
-            onClickCapture(new MouseEvent('click', { bubbles: true }) as any);
+            onClickCapture(new MouseEvent('click', { bubbles: true }));
             // No target set via constructor — need to dispatch on element
             btn.dispatchEvent(new MouseEvent('click', { bubbles: true }));
             // The handler reads e.target, so dispatch on the element

--- a/packages/extension/test/lib/bridge.test.ts
+++ b/packages/extension/test/lib/bridge.test.ts
@@ -17,8 +17,8 @@ vi.mock('@/lib/settings', () => ({
 import { loadSettings } from '@/lib/settings';
 
 vi.mock('@/lib/commands', async (importOriginal) => {
-    const actual = await importOriginal() as any;
-    return { ...actual, parseReplCommand: vi.fn(actual.parseReplCommand) };
+    const actual = await importOriginal() as Record<string, unknown>;
+    return { ...actual, parseReplCommand: vi.fn(actual.parseReplCommand as ((...args: unknown[]) => unknown)) };
 });
 
 import { swDebugEval, swCallFunctionOn } from '@/lib/sw-debugger';

--- a/packages/extension/test/lib/cdpToSerialized.test.ts
+++ b/packages/extension/test/lib/cdpToSerialized.test.ts
@@ -393,7 +393,7 @@ describe('fromCdpRemoteObject', () => {
             type: 'object',
             preview: { type: 'object', properties: [{ name: 'x', type: 'undefined' }] },
         };
-        const result = fromCdpRemoteObject(obj) as any;
+        const result = fromCdpRemoteObject(obj) as unknown as Record<string, Record<string, unknown>>;
         expect(result.props.x).toEqual({ __type: 'undefined' });
     });
 
@@ -402,7 +402,7 @@ describe('fromCdpRemoteObject', () => {
             type: 'object',
             preview: { type: 'object', properties: [{ name: 'x', type: 'object', subtype: 'null', value: 'null' }] },
         };
-        const result = fromCdpRemoteObject(obj) as any;
+        const result = fromCdpRemoteObject(obj) as unknown as Record<string, Record<string, unknown>>;
         expect(result.props.x).toEqual({ __type: 'null' });
     });
 
@@ -411,7 +411,7 @@ describe('fromCdpRemoteObject', () => {
             type: 'object',
             preview: { type: 'object', properties: [{ name: 'x', type: 'boolean', value: 'true' }] },
         };
-        const result = fromCdpRemoteObject(obj) as any;
+        const result = fromCdpRemoteObject(obj) as unknown as Record<string, Record<string, unknown>>;
         expect(result.props.x).toEqual({ __type: 'boolean', v: true });
     });
 
@@ -420,7 +420,7 @@ describe('fromCdpRemoteObject', () => {
             type: 'object',
             preview: { type: 'object', properties: [{ name: 'fn', type: 'function' }] },
         };
-        const result = fromCdpRemoteObject(obj) as any;
+        const result = fromCdpRemoteObject(obj) as unknown as Record<string, Record<string, unknown>>;
         expect(result.props.fn).toEqual({ __type: 'function', name: 'fn' });
     });
 
@@ -429,7 +429,7 @@ describe('fromCdpRemoteObject', () => {
             type: 'object',
             preview: { type: 'object', properties: [{ name: 'child', type: 'object', value: 'MyClass' }] },
         };
-        const result = fromCdpRemoteObject(obj) as any;
+        const result = fromCdpRemoteObject(obj) as unknown as Record<string, Record<string, unknown>>;
         expect(result.props.child).toEqual({ __type: 'ref', cls: 'MyClass' });
     });
 });

--- a/packages/extension/test/lib/cm-input-setup.test.ts
+++ b/packages/extension/test/lib/cm-input-setup.test.ts
@@ -2,8 +2,8 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 // Mock CodeMirror modules
 vi.mock('@codemirror/view', () => ({
-    EditorView: { theme: (spec: any) => spec },
-    keymap: { of: (bindings: any[]) => ({ bindings }) },
+    EditorView: { theme: (spec: unknown) => spec },
+    keymap: { of: (bindings: unknown[]) => ({ bindings }) },
     placeholder: (text: string) => ({ placeholder: text }),
     drawSelection: () => ({}),
 }));
@@ -15,7 +15,7 @@ vi.mock('@codemirror/commands', () => ({
 
 let completionStatusValue: string | null = null;
 vi.mock('@codemirror/autocomplete', () => ({
-    autocompletion: (opts: any) => opts,
+    autocompletion: (opts: unknown) => opts,
     acceptCompletion: 'acceptCompletion',
     completionStatus: () => completionStatusValue,
 }));
@@ -39,12 +39,12 @@ import { inputExtensions } from '@/lib/cm-input-setup';
 
 /** Create a minimal mock EditorView for keymap handler testing */
 function mockView(doc = '') {
-    const dispatched: any[] = [];
+    const dispatched: Array<Record<string, unknown>> = [];
     return {
         state: {
             doc: { toString: () => doc, length: doc.length },
         },
-        dispatch: (tr: any) => dispatched.push(tr),
+        dispatch: (tr: Record<string, unknown>) => dispatched.push(tr),
         _dispatched: dispatched,
     };
 }
@@ -53,8 +53,8 @@ function mockView(doc = '') {
 function getBindings(onSubmit: (cmd: string) => void) {
     const exts = inputExtensions(onSubmit);
     // First item is the custom keymap: { bindings: [...] }
-    const km = exts[0] as any;
-    return km.bindings as Array<{ key: string; run: (view: any) => boolean }>;
+    const km = exts[0] as unknown as { bindings: Array<{ key: string; run: (view: unknown) => boolean }> };
+    return km.bindings;
 }
 
 describe('cm-input-setup', () => {
@@ -135,7 +135,7 @@ describe('cm-input-setup', () => {
 
             expect(handled).toBe(true);
             expect(view._dispatched).toHaveLength(1);
-            expect(view._dispatched[0].changes.insert).toBe('snapshot');
+            expect((view._dispatched[0].changes as Record<string, unknown>).insert).toBe('snapshot');
         });
 
         it('does nothing when goUp returns undefined', () => {
@@ -173,7 +173,7 @@ describe('cm-input-setup', () => {
 
             expect(handled).toBe(true);
             expect(view._dispatched).toHaveLength(1);
-            expect(view._dispatched[0].changes.insert).toBe('goto url');
+            expect((view._dispatched[0].changes as Record<string, unknown>).insert).toBe('goto url');
         });
 
         it('replaces editor content with empty string from goDown', () => {
@@ -186,7 +186,7 @@ describe('cm-input-setup', () => {
 
             expect(handled).toBe(true);
             expect(view._dispatched).toHaveLength(1);
-            expect(view._dispatched[0].changes.insert).toBe('');
+            expect((view._dispatched[0].changes as Record<string, unknown>).insert).toBe('');
         });
 
         it('does nothing when goDown returns null/undefined', () => {

--- a/packages/extension/test/lib/commands.test.ts
+++ b/packages/extension/test/lib/commands.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeAll } from "vitest";
+import type { ParseResult } from '../../src/panel/lib/commands';
 
-let parseReplCommand: (input: string) => any;
+let parseReplCommand: (input: string) => ParseResult;
 
 beforeAll(async () => {
   const mod = await import("../../src/panel/lib/commands");

--- a/packages/extension/test/lib/page-scripts.test.ts
+++ b/packages/extension/test/lib/page-scripts.test.ts
@@ -20,8 +20,31 @@ import {
 
 // ─── Locator mock factory ─────────────────────────────────────────────────
 
-function createLocator(overrides: Record<string, any> = {}) {
-    const loc: any = {
+interface MockLocator {
+    count: ReturnType<typeof vi.fn>;
+    click: ReturnType<typeof vi.fn>;
+    fill: ReturnType<typeof vi.fn>;
+    check: ReturnType<typeof vi.fn>;
+    uncheck: ReturnType<typeof vi.fn>;
+    press: ReturnType<typeof vi.fn>;
+    selectOption: ReturnType<typeof vi.fn>;
+    highlight: ReturnType<typeof vi.fn>;
+    inputValue: ReturnType<typeof vi.fn>;
+    isVisible: ReturnType<typeof vi.fn>;
+    isChecked: ReturnType<typeof vi.fn>;
+    evaluate: ReturnType<typeof vi.fn>;
+    textContent: ReturnType<typeof vi.fn>;
+    filter: ReturnType<typeof vi.fn>;
+    first: ReturnType<typeof vi.fn>;
+    nth: ReturnType<typeof vi.fn>;
+    locator: ReturnType<typeof vi.fn>;
+    getByText: ReturnType<typeof vi.fn>;
+    getByRole: ReturnType<typeof vi.fn>;
+    [key: string]: ReturnType<typeof vi.fn>;
+}
+
+function createLocator(overrides: Record<string, unknown> = {}): MockLocator {
+    const loc: MockLocator = {
         count: vi.fn().mockResolvedValue(1),
         click: vi.fn().mockResolvedValue(undefined),
         fill: vi.fn().mockResolvedValue(undefined),
@@ -55,9 +78,31 @@ function createLocator(overrides: Record<string, any> = {}) {
 
 // ─── Page mock factory ────────────────────────────────────────────────────
 
-function createPage(overrides: Record<string, any> = {}) {
+interface MockPage {
+    getByText: ReturnType<typeof vi.fn>;
+    getByRole: ReturnType<typeof vi.fn>;
+    getByLabel: ReturnType<typeof vi.fn>;
+    getByPlaceholder: ReturnType<typeof vi.fn>;
+    locator: ReturnType<typeof vi.fn>;
+    title: ReturnType<typeof vi.fn>;
+    url: ReturnType<typeof vi.fn>;
+    goBack: ReturnType<typeof vi.fn>;
+    goForward: ReturnType<typeof vi.fn>;
+    goto: ReturnType<typeof vi.fn>;
+    reload: ReturnType<typeof vi.fn>;
+    waitForTimeout: ReturnType<typeof vi.fn>;
+    evaluate: ReturnType<typeof vi.fn>;
+    screenshot: ReturnType<typeof vi.fn>;
+    ariaSnapshot?: ReturnType<typeof vi.fn>;
+    _snapshotForAI?: ReturnType<typeof vi.fn>;
+    keyboard: { press: ReturnType<typeof vi.fn>; type: ReturnType<typeof vi.fn> };
+    context: ReturnType<typeof vi.fn>;
+    [key: string]: unknown;
+}
+
+function createPage(overrides: Record<string, unknown> = {}): MockPage {
     const defaultLocator = createLocator();
-    const page: any = {
+    const page: MockPage = {
         getByText: vi.fn().mockReturnValue(defaultLocator),
         getByRole: vi.fn().mockReturnValue(defaultLocator),
         getByLabel: vi.fn().mockReturnValue(defaultLocator),
@@ -300,7 +345,7 @@ describe('verifyInputValue', () => {
     it('checks radio group when no direct input found', async () => {
         // Mock document.querySelector so the evaluate closure actually runs
         const origDoc = globalThis.document;
-        globalThis.document = { querySelector: vi.fn().mockReturnValue({ textContent: '  Option A  ' }) } as any;
+        globalThis.document = { querySelector: vi.fn().mockReturnValue({ textContent: '  Option A  ' }) } as unknown as Document;
 
         const noLoc = createLocator({ count: vi.fn().mockResolvedValue(0) });
         const checkedRadio = createLocator({
@@ -323,7 +368,7 @@ describe('verifyInputValue', () => {
 
     it('throws when radio group value does not match', async () => {
         const origDoc = globalThis.document;
-        globalThis.document = { querySelector: vi.fn().mockReturnValue(null) } as any;
+        globalThis.document = { querySelector: vi.fn().mockReturnValue(null) } as unknown as Document;
 
         const noLoc = createLocator({ count: vi.fn().mockResolvedValue(0) });
         const checkedRadio = createLocator({
@@ -895,13 +940,13 @@ describe('localStorage', () => {
         removeItem: vi.fn((k: string) => { delete mockStore[k]; }),
         clear: vi.fn(() => { for (const k in mockStore) delete mockStore[k]; }),
         key: vi.fn((i: number) => Object.keys(mockStore)[i]),
-    } as any;
+    } as unknown as Storage;
 
     beforeEach(() => {
         origLS = globalThis.localStorage;
         globalThis.localStorage = mockLS;
         for (const k in mockStore) delete mockStore[k];
-        mockLS.length = 0;
+        (mockLS as Record<string, unknown>).length = 0;
     });
 
     afterEach(() => {
@@ -936,7 +981,7 @@ describe('localStorage', () => {
     it('list calls evaluate closure to iterate storage', async () => {
         mockStore['a'] = '1';
         mockStore['b'] = '2';
-        mockLS.length = 2;
+        (mockLS as Record<string, unknown>).length = 2;
         const page = createPage({ evaluate: vi.fn().mockImplementation(fn => Promise.resolve(fn())) });
         const result = await localStorageList(page);
         expect(JSON.parse(result)).toEqual({ a: '1', b: '2' });
@@ -953,13 +998,13 @@ describe('sessionStorage', () => {
         removeItem: vi.fn((k: string) => { delete mockStore[k]; }),
         clear: vi.fn(() => { for (const k in mockStore) delete mockStore[k]; }),
         key: vi.fn((i: number) => Object.keys(mockStore)[i]),
-    } as any;
+    } as unknown as Storage;
 
     beforeEach(() => {
         origSS = globalThis.sessionStorage;
         globalThis.sessionStorage = mockSS;
         for (const k in mockStore) delete mockStore[k];
-        mockSS.length = 0;
+        (mockSS as Record<string, unknown>).length = 0;
     });
 
     afterEach(() => {
@@ -993,7 +1038,7 @@ describe('sessionStorage', () => {
 
     it('list calls evaluate closure to iterate storage', async () => {
         mockStore['x'] = 'y';
-        mockSS.length = 1;
+        (mockSS as Record<string, unknown>).length = 1;
         const page = createPage({ evaluate: vi.fn().mockImplementation(fn => Promise.resolve(fn())) });
         const result = await sessionStorageList(page);
         expect(JSON.parse(result)).toEqual({ x: 'y' });
@@ -1041,9 +1086,15 @@ describe('cookies', () => {
 // ─── Tab operations ───────────────────────────────────────────────────────
 
 describe('tab operations', () => {
+    // Access the mock chrome object that we override per-test
+    const mockChromeObj = globalThis as unknown as Record<string, unknown>;
+    function mockChrome() {
+        return (mockChromeObj.chrome as Record<string, Record<string, ReturnType<typeof vi.fn>>>);
+    }
+
     beforeEach(() => {
-        (globalThis as any).activeTabId = 1;
-        (globalThis as any).chrome = {
+        mockChromeObj.activeTabId = 1;
+        mockChromeObj.chrome = {
             runtime: {
                 getURL: vi.fn((path: string) => `chrome-extension://test-id/${path}`),
             },
@@ -1057,7 +1108,7 @@ describe('tab operations', () => {
                 remove: vi.fn().mockResolvedValue(undefined),
             },
         };
-        (globalThis as any).attachToTab = vi.fn().mockResolvedValue({ ok: true, url: 'https://b.com' });
+        mockChromeObj.attachToTab = vi.fn().mockResolvedValue({ ok: true, url: 'https://b.com' });
     });
 
     it('tabList returns tab info with current marker', async () => {
@@ -1070,13 +1121,13 @@ describe('tab operations', () => {
 
     it('tabNew creates tab in same window', async () => {
         const result = await tabNew({}, 'https://new.com');
-        expect((globalThis as any).chrome.tabs.create).toHaveBeenCalledWith({ url: 'https://new.com', windowId: 10 });
+        expect(mockChrome().tabs.create).toHaveBeenCalledWith({ url: 'https://new.com', windowId: 10 });
         expect(result).toContain('https://new.com');
     });
 
     it('tabNew without URL', async () => {
         const result = await tabNew({}, undefined);
-        expect((globalThis as any).chrome.tabs.create).toHaveBeenCalledWith({
+        expect(mockChrome().tabs.create).toHaveBeenCalledWith({
             url: 'about:blank',
             windowId: 10,
         });
@@ -1085,13 +1136,13 @@ describe('tab operations', () => {
 
     it('tabClose closes tab by index', async () => {
         const result = await tabClose({}, 1);
-        expect((globalThis as any).chrome.tabs.remove).toHaveBeenCalledWith(2);
+        expect(mockChrome().tabs.remove).toHaveBeenCalledWith(2);
         expect(result).toContain('https://b.com');
     });
 
     it('tabClose closes current tab when no index', async () => {
         const result = await tabClose({}, undefined);
-        expect((globalThis as any).chrome.tabs.remove).toHaveBeenCalledWith(1);
+        expect(mockChrome().tabs.remove).toHaveBeenCalledWith(1);
         expect(result).toContain('https://a.com');
     });
 
@@ -1101,7 +1152,7 @@ describe('tab operations', () => {
 
     it('tabSelect attaches to tab by index', async () => {
         const result = await tabSelect({}, 1);
-        expect((globalThis as any).attachToTab).toHaveBeenCalledWith(2);
+        expect(mockChromeObj.attachToTab).toHaveBeenCalledWith(2);
         expect(result).toContain('Selected tab 1');
     });
 
@@ -1110,38 +1161,38 @@ describe('tab operations', () => {
     });
 
     it('tabSelect throws when attach fails', async () => {
-        (globalThis as any).attachToTab = vi.fn().mockResolvedValue({ ok: false, error: 'denied' });
+        mockChromeObj.attachToTab = vi.fn().mockResolvedValue({ ok: false, error: 'denied' });
         await expect(tabSelect({}, 0)).rejects.toThrow('denied');
     });
 
     it('tabList works without activeTabId', async () => {
-        (globalThis as any).activeTabId = undefined;
+        mockChromeObj.activeTabId = undefined;
         const result = await tabList({});
         const tabs = JSON.parse(result);
-        expect(tabs.every((t: any) => t.current === false)).toBe(true);
+        expect(tabs.every((t: Record<string, unknown>) => t.current === false)).toBe(true);
     });
 
     it('tabClose without activeTabId closes by index', async () => {
-        (globalThis as any).activeTabId = undefined;
+        mockChromeObj.activeTabId = undefined;
         const result = await tabClose({}, 0);
-        expect((globalThis as any).chrome.tabs.query).toHaveBeenCalledWith({});
+        expect(mockChrome().tabs.query).toHaveBeenCalledWith({});
         expect(result).toContain('https://a.com');
     });
 
     it('tabClose throws for current tab when no activeTabId', async () => {
-        (globalThis as any).activeTabId = undefined;
+        mockChromeObj.activeTabId = undefined;
         await expect(tabClose({}, undefined)).rejects.toThrow('Tab current not found');
     });
 
     it('tabSelect without activeTabId selects by index', async () => {
-        (globalThis as any).activeTabId = undefined;
+        mockChromeObj.activeTabId = undefined;
         const result = await tabSelect({}, 0);
-        expect((globalThis as any).chrome.tabs.query).toHaveBeenCalledWith({});
+        expect(mockChrome().tabs.query).toHaveBeenCalledWith({});
         expect(result).toContain('Selected tab 0');
     });
 
     it('tabClose handles tab with no url', async () => {
-        (globalThis as any).chrome.tabs.query = vi.fn().mockResolvedValue([
+        mockChrome().tabs.query = vi.fn().mockResolvedValue([
             { id: 10, title: 'No URL' },
         ]);
         const result = await tabClose({}, 0);
@@ -1149,18 +1200,18 @@ describe('tab operations', () => {
     });
 
     it('tabSelect handles attach with no url in response', async () => {
-        (globalThis as any).attachToTab = vi.fn().mockResolvedValue({ ok: true });
+        mockChromeObj.attachToTab = vi.fn().mockResolvedValue({ ok: true });
         const result = await tabSelect({}, 0);
         expect(result).toBe('Selected tab 0: ');
     });
 
     it('tabSelect throws with default error when no error message', async () => {
-        (globalThis as any).attachToTab = vi.fn().mockResolvedValue({ ok: false });
+        mockChromeObj.attachToTab = vi.fn().mockResolvedValue({ ok: false });
         await expect(tabSelect({}, 0)).rejects.toThrow('Attach failed');
     });
 
     it('tabList handles tabs with no title or url', async () => {
-        (globalThis as any).chrome.tabs.query = vi.fn().mockResolvedValue([
+        mockChrome().tabs.query = vi.fn().mockResolvedValue([
             { id: 1 },
         ]);
         const result = await tabList({});
@@ -1170,9 +1221,9 @@ describe('tab operations', () => {
     });
 
     it('tabNew without activeTabId', async () => {
-        (globalThis as any).activeTabId = undefined;
+        mockChromeObj.activeTabId = undefined;
         const result = await tabNew({}, 'https://new.com');
-        expect((globalThis as any).chrome.tabs.create).toHaveBeenCalledWith({ url: 'https://new.com' });
+        expect(mockChrome().tabs.create).toHaveBeenCalledWith({ url: 'https://new.com' });
         expect(result).toContain('https://new.com');
     });
 });

--- a/packages/extension/test/lib/pw-language.test.ts
+++ b/packages/extension/test/lib/pw-language.test.ts
@@ -1,11 +1,25 @@
 import { describe, it, expect, vi } from 'vitest';
 
 // Mock @codemirror/language to capture the token function passed to StreamLanguage.define
-let capturedParser: { startState: () => any; token: (stream: any, state: any) => string | null };
+interface StreamState { commandSeen: boolean }
+interface MockStream {
+    pos: number;
+    string: string;
+    start: number;
+    sol: () => boolean;
+    eol: () => boolean;
+    peek: () => string | undefined;
+    next: () => string | undefined;
+    eatSpace: () => boolean;
+    match: (pattern: RegExp | string, consume?: boolean) => boolean | RegExpMatchArray | null;
+    skipToEnd: () => void;
+}
+
+let capturedParser: { startState: () => StreamState; token: (stream: MockStream, state: StreamState) => string | null };
 
 vi.mock('@codemirror/language', () => ({
   StreamLanguage: {
-    define: (parser: any) => { capturedParser = parser; return { language: {} }; },
+    define: (parser: typeof capturedParser) => { capturedParser = parser; return { language: {} }; },
   },
   HighlightStyle: { define: () => ({}) },
   syntaxHighlighting: () => ({}),

--- a/packages/extension/test/lib/run.test.ts
+++ b/packages/extension/test/lib/run.test.ts
@@ -4,7 +4,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 const mockExecuteCommand = vi.fn();
 vi.mock('@/lib/bridge', () => ({
-    executeCommand: (...args: any[]) => mockExecuteCommand(...args),
+    executeCommand: (...args: unknown[]) => mockExecuteCommand(...args),
 }));
 
 const mockFilterResponse = vi.fn((text: string) => text);
@@ -38,13 +38,13 @@ const mockSwDebuggerDisable = vi.fn().mockResolvedValue(undefined);
 const mockSwDebugPause = vi.fn().mockResolvedValue(undefined);
 const mockOnDebugPaused = vi.fn();
 vi.mock('@/lib/sw-debugger', () => ({
-    swDebugEval: (...args: any[]) => mockSwDebugEval(...args),
-    swDebugEvalRaw: (...args: any[]) => mockSwDebugEvalRaw(...args),
-    swGetProperties: (...args: any[]) => mockSwGetProperties(...args),
-    swDebuggerEnable: (...args: any[]) => mockSwDebuggerEnable(...args),
-    swDebuggerDisable: (...args: any[]) => mockSwDebuggerDisable(...args),
-    swDebugPause: (...args: any[]) => mockSwDebugPause(...args),
-    onDebugPaused: (...args: any[]) => mockOnDebugPaused(...args),
+    swDebugEval: (...args: unknown[]) => mockSwDebugEval(...args),
+    swDebugEvalRaw: (...args: unknown[]) => mockSwDebugEvalRaw(...args),
+    swGetProperties: (...args: unknown[]) => mockSwGetProperties(...args),
+    swDebuggerEnable: (...args: unknown[]) => mockSwDebuggerEnable(...args),
+    swDebuggerDisable: (...args: unknown[]) => mockSwDebuggerDisable(...args),
+    swDebugPause: (...args: unknown[]) => mockSwDebugPause(...args),
+    onDebugPaused: (...args: unknown[]) => mockOnDebugPaused(...args),
     swDebugResume: vi.fn().mockResolvedValue(undefined),
     swDebugStepOver: vi.fn().mockResolvedValue(undefined),
     swDebugStepInto: vi.fn().mockResolvedValue(undefined),
@@ -54,9 +54,9 @@ vi.mock('@/lib/sw-debugger', () => ({
     swRemoveAllBreakpoints: vi.fn().mockResolvedValue(undefined),
 }));
 
-const mockFromCdpRemoteObject = vi.fn((_obj: unknown) => ({ __type: 'string', v: 'mocked' }) as any);
+const mockFromCdpRemoteObject = vi.fn((_obj: unknown) => ({ __type: 'string', v: 'mocked' }) as Record<string, unknown>);
 vi.mock('@/components/Console/cdpToSerialized', () => ({
-    fromCdpRemoteObject: (obj: any) => mockFromCdpRemoteObject(obj),
+    fromCdpRemoteObject: (obj: unknown) => mockFromCdpRemoteObject(obj),
 }));
 
 import { runAndDispatch, runJsScript, runJsScriptStep } from '@/lib/run';
@@ -64,7 +64,7 @@ import { runAndDispatch, runJsScript, runJsScriptStep } from '@/lib/run';
 // ─── Helpers ────────────────────────────────────────────────────────────────
 
 function createDispatch() {
-    return vi.fn() as unknown as React.Dispatch<any> & ReturnType<typeof vi.fn>;
+    return vi.fn() as unknown as React.Dispatch<unknown> & ReturnType<typeof vi.fn>;
 }
 
 // ─── Setup ──────────────────────────────────────────────────────────────────

--- a/packages/extension/test/lib/sw-debugger.test.ts
+++ b/packages/extension/test/lib/sw-debugger.test.ts
@@ -12,14 +12,14 @@ import {
 /** Make chrome.debugger.getTargets call back with given targets */
 function mockGetTargets(targets: Array<{ id: string; type: string; url: string }>) {
     (chrome.debugger.getTargets as ReturnType<typeof vi.fn>).mockImplementation(
-        (cb: (t: any[]) => void) => cb(targets)
+        (cb: (t: Array<{ id: string; type: string; url: string }>) => void) => cb(targets)
     );
 }
 
 /** Make chrome.debugger.attach succeed */
 function mockAttachSuccess() {
     (chrome.debugger.attach as ReturnType<typeof vi.fn>).mockImplementation(
-        (_target: any, _version: string, cb: () => void) => {
+        (_target: unknown, _version: string, cb: () => void) => {
             Object.defineProperty(chrome.runtime, 'lastError', { get: () => undefined, configurable: true });
             cb();
         }
@@ -27,9 +27,9 @@ function mockAttachSuccess() {
 }
 
 /** Make chrome.debugger.sendCommand call back with given result */
-function mockSendCommand(result: any) {
+function mockSendCommand(result: unknown) {
     (chrome.debugger.sendCommand as ReturnType<typeof vi.fn>).mockImplementation(
-        (_target: any, _method: string, _params: any, cb: (r: any) => void) => {
+        (_target: unknown, _method: string, _params: unknown, cb: (r: unknown) => void) => {
             Object.defineProperty(chrome.runtime, 'lastError', { get: () => undefined, configurable: true });
             cb(result);
         }
@@ -40,7 +40,7 @@ const SW_TARGET = { id: 'target-1', type: 'worker', url: `chrome-extension://${c
 
 /** Reset module-level swTargetId by firing the onDetach event (vitest-chrome's callListeners) */
 function resetSwTargetId() {
-    (chrome.debugger.onDetach as any).callListeners({ targetId: 'target-1' });
+    (chrome.debugger.onDetach as unknown as { callListeners: (...args: unknown[]) => void }).callListeners({ targetId: 'target-1' });
 }
 
 // ─── swDebugTargets ──────────────────────────────────────────────────────────
@@ -89,7 +89,7 @@ describe('swDebugEval', () => {
 
         await swDebugEval('const x = 42');
         const expr = (chrome.debugger.sendCommand as ReturnType<typeof vi.fn>).mock.calls
-            .find((c: any) => c[1] === 'Runtime.evaluate')![2].expression;
+            .find((c: unknown[]) => c[1] === 'Runtime.evaluate')![2].expression;
         expect(expr).toBe('const x = 42');
     });
 
@@ -100,7 +100,7 @@ describe('swDebugEval', () => {
 
         await swDebugEval('{a:1, b:2}');
         const expr = (chrome.debugger.sendCommand as ReturnType<typeof vi.fn>).mock.calls
-            .find((c: any) => c[1] === 'Runtime.evaluate')![2].expression;
+            .find((c: unknown[]) => c[1] === 'Runtime.evaluate')![2].expression;
         expect(expr).toBe('({a:1, b:2})');
     });
 
@@ -111,7 +111,7 @@ describe('swDebugEval', () => {
 
         await swDebugEval('const x = {a:1}');
         const expr = (chrome.debugger.sendCommand as ReturnType<typeof vi.fn>).mock.calls
-            .find((c: any) => c[1] === 'Runtime.evaluate')![2].expression;
+            .find((c: unknown[]) => c[1] === 'Runtime.evaluate')![2].expression;
         expect(expr).toBe('const x = {a:1}');
     });
 
@@ -143,7 +143,7 @@ describe('swDebugEval', () => {
         mockGetTargets([SW_TARGET]);
         mockAttachSuccess();
         (chrome.debugger.sendCommand as ReturnType<typeof vi.fn>).mockImplementation(
-            (_target: any, _method: string, _params: any, cb: (r: any) => void) => {
+            (_target: unknown, _method: string, _params: unknown, cb: (r: unknown) => void) => {
                 Object.defineProperty(chrome.runtime, 'lastError', {
                     get: () => ({ message: 'Debugger is not attached' }),
                     configurable: true,
@@ -177,7 +177,7 @@ describe('swDebugEval', () => {
     it('handles "already attached" error by reusing target', async () => {
         mockGetTargets([SW_TARGET]);
         (chrome.debugger.attach as ReturnType<typeof vi.fn>).mockImplementation(
-            (_target: any, _version: string, cb: () => void) => {
+            (_target: unknown, _version: string, cb: () => void) => {
                 Object.defineProperty(chrome.runtime, 'lastError', {
                     get: () => ({ message: 'Another debugger is already attached' }),
                     configurable: true,
@@ -194,7 +194,7 @@ describe('swDebugEval', () => {
     it('rejects with attach error when not "already attached"', async () => {
         mockGetTargets([SW_TARGET]);
         (chrome.debugger.attach as ReturnType<typeof vi.fn>).mockImplementation(
-            (_target: any, _version: string, cb: () => void) => {
+            (_target: unknown, _version: string, cb: () => void) => {
                 Object.defineProperty(chrome.runtime, 'lastError', {
                     get: () => ({ message: 'Cannot attach to this target' }),
                     configurable: true,
@@ -237,7 +237,7 @@ describe('swGetProperties', () => {
         mockAttachSuccess();
         // First call to sendCommand succeeds (Runtime.enable), second fails
         (chrome.debugger.sendCommand as ReturnType<typeof vi.fn>).mockImplementation(
-            (_target: any, method: string, _params: any, cb: (r: any) => void) => {
+            (_target: unknown, method: string, _params: unknown, cb: (r: unknown) => void) => {
                 if (method === 'Runtime.getProperties') {
                     Object.defineProperty(chrome.runtime, 'lastError', {
                         get: () => ({ message: 'Object has been collected' }),
@@ -279,7 +279,7 @@ describe('swCallFunctionOn', () => {
         mockGetTargets([SW_TARGET]);
         mockAttachSuccess();
         (chrome.debugger.sendCommand as ReturnType<typeof vi.fn>).mockImplementation(
-            (_target: any, method: string, _params: any, cb: (r: any) => void) => {
+            (_target: unknown, method: string, _params: unknown, cb: (r: unknown) => void) => {
                 if (method === 'Runtime.callFunctionOn') {
                     Object.defineProperty(chrome.runtime, 'lastError', {
                         get: () => ({ message: 'Function call failed' }),

--- a/packages/extension/test/offscreen.test.ts
+++ b/packages/extension/test/offscreen.test.ts
@@ -26,7 +26,7 @@ class MockWebSocket {
 // ─── Tests ───────────────────────────────────────────────────────────────────
 
 describe('offscreen bridge', () => {
-  let onMessageListener: (msg: any) => void;
+  let onMessageListener: (msg: Record<string, unknown>) => void;
   let OriginalWebSocket: typeof WebSocket;
   let sendMessage: ReturnType<typeof vi.fn>;
 
@@ -38,17 +38,18 @@ describe('offscreen bridge', () => {
     sendMessage = vi.fn().mockResolvedValue(9876);
 
     // Mock chrome.runtime
-    (globalThis as any).chrome = {
+    const g = globalThis as unknown as Record<string, unknown>;
+    g.chrome = {
       runtime: {
         sendMessage,
         onMessage: {
-          addListener: vi.fn((fn: any) => { onMessageListener = fn; }),
+          addListener: vi.fn((fn: (msg: Record<string, unknown>) => void) => { onMessageListener = fn; }),
         },
       },
     };
 
     // Replace WebSocket
-    (globalThis as any).WebSocket = MockWebSocket;
+    g.WebSocket = MockWebSocket;
 
     // Import module (triggers side effects: get-bridge-port → connect)
     vi.resetModules();
@@ -167,13 +168,13 @@ describe('offscreen bridge', () => {
     sendMessage.mockResolvedValue(9999);
 
     let callCount = 0;
-    (globalThis as any).WebSocket = class ThrowingWS {
+    (globalThis as unknown as Record<string, unknown>).WebSocket = class ThrowingWS {
       constructor() {
         callCount++;
         if (callCount === 1) throw new Error('connection refused');
         // Second call succeeds — use MockWebSocket
         const inst = new MockWebSocket('ws://127.0.0.1:9999');
-        return inst as any;
+        return inst as unknown as ThrowingWS;
       }
     };
 
@@ -227,12 +228,12 @@ describe('offscreen bridge', () => {
     sendMessage.mockResolvedValue(0);
 
     let callCount = 0;
-    (globalThis as any).WebSocket = class ThrowingWS {
+    (globalThis as unknown as Record<string, unknown>).WebSocket = class ThrowingWS {
       constructor() {
         callCount++;
         if (callCount === 1) throw new Error('connection refused');
         const inst = new MockWebSocket('ws://127.0.0.1:7777');
-        return inst as any;
+        return inst as unknown as ThrowingWS;
       }
     };
 
@@ -289,7 +290,7 @@ describe('offscreen bridge', () => {
     await vi.advanceTimersByTimeAsync(0);
 
     const call = sendMessage.mock.calls.find(
-      (c: any[]) => c[0]?.type === 'bridge-command' && c[0]?.command === 'click e5'
+      (c: unknown[]) => (c[0] as Record<string, unknown>)?.type === 'bridge-command' && (c[0] as Record<string, unknown>)?.command === 'click e5'
     );
     expect(call).toBeDefined();
     expect(call![0]).not.toHaveProperty('includeSnapshot');

--- a/packages/extension/test/setup.ts
+++ b/packages/extension/test/setup.ts
@@ -6,19 +6,19 @@ Object.assign(global, chrome);
 
 // vitest-chrome doesn't include chrome.tabs.update — add it manually
 if (!globalThis.chrome.tabs?.update) {
-  (globalThis.chrome.tabs as any).update = vi.fn().mockResolvedValue({});
+  (globalThis.chrome.tabs as unknown as Record<string, unknown>).update = vi.fn().mockResolvedValue({});
 }
 
 // vitest-chrome doesn't include chrome.scripting — add it manually
 if (!globalThis.chrome.scripting) {
-  (globalThis.chrome as any).scripting = {
+  (globalThis.chrome as Record<string, unknown>).scripting = {
     executeScript: async () => [],
   };
 }
 
 // vitest-chrome doesn't include chrome.sidePanel — add it manually
 if (!globalThis.chrome.sidePanel) {
-  (globalThis.chrome as any).sidePanel = {
+  (globalThis.chrome as Record<string, unknown>).sidePanel = {
     setPanelBehavior: () => Promise.resolve(),
     open: () => Promise.resolve(),
   };
@@ -26,14 +26,14 @@ if (!globalThis.chrome.sidePanel) {
 
 // vitest-chrome doesn't include chrome.action — add it manually
 if (!globalThis.chrome.action) {
-  (globalThis.chrome as any).action = {
+  (globalThis.chrome as Record<string, unknown>).action = {
     onClicked: { addListener: () => {} },
   };
 }
 
 // vitest-chrome doesn't include chrome.offscreen — add it manually
 if (!globalThis.chrome.offscreen) {
-  (globalThis.chrome as any).offscreen = {
+  (globalThis.chrome as Record<string, unknown>).offscreen = {
     hasDocument: async () => false,
     createDocument: async () => {},
     Reason: { BLOBS: 'BLOBS' },
@@ -42,14 +42,14 @@ if (!globalThis.chrome.offscreen) {
 
 // vitest-chrome doesn't include chrome.management — add it manually
 if (!globalThis.chrome.management) {
-  (globalThis.chrome as any).management = {
+  (globalThis.chrome as Record<string, unknown>).management = {
     getSelf: async () => ({ installType: 'development' }),
   };
 }
 
 // vitest-chrome doesn't include chrome.webNavigation — add it manually
 if (!globalThis.chrome.webNavigation) {
-  (globalThis.chrome as any).webNavigation = {
+  (globalThis.chrome as Record<string, unknown>).webNavigation = {
     onCommitted: {
       addListener: () => {},
       removeListener: () => {},

--- a/packages/extension/tsconfig.json
+++ b/packages/extension/tsconfig.json
@@ -10,9 +10,9 @@
     "noEmit": true,
     "isolatedModules": true,
     "resolveJsonModule": true,
-    "baseUrl": ".",
+    "types": ["chrome", "react", "react-dom", "js-yaml", "node"],
     "paths": {
-      "@/*": ["src/panel/*"]
+      "@/*": ["./src/panel/*"]
     }
   },
   "include": ["src", "test", "e2e", "types.d.ts"]

--- a/packages/extension/types.d.ts
+++ b/packages/extension/types.d.ts
@@ -1,7 +1,32 @@
+// ─── Global extensions (background.ts, test-framework.ts, recorder.ts) ──────
+// These are ambient declarations (script-context .d.ts) — no `declare global` needed.
+
+// Page observation globals set by attachToTab() in background.ts
+declare var __consoleMessages: string[];
+declare var __networkRequests: Array<{ status: number; method: string; url: string; type: string }>;
+declare var __activeRoutes: string[];
+declare var __dialogMode: 'accept' | 'dismiss' | undefined;
+
+// Exposed on globalThis for serviceWorker.evaluate() / VS Code CDP injection
+declare var attachToTab: (tabId: number) => Promise<{ ok: boolean; url?: string; error?: string }>;
+declare var handleBridgeCommand: (msg: { command: string; scriptType?: 'command' | 'script'; language?: 'pw' | 'javascript'; includeSnapshot?: boolean }) => Promise<{ text: string; isError: boolean; image?: string }>;
+
+// Test framework globals (test-framework.ts -> installFramework)
+declare var __test: unknown;
+declare var __expect: (target: unknown) => unknown;
+declare var __runTests: () => Promise<string>;
+declare var __resetTestState: () => void;
+declare var __setGrep: (pattern: string | null) => void;
+declare var __setGrepExact: (pattern: string | null) => void;
+declare var __setTimeout: (ms: number) => void;
+declare var __proxyPage: unknown;
+declare var __proxyExpect: unknown;
+
 // ─── Window extensions ───────────────────────────────────────────────────────
 
 interface Window {
   __pwRecorderCleanup?: () => void;
+  __pw_recorder_active?: boolean;
   showSaveFilePicker(options?: {
     suggestedName?: string;
     types?: Array<{
@@ -28,6 +53,7 @@ interface FileSystemWritableFileStream extends WritableStream {
 declare namespace chrome {
   namespace sidePanel {
     function setPanelBehavior(options: { openPanelOnActionClick: boolean }): void;
+    function open(options: { windowId?: number }): Promise<void>;
   }
 
   namespace scripting {
@@ -37,6 +63,20 @@ declare namespace chrome {
       func?: () => void;
     }
     function executeScript(injection: ScriptInjection): Promise<unknown>;
+  }
+
+  namespace offscreen {
+    function hasDocument(): Promise<boolean>;
+    function createDocument(options: { url: string; reasons: string[]; justification: string }): Promise<void>;
+    const Reason: { BLOBS: string; USER_MEDIA: string };
+  }
+
+  namespace management {
+    function getSelf(): Promise<{ installType: string }>;
+  }
+
+  namespace action {
+    const onClicked: { addListener: (callback: (tab: { id?: number; url?: string; windowId?: number }) => void) => void };
   }
 }
 

--- a/packages/extension/types.d.ts
+++ b/packages/extension/types.d.ts
@@ -78,6 +78,10 @@ declare namespace chrome {
   namespace action {
     const onClicked: { addListener: (callback: (tab: { id?: number; url?: string; windowId?: number }) => void) => void };
   }
+
+  namespace tabCapture {
+    function getMediaStreamId(options: { targetTabId?: number }): Promise<string>;
+  }
 }
 
 // ─── nextcov (no published types) ────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Replace all 517 `any` type usages across 37 files with proper types (`unknown`, specific interfaces, typed casts)
- Change `@typescript-eslint/no-explicit-any` from `"off"` to `"error"` in eslint config
- Add globalThis declarations and missing Chrome API type augmentations in `types.d.ts`
- Fix all 3 pre-existing `tsc --noEmit` errors (missing props, callback-only type signature)
- Add `"types": ["chrome", ...]` to tsconfig so IDE resolves `@types/chrome` reliably

## Test plan
- [x] `npx eslint src/ test/ e2e/ types.d.ts` — 0 errors
- [x] `npx tsc --noEmit` — 0 errors
- [x] `npx vitest run` — 18 files, 712 tests passed
- [x] `pnpm run build` — passes
- [x] IDE shows 0 errors

Closes #825

🤖 Generated with [Claude Code](https://claude.com/claude-code)