### PR TITLE
feat: stagecraft skills package and pw-cli --replay with template variables

### DIFF
--- a/packages/cli/src/pw-cli.ts
+++ b/packages/cli/src/pw-cli.ts
@@ -12,10 +12,12 @@
 
 import { startRepl } from './repl.js';
 import { minimist } from '@playwright-repl/core';
+import { SessionPlayer } from './recorder.js';
+import http from 'node:http';
 
 const args = minimist(process.argv.slice(2), {
   boolean: ['headed', 'headless', 'bridge', 'http', 'interactive', 'help'],
-  string: ['http-port', 'bridge-port', 'command'],
+  string: ['http-port', 'bridge-port', 'command', 'replay', 'variable'],
   alias: { h: 'help' },
 });
 
@@ -36,6 +38,39 @@ Examples:
   pw-cli "screenshot"
 `);
   process.exit(0);
+}
+
+// --replay: load .pw file, substitute variables, send commands via HTTP
+if (args.replay) {
+  const httpPort = args['http-port'] ? parseInt(args['http-port'] as string, 10) : 9223;
+  // Parse --variable args (string or string[])
+  const variables: Record<string, string> = {};
+  const varArgs = args.variable ? (Array.isArray(args.variable) ? args.variable : [args.variable]) as string[] : [];
+  for (const v of varArgs) {
+    const [key, ...rest] = v.split('=');
+    if (key && rest.length > 0) variables[key] = rest.join('=');
+  }
+  const commands = SessionPlayer.load(args.replay as string, Object.keys(variables).length > 0 ? variables : undefined);
+
+  let failed = false;
+  for (const cmd of commands) {
+    const result = await new Promise<{ text?: string; isError?: boolean }>((resolve, reject) => {
+      const body = JSON.stringify({ command: cmd });
+      const req = http.request({ hostname: '127.0.0.1', port: httpPort, path: '/run', method: 'POST', headers: { 'Content-Type': 'application/json', 'Content-Length': Buffer.byteLength(body) } }, res => {
+        let data = '';
+        res.on('data', (chunk: string) => data += chunk);
+        res.on('end', () => { try { resolve(JSON.parse(data)); } catch { reject(new Error('Invalid response')); } });
+      });
+      req.on('error', reject);
+      req.write(body);
+      req.end();
+    }).catch((e: Error) => ({ text: e.message, isError: true }));
+
+    const mark = result.isError ? '✗' : '✓';
+    console.log(`${mark} ${cmd}${result.isError && result.text ? ` — ${result.text}` : ''}`);
+    if (result.isError) { failed = true; break; }
+  }
+  process.exit(failed ? 1 : 0);
 }
 
 // If positional args given, treat as --http --command

--- a/packages/cli/src/recorder.ts
+++ b/packages/cli/src/recorder.ts
@@ -126,12 +126,27 @@ export class SessionPlayer {
   /**
    * Load commands from a .pw file.
    */
-  static load(filename: string): string[] {
+  static load(filename: string, variables?: Record<string, string>): string[] {
     if (!fs.existsSync(filename)) {
       throw new Error(`File not found: ${filename}`);
     }
 
-    const content = fs.readFileSync(filename, 'utf-8');
+    let content = fs.readFileSync(filename, 'utf-8');
+
+    // Replace {{key}} placeholders with --variable key=value args
+    if (variables) {
+      for (const [key, value] of Object.entries(variables)) {
+        content = content.replaceAll(`{{${key}}}`, value);
+      }
+    }
+
+    // Check for unresolved variables
+    const unresolved = content.match(/\{\{(\w+)\}\}/g);
+    if (unresolved) {
+      const keys = [...new Set(unresolved.map(m => m.slice(2, -2)))];
+      throw new Error(`Missing variables: ${keys.join(', ')}. Use --variable key=value`);
+    }
+
     return content
       .split('\n')
       .map(line => line.trim())
@@ -142,9 +157,9 @@ export class SessionPlayer {
    * Create a player that yields commands one at a time.
    * Supports step-through mode where it pauses between commands.
    */
-  constructor(filename: string) {
+  constructor(filename: string, variables?: Record<string, string>) {
     this.filename = filename;
-    this.commands = SessionPlayer.load(filename);
+    this.commands = SessionPlayer.load(filename, variables);
   }
 
   get done(): boolean {
@@ -221,9 +236,9 @@ export class SessionManager {
 
   // ── Playback ───────────────────────────────────────────────────
 
-  startReplay(filename: string, step = false): SessionPlayer {
+  startReplay(filename: string, step = false, variables?: Record<string, string>): SessionPlayer {
     if (this.mode !== 'idle') throw new Error(`Cannot replay while ${this.mode}`);
-    this.#player = new SessionPlayer(filename);
+    this.#player = new SessionPlayer(filename, variables);
     this.#step = step;
     return this.#player;
   }

--- a/packages/cli/src/repl.ts
+++ b/packages/cli/src/repl.ts
@@ -266,13 +266,22 @@ export async function processLine(ctx: ReplContext, line: string): Promise<void>
   // ── Inline replay ──────────────────────────────────────────────
 
   if (line.startsWith('.replay')) {
-    const filename = line.split(/\s+/)[1];
+    const parts = line.split(/\s+/);
+    const filename = parts[1];
     if (!filename) {
-      console.log(`${c.yellow}Usage: .replay <filename>${c.reset}`);
+      console.log(`${c.yellow}Usage: .replay <filename> [--variable key=value ...]${c.reset}`);
       return;
     }
+    // Parse --variable key=value args
+    const variables: Record<string, string> = {};
+    for (let i = 2; i < parts.length; i++) {
+      if (parts[i] === '--variable' && parts[i + 1]) {
+        const [key, ...rest] = parts[++i].split('=');
+        if (key && rest.length > 0) variables[key] = rest.join('=');
+      }
+    }
     try {
-      const player = ctx.session.startReplay(filename);
+      const player = ctx.session.startReplay(filename, false, Object.keys(variables).length > 0 ? variables : undefined);
       console.log(`${c.blue}▶${c.reset} Replaying ${c.bold}${filename}${c.reset} (${player.commands.length} commands)\n`);
       while (!player.done) {
         const cmd = player.next()!;

--- a/packages/stagecraft/package.json
+++ b/packages/stagecraft/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@playwright-repl/stagecraft",
+  "description": "Skill library and agent runtime for playwright-repl",
+  "version": "0.26.1",
+  "type": "module",
+  "main": "./dist/index.js",
+  "exports": {
+    ".": "./dist/index.js"
+  },
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist/",
+    "skills/"
+  ],
+  "scripts": {
+    "build": "tsc"
+  },
+  "dependencies": {
+    "@playwright-repl/core": "workspace:*"
+  },
+  "license": "ISC"
+}

--- a/packages/stagecraft/skills/rogers/SKILL.md
+++ b/packages/stagecraft/skills/rogers/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: download-rogers-bill
+description: Navigate to MyRogers and download bill PDFs
+category: tax/bills/telecom
+preconditions: Must be logged into rogers.com (use bridge mode)
+parameters:
+  - billing_periods: list of dates to check (e.g. "January 24, 2026", "February 24, 2026")
+output: PDF files downloaded to browser's default download folder
+---
+
+# Download Rogers Bill
+
+Navigates to MyRogers self-serve billing page, opens the Save PDF modal,
+selects the requested billing periods, and triggers the download.
+
+The agent should:
+1. Run the .pw script to navigate to the billing page
+2. Read the snapshot to see available billing periods
+3. Check the requested periods
+4. Click "Download bills"
+
+Note: The latest billing period is pre-checked by default.

--- a/packages/stagecraft/skills/rogers/download-bill.js
+++ b/packages/stagecraft/skills/rogers/download-bill.js
@@ -1,0 +1,17 @@
+/**
+ * Download Rogers bill PDFs for specified billing periods.
+ *
+ * @param {import('playwright').Page} page
+ * @param {string[]} periods - Billing period labels, e.g. ["January 24, 2026", "February 24, 2026"]
+ */
+async function downloadRogersBill(page, periods) {
+  await page.goto('https://www.rogers.com/consumer/self-serve/overview');
+  await page.getByText('View your bill').filter({ visible: true }).first().click();
+  await page.getByText('Save PDF').click();
+
+  for (const period of periods) {
+    await page.getByText(period, { exact: true }).first().click();
+  }
+
+  await page.getByText('Download bills').click();
+}

--- a/packages/stagecraft/skills/rogers/download-bill.pw
+++ b/packages/stagecraft/skills/rogers/download-bill.pw
@@ -1,0 +1,12 @@
+# Rogers bill download
+# Navigate to MyRogers billing page and download bill PDFs
+# Requires: logged into rogers.com (bridge mode)
+#
+# Usage:
+#   replay skills/rogers/download-bill.pw --variable billing_period="January 24, 2026"
+
+goto https://www.rogers.com/consumer/self-serve/overview
+click "View your bill" --exact
+click "Save PDF"
+check "{{billing_period}}"
+click "Download bills"

--- a/packages/stagecraft/src/index.ts
+++ b/packages/stagecraft/src/index.ts
@@ -1,0 +1,8 @@
+/**
+ * Stagecraft — skill library and agent runtime for playwright-repl.
+ *
+ * Skills are .pw files paired with SKILL.md metadata. Agents (Cowork, Claude)
+ * discover and invoke skills through existing run_command / run_script MCP tools.
+ */
+
+export { }

--- a/packages/stagecraft/tsconfig.build.json
+++ b/packages/stagecraft/tsconfig.build.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"],
+  "references": [
+    { "path": "../core/tsconfig.build.json" }
+  ]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -226,6 +226,12 @@ importers:
         specifier: ^5.0.0
         version: 5.9.3
 
+  packages/stagecraft:
+    dependencies:
+      '@playwright-repl/core':
+        specifier: workspace:*
+        version: link:../core
+
   packages/vscode:
     dependencies:
       '@playwright-repl/browser-extension':


### PR DESCRIPTION
## Summary
- New `packages/stagecraft` package — skill library for agent-driven browser automation
- Skills are `.pw` files with `{{variable}}` placeholders, substituted at replay time
- `pw-cli --replay <file> --variable key=value` sends commands via HTTP to running server
- REPL `.replay` also supports `--variable key=value` args
- First skill: Rogers bill download (`skills/rogers/download-bill.pw`)

## Example
```bash
pw-cli --replay skills/rogers/download-bill.pw --variable billing_period="February 24, 2026"

✓ goto https://www.rogers.com/consumer/self-serve/overview
✓ click "View your bill" --exact
✓ click "Save PDF"
✓ check "February 24, 2026"
✓ click "Download bills"
```

## Test plan
- [x] `SessionPlayer.load()` substitutes `{{variables}}` correctly
- [x] Missing variables throw clear error
- [x] `pw-cli --replay` sends commands via HTTP and prints ✓/✗ status
- [x] End-to-end test: Rogers bill download with `--variable billing_period="February 24, 2026"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)