### PR TITLE
fix: CSS strict violations and video element recording (#835)

### DIFF
--- a/packages/extension/src/content/recorder.ts
+++ b/packages/extension/src/content/recorder.ts
@@ -120,7 +120,7 @@ export function flushPendingFill() {
 // ─── Event handlers (capture phase, transparent) ──────────────────────────
 
 export function onClickCapture(e: MouseEvent) {
-    let target = e.target as Element;
+    const target = e.target as Element;
     if (!target) return;
 
     // Media elements (video/audio) are typically covered by player overlays —

--- a/packages/extension/src/content/recorder.ts
+++ b/packages/extension/src/content/recorder.ts
@@ -120,8 +120,28 @@ export function flushPendingFill() {
 // ─── Event handlers (capture phase, transparent) ──────────────────────────
 
 export function onClickCapture(e: MouseEvent) {
-    const target = e.target as Element;
+    let target = e.target as Element;
     if (!target) return;
+
+    // Media elements (video/audio) are typically covered by player overlays —
+    // walk up to the nearest <a> with href for a unique URL-based locator
+    if (target.matches('video, audio')) {
+        const link = target.closest('a[href]') as HTMLAnchorElement | null;
+        if (link) {
+            // Strip tracking params — keep path + first query param for stable matching
+            let href = link.getAttribute('href') || '';
+            const ampIdx = href.indexOf('&');
+            if (ampIdx > 0) href = href.slice(0, ampIdx);
+            if (href) {
+                const cmds = {
+                    pw: `click link "${href}"`,
+                    js: `await page.locator('a[href^="${href}"]:not([aria-hidden="true"])').click();`,
+                };
+                safeSendMessage({ type: 'recorded-action', action: wrapWithFrameContext(cmds) });
+                return;
+            }
+        }
+    }
 
     // Skip clicks on text fields (focus-click noise before fill)
     if (isTextField(target)) return;

--- a/packages/extension/src/panel/lib/page-scripts.ts
+++ b/packages/extension/src/panel/lib/page-scripts.ts
@@ -20,7 +20,7 @@ export async function verifyText(page, text) {
 export async function verifyElement(page, role, name) {
   // Link with URL: match by href instead of accessible name
   const isUrl = role === 'link' && name && /^\/|^https?:\/\//.test(name);
-  const loc = isUrl ? page.locator('a[href="' + name + '"]:not([aria-hidden="true"])') : page.getByRole(role, { name });
+  const loc = isUrl ? page.locator('a[href^="' + name + '"]:not([aria-hidden="true"])') : page.getByRole(role, { name });
   if (await loc.count() === 0)
     throw new Error('Element not found: ' + role + ' "' + name + '"');
 }
@@ -254,7 +254,7 @@ export async function actionByRole(page, role, name, action, nth, inRole, inText
   // Link with URL: match by href instead of accessible name
   const isUrl = role === 'link' && name && /^\/|^https?:\/\//.test(name);
   const roleOpts = (name && !isUrl) ? { name, exact: true } : {};
-  let loc = isUrl ? page.locator('a[href="' + name + '"]:not([aria-hidden="true"])') : page.getByRole(role, roleOpts);
+  let loc = isUrl ? page.locator('a[href^="' + name + '"]:not([aria-hidden="true"])') : page.getByRole(role, roleOpts);
   if (inRole !== undefined && inText !== undefined) {
     const cr = ({ list: 'listitem' })[inRole] || inRole;
     loc = page.getByRole(cr).filter({ hasText: inText }).getByRole(role, roleOpts);
@@ -319,7 +319,7 @@ export async function highlightByRole(page, role, name, nth, inRole?, inText?) {
   // Link with URL: match by href instead of accessible name
   const isUrl = role === 'link' && name && /^\/|^https?:\/\//.test(name);
   const roleOpts = (name && !isUrl) ? { name, exact: true } : {};
-  let loc = isUrl ? page.locator('a[href="' + name + '"]:not([aria-hidden="true"])') : page.getByRole(role, roleOpts);
+  let loc = isUrl ? page.locator('a[href^="' + name + '"]:not([aria-hidden="true"])') : page.getByRole(role, roleOpts);
   if (inRole !== undefined && inText !== undefined) {
     const cr = ({ list: 'listitem' })[inRole] || inRole;
     loc = page.getByRole(cr).filter({ hasText: inText }).getByRole(role, roleOpts);
@@ -363,9 +363,29 @@ export async function clearHighlight(page) {
 // ─── Chaining (>> selectors) ────────────────────────────────────────────────
 
 export async function chainAction(page, selector, action, value) {
-  const loc = page.locator(selector);
-  if (value !== undefined) await loc[action](value);
-  else await loc[action]();
+  let loc = page.locator(selector);
+  // If multiple matches, try filtering to avoid strict violation:
+  // 1. Exclude aria-hidden elements
+  // 2. Filter to visible elements only
+  // 3. Fall back to first match
+  if (await loc.count() > 1) {
+    const noHidden = page.locator(selector + ':not([aria-hidden="true"])');
+    if (await noHidden.count() === 1) { loc = noHidden; }
+    else {
+      const visible = loc.filter({ visible: true });
+      const vc = await visible.count();
+      if (vc >= 1) loc = vc === 1 ? visible : visible.first();
+      else loc = loc.first();
+    }
+  }
+  try {
+    if (value !== undefined) await loc[action](value);
+    else await loc[action]();
+  } catch {
+    // Retry with force for covered elements (e.g. YouTube video player overlay)
+    if (value !== undefined) await loc[action](value, { force: true });
+    else await loc[action]({ force: true });
+  }
   return 'Done';
 }
 


### PR DESCRIPTION
## Summary
- **chainAction**: disambiguate CSS selectors matching multiple elements (aria-hidden filter → visible filter → `.first()`). Retry with `force: true` on failure for overlay-covered elements
- **Recorder**: walk up from `<video>`/`<audio>` to nearest `<a>` ancestor, use href URL (stripped of tracking params) for stable unique locators
- **Runtime**: URL-based link matching uses starts-with (`href^=`) to handle varying tracking parameters

## Test plan
- [x] CSS selectors matching multiple elements no longer cause strict violation
- [x] Video thumbnail clicks record as `click link "/watch?v=xyz"` with unique URLs
- [x] URL links replay correctly with starts-with matching
- [x] Lint passes
- [x] 719 extension tests pass

Closes #835

🤖 Generated with [Claude Code](https://claude.com/claude-code)