### PR TITLE
fix: pick locator uses URL for nameless links (#833)

### DIFF
--- a/packages/extension/src/background.ts
+++ b/packages/extension/src/background.ts
@@ -386,38 +386,6 @@ async function pickElement(): Promise<{ ok: boolean; info?: Record<string, unkno
       const tag = el.tagName;
       const inputType = (attrs.type || '').toLowerCase();
 
-      // Detect nearest preceding sibling text (for --in context)
-      // Generic: finds first short leaf text, skipping buttons — works for headings, banners, labels
-      function leafText(node: Node): string {
-        for (const c of node.childNodes) {
-          if (c.nodeType === 3) {
-            const t = (c.textContent || '').trim();
-            if (t && t.length >= 2 && t.length <= 50) {
-              // Use parent element's full text to match what --in sees at runtime
-              // (child elements like info icons contribute to the element's text content)
-              const full = (c.parentElement?.textContent || '').trim();
-              return (full.length <= 50) ? full : t;
-            }
-          }
-          if (c.nodeType === 1) { const e = c as Element; if (e.matches('button') || e.closest('button')) continue; const t = leafText(e); if (t) return t; }
-        }
-        return '';
-      }
-      let headingContext: string | null = null;
-      let cur = el.parentElement;
-      while (cur && cur !== document.body && cur !== document.documentElement) {
-        for (const child of cur.children) {
-          if (child.contains(el)) break;
-          if (child.matches('a') || child.querySelector('a')) continue; // skip peer items with links
-          if (child.querySelector('input[type="radio"], input[type="checkbox"]')) continue; // skip peer radio/checkbox labels
-          if (child.matches('input[type="radio"], input[type="checkbox"]')) continue;
-          const t = leafText(child);
-          if (t) { headingContext = t; break; }
-        }
-        if (headingContext) break;
-        cur = cur.parentElement;
-      }
-
       return {
         tag,
         text: (el as HTMLElement).innerText?.slice(0, 200) ?? '',
@@ -429,7 +397,6 @@ async function pickElement(): Promise<{ ok: boolean; info?: Record<string, unkno
         value: ('value' in el) ? (el as HTMLInputElement).value : undefined,
         checked: (tag === 'INPUT' && (inputType === 'checkbox' || inputType === 'radio'))
           ? (el as HTMLInputElement).checked : undefined,
-        headingContext,
       };
     }).catch(() => null);
 

--- a/packages/extension/src/content/locator.ts
+++ b/packages/extension/src/content/locator.ts
@@ -237,7 +237,8 @@ function findLeafText(node: Node): string {
  */
 function findNearestHeading(el: Element): { container: Element; text: string } | null {
     let current = el.parentElement;
-    while (current && current !== document.body && current !== document.documentElement) {
+    let depth = 0;
+    while (current && current !== document.body && current !== document.documentElement && depth < 5) {
         for (const child of current.children) {
             if (child.contains(el)) break; // stop at el's branch
             // Skip peer items — section labels don't contain navigation links
@@ -245,10 +246,14 @@ function findNearestHeading(el: Element): { container: Element; text: string } |
             // Skip peer radio/checkbox labels — "Ja" label is not a heading for "Nein"
             if (child.querySelector('input[type="radio"], input[type="checkbox"]')) continue;
             if (child.matches('input[type="radio"], input[type="checkbox"]')) continue;
+            // Skip navigation/toolbar chrome — text like "Previous"/"Next" is not a section heading
+            if (child.matches('nav, [role="navigation"], [role="toolbar"], [role="tablist"]')) continue;
+            if (child.closest('nav, [role="navigation"], [role="toolbar"], [role="tablist"]')) continue;
             const text = findLeafText(child);
             if (text) return { container: current, text };
         }
         current = current.parentElement;
+        depth++;
     }
     return null;
 }

--- a/packages/extension/src/panel/lib/commands.ts
+++ b/packages/extension/src/panel/lib/commands.ts
@@ -215,6 +215,10 @@ function callScoped(fn: (...args: unknown[]) => unknown, inText: string, _target
         if (__sel) __scope = page.locator(__sel);
       } catch {}
     }
+    if (__scope !== page) {
+      const __tc = await __scope.getByText(${ser(_targetText)}).count().catch(() => 0);
+      if (__tc === 0) __scope = page;
+    }
     try {
       return await (${fn.toString()})(__scope, ${args.map(ser).join(', ')});
     } finally {

--- a/packages/extension/src/panel/lib/page-scripts.ts
+++ b/packages/extension/src/panel/lib/page-scripts.ts
@@ -18,7 +18,10 @@ export async function verifyText(page, text) {
 }
 
 export async function verifyElement(page, role, name) {
-  if (await page.getByRole(role, { name }).count() === 0)
+  // Link with URL: match by href instead of accessible name
+  const isUrl = role === 'link' && name && /^\/|^https?:\/\//.test(name);
+  const loc = isUrl ? page.locator('a[href="' + name + '"]:not([aria-hidden="true"])') : page.getByRole(role, { name });
+  if (await loc.count() === 0)
     throw new Error('Element not found: ' + role + ' "' + name + '"');
 }
 
@@ -248,8 +251,10 @@ export async function uncheckByText(page, text, nth?, exact?) {
 // ─── Role-based actions (used by recorder output) ──────────────────────────
 
 export async function actionByRole(page, role, name, action, nth, inRole, inText) {
-  const roleOpts = name ? { name, exact: true } : {};
-  let loc = page.getByRole(role, roleOpts);
+  // Link with URL: match by href instead of accessible name
+  const isUrl = role === 'link' && name && /^\/|^https?:\/\//.test(name);
+  const roleOpts = (name && !isUrl) ? { name, exact: true } : {};
+  let loc = isUrl ? page.locator('a[href="' + name + '"]:not([aria-hidden="true"])') : page.getByRole(role, roleOpts);
   if (inRole !== undefined && inText !== undefined) {
     const cr = ({ list: 'listitem' })[inRole] || inRole;
     loc = page.getByRole(cr).filter({ hasText: inText }).getByRole(role, roleOpts);
@@ -311,8 +316,10 @@ export async function highlightByText(page, text, nth?, exact?) {
 }
 
 export async function highlightByRole(page, role, name, nth, inRole?, inText?) {
-  const roleOpts = name ? { name, exact: true } : {};
-  let loc = page.getByRole(role, roleOpts);
+  // Link with URL: match by href instead of accessible name
+  const isUrl = role === 'link' && name && /^\/|^https?:\/\//.test(name);
+  const roleOpts = (name && !isUrl) ? { name, exact: true } : {};
+  let loc = isUrl ? page.locator('a[href="' + name + '"]:not([aria-hidden="true"])') : page.getByRole(role, roleOpts);
   if (inRole !== undefined && inText !== undefined) {
     const cr = ({ list: 'listitem' })[inRole] || inRole;
     loc = page.getByRole(cr).filter({ hasText: inText }).getByRole(role, roleOpts);

--- a/packages/extension/src/panel/lib/pick-info.ts
+++ b/packages/extension/src/panel/lib/pick-info.ts
@@ -145,6 +145,9 @@ function derivePwCommand(info: ElementPickInfo, ariaSnapshot?: string, headingCo
     // (which may be a substring — Playwright's getByRole uses substring matching by default)
     const name = ariaParsed?.element.name || parsed.name;
 
+    // URL: extract from aria snapshot for link elements without an accessible name
+    const ariaUrl = ariaSnapshot?.match(/\/url:\s*(\S+)/)?.[1];
+
     // --in: from chained locator (getByRole('group', { name: 'X' }).getByLabel('Y'))
     // or from aria parent (when parent role differs from element role)
     let inFlag = '';
@@ -166,6 +169,10 @@ function derivePwCommand(info: ElementPickInfo, ariaSnapshot?: string, headingCo
 
     // Only add heading --in when replacing --nth or complex CSS scoping (locator()/filter())
     const needsScoping = nth || /\.locator\(|\.filter\(|^locator\(/.test(info.locator);
+
+    // Link with URL but no accessible name — use URL as the link identifier
+    // (ariaUrl presence implies a link even when aria parsing fails to extract the role)
+    if (!name && ariaUrl) return `highlight link "${ariaUrl}"`;
 
     if (role || name) {
         const base = parts.join(' ');
@@ -203,9 +210,11 @@ function deriveAssertion(info: ElementPickInfo, locator: string, pwCommand: stri
     const inputType = info.attributes?.type?.toLowerCase() ?? '';
     // Extract name from pw command, falling back to JS locator parsing
     // Skip extraction for CSS fallback commands — the quoted value is a selector, not a name
+    // Skip URL values — they're href identifiers, not visible text for assertions
     const parsed = parseJsLocator(locator);
     const isCssPw = pwCommand?.includes(' css ') ?? false;
-    const name = (pwCommand && !isCssPw ? extractPwName(pwCommand) : null) ?? parsed.name ?? null;
+    const pwName = pwCommand && !isCssPw ? extractPwName(pwCommand) : null;
+    const name = (pwName && !/^\/|^https?:\/\//.test(pwName) ? pwName : null) ?? parsed.name ?? null;
     const quotedName = name ? `"${name}"` : null;
     // Extract role from aria snapshot, element attributes, or JS locator
     const ariaRole = ariaSnapshot ? parseAriaSnapshot(ariaSnapshot)?.element.role : null;
@@ -244,6 +253,15 @@ function deriveAssertion(info: ElementPickInfo, locator: string, pwCommand: stri
         if (quotedName) return `${quotedName}${nth}`;
         if (fallbackText) return `"${fallbackText}"${nth}`;
         return '';
+    }
+
+    // Link identified by URL — assert visibility, not text content
+    const isUrlLink = pwName && /^\/|^https?:\/\//.test(pwName);
+    if (isUrlLink) {
+        return {
+            assertJs: `await expect(${locator}).toBeVisible();`,
+            assertPw: `verify-element link "${pwName}"`,
+        };
     }
 
     // Has text content → text assertion

--- a/packages/extension/src/panel/lib/pick-info.ts
+++ b/packages/extension/src/panel/lib/pick-info.ts
@@ -23,7 +23,7 @@ type AriaNode = { role: string; name: string };
  */
 function parseAriaLine(line: string): AriaNode | null {
     const trimmed = line.replace(/^\s*-\s*/, '').replace(/:$/, '')
-        .replace(/\s*\[[\w\s=]+\]\s*$/, ''); // strip aria attributes like [checked], [disabled]
+        .replace(/(\s*\[[\w\s=]+\])+\s*$/, ''); // strip aria attributes like [ref=e1], [cursor=pointer]
     // role "name" or role 'name'
     const match = trimmed.match(/^(\w[\w-]*)\s+["'](.+?)["']$/);
     if (match) return { role: match[1], name: match[2] };

--- a/packages/extension/test/lib/pick-info.test.ts
+++ b/packages/extension/test/lib/pick-info.test.ts
@@ -576,4 +576,78 @@ describe('buildPickResult', () => {
         }), null, '', null);
         expect(result.pwCommand).toBe('highlight css ".item" --nth 0');
     });
+
+    // ─── Link with URL (nameless links) ──────────────────────────────────
+
+    it('uses URL for nameless link with CSS locator (#833)', () => {
+        const result = buildPickResult(makeInfo({
+            locator: "locator('a').filter({ hasText: ':04' })",
+            tag: 'a',
+            text: '14:04',
+            attributes: {},
+        }), null, '- link [ref=e1]:\n  - /url: /watch?v=d1uwvo5Z8LY\n  - generic [ref=e2]: 14:04');
+        expect(result.pwCommand).toBe('highlight link "/watch?v=d1uwvo5Z8LY"');
+    });
+
+    it('URL link assertion uses verify-element, not text (#833)', () => {
+        const result = buildPickResult(makeInfo({
+            locator: "locator('a').filter({ hasText: ':04' })",
+            tag: 'a',
+            text: '14:04',
+            attributes: {},
+        }), null, '- link [ref=e1]:\n  - /url: /watch?v=d1uwvo5Z8LY\n  - generic [ref=e2]: 14:04');
+        expect(result.assertPw).toBe('verify-element link "/watch?v=d1uwvo5Z8LY"');
+        expect(result.assertJs).toContain('toBeVisible()');
+    });
+
+    it('uses full aria name for link with accessible name (#833)', () => {
+        const result = buildPickResult(makeInfo({
+            locator: "getByRole('link', { name: 'Stop Guessing on Contract' })",
+            tag: 'a',
+            text: 'Stop Guessing on Contract Terms. Agiloft Astra Gives You Instant Clarity.',
+            attributes: {},
+        }), null, '- link "Stop Guessing on Contract Terms. Agiloft Astra Gives You Instant Clarity." [ref=e1]:\n  - /url: /watch?v=Dkk4tZLeLO0');
+        expect(result.pwCommand).toBe('highlight link "Stop Guessing on Contract Terms. Agiloft Astra Gives You Instant Clarity."');
+    });
+
+    it('named link assertion uses full aria name', () => {
+        const result = buildPickResult(makeInfo({
+            locator: "getByRole('link', { name: 'Stop Guessing on Contract' })",
+            tag: 'a',
+            text: 'Stop Guessing on Contract Terms. Agiloft Astra Gives You Instant Clarity.',
+            attributes: {},
+        }), null, '- link "Stop Guessing on Contract Terms. Agiloft Astra Gives You Instant Clarity." [ref=e1]:\n  - /url: /watch?v=Dkk4tZLeLO0');
+        expect(result.assertPw).toBe('verify-element link "Stop Guessing on Contract Terms. Agiloft Astra Gives You Instant Clarity."');
+    });
+
+    it('uses full aria name with multiple bracket attributes [ref] [cursor] (#833)', () => {
+        const result = buildPickResult(makeInfo({
+            locator: "getByRole('link', { name: 'Stop Guessing on Contract' })",
+            tag: 'a',
+            text: 'Stop Guessing on Contract Terms. Agiloft Astra Gives You Instant Clarity.',
+            attributes: {},
+        }), null, '- link "Stop Guessing on Contract Terms. Agiloft Astra Gives You Instant Clarity." [ref=e1] [cursor=pointer]:\n  - /url: /watch?v=Dkk4tZLeLO0');
+        expect(result.pwCommand).toBe('highlight link "Stop Guessing on Contract Terms. Agiloft Astra Gives You Instant Clarity."');
+    });
+
+    it('uses full aria name even without ref attributes in snapshot', () => {
+        const result = buildPickResult(makeInfo({
+            locator: "getByRole('link', { name: 'Stop Guessing on Contract' })",
+            tag: 'a',
+            text: 'Stop Guessing on Contract Terms. Agiloft Astra Gives You Instant Clarity.',
+            attributes: {},
+        }), null, '- link "Stop Guessing on Contract Terms. Agiloft Astra Gives You Instant Clarity.":\n  - /url: /watch?v=Dkk4tZLeLO0');
+        expect(result.pwCommand).toBe('highlight link "Stop Guessing on Contract Terms. Agiloft Astra Gives You Instant Clarity."');
+    });
+
+    it('does not use URL when link has an accessible name', () => {
+        const result = buildPickResult(makeInfo({
+            locator: "getByRole('link', { name: 'Home' })",
+            tag: 'a',
+            text: 'Home',
+            attributes: { href: '/' },
+        }), null, '- link "Home" [ref=e1]:\n  - /url: /');
+        expect(result.pwCommand).toBe('highlight link "Home"');
+        expect(result.pwCommand).not.toContain('/');
+    });
 });


### PR DESCRIPTION
## Summary
- Remove DOM-based `headingContext` from pick handler — pick locator uses snapshots, not the DOM tree, so the DOM walk picked up unrelated navigation text like "Previous" on YouTube
- For nameless links with a `/url` in the aria snapshot, generate `highlight link "/watch?v=..."` using href matching with `:not([aria-hidden="true"])` to exclude hidden duplicates
- Runtime functions (`highlightByRole`, `actionByRole`, `verifyElement`) detect URL names and match via CSS `a[href="..."]` instead of `getByRole`
- Assertions use `verify-element link "/url"` instead of text-based assertions for URL links
- Add depth limit (5 levels) + nav/toolbar skip to `findNearestHeading` in recorder path
- `callScoped` falls back to full page when scoped search finds 0 elements

## Test plan
- [x] Pick locator on YouTube video thumbnail → generates `highlight link "/watch?v=..."` 
- [x] `highlight link "/watch?v=..."` highlights exactly 1 element (excludes aria-hidden)
- [x] `verify-element link "/watch?v=..."` passes
- [ ] Pick locator on non-YouTube pages still generates correct commands
- [ ] Recorder `--in` still works for elements within 5 levels of a heading

Closes #833

🤖 Generated with [Claude Code](https://claude.com/claude-code)