### PR TITLE
fix: pick locator uses correct role and full name for elements with children (#843)

### DIFF
--- a/packages/extension/src/panel/lib/pick-info.ts
+++ b/packages/extension/src/panel/lib/pick-info.ts
@@ -40,6 +40,12 @@ function parseAriaLine(line: string): AriaNode | null {
  * Single line:  `- button "Submit"` → element only
  * Nested:       `- listitem:\n  - checkbox "reading"` → element=checkbox, parent=listitem
  */
+const INTERACTIVE_ROLES = new Set([
+    'button', 'link', 'checkbox', 'radio', 'textbox', 'combobox', 'switch',
+    'menuitem', 'menuitemcheckbox', 'menuitemradio', 'tab', 'option',
+    'slider', 'spinbutton', 'searchbox', 'treeitem',
+]);
+
 function parseAriaSnapshot(snapshot: string): { element: AriaNode; parent?: AriaNode } | null {
     const lines = snapshot.split('\n').filter(l => l.trim() && l.trim() !== '-');
     if (!lines.length) return null;
@@ -50,22 +56,30 @@ function parseAriaSnapshot(snapshot: string): { element: AriaNode; parent?: Aria
         return element ? { element } : null;
     }
 
-    // Multi-line: first line is parent, first child is the element
-    const parent = parseAriaLine(lines[0]);
-    if (!parent) return null;
+    const firstNode = parseAriaLine(lines[0]);
+    if (!firstNode) return null;
 
     // Find first child line (deeper indentation)
     const parentIndent = lines[0].search(/\S/);
     for (let i = 1; i < lines.length; i++) {
         const indent = lines[i].search(/\S/);
         if (indent > parentIndent) {
-            const element = parseAriaLine(lines[i]);
-            if (element) return { element, parent };
+            const child = parseAriaLine(lines[i]);
+            if (child) {
+                // If child is interactive (button, link, checkbox, etc.),
+                // first line is a container/parent and child is the element.
+                // If child is structural (generic, img, text, etc.),
+                // first line IS the picked element — children are just DOM contents.
+                if (INTERACTIVE_ROLES.has(child.role)) {
+                    return { element: child, parent: firstNode };
+                }
+                return { element: firstNode };
+            }
         }
     }
 
     // No children parsed — treat first line as the element
-    return { element: parent };
+    return { element: firstNode };
 }
 
 /**

--- a/packages/extension/test/lib/pick-info.test.ts
+++ b/packages/extension/test/lib/pick-info.test.ts
@@ -640,6 +640,40 @@ describe('buildPickResult', () => {
         expect(result.pwCommand).toBe('highlight link "Stop Guessing on Contract Terms. Agiloft Astra Gives You Instant Clarity."');
     });
 
+    // ─── Interactive element with structural children (#843) ──────────
+
+    it('uses element role (not child role) when picked element has generic children', () => {
+        const result = buildPickResult(makeInfo({
+            locator: "getByRole('link', { name: 'View bill for account number' })",
+            tag: 'a',
+            text: 'View your bill',
+            attributes: {},
+        }), null, '- link "View bill for account number 877380717":\n  - generic:\n    - generic: View your bill\n    - img: ');
+        expect(result.pwCommand).toBe('highlight link "View bill for account number 877380717"');
+        expect(result.assertPw).toBe('verify-element link "View bill for account number 877380717"');
+    });
+
+    it('still uses parent/child for container with interactive child', () => {
+        const result = buildPickResult(makeInfo({
+            locator: "getByRole('checkbox', { name: 'reading' })",
+            tag: 'input',
+            text: '',
+            attributes: { type: 'checkbox' },
+            checked: true,
+        }), null, '- listitem:\n  - checkbox "reading"');
+        expect(result.pwCommand).toBe('highlight checkbox "reading" --in listitem');
+    });
+
+    it('treats button with generic children as the element itself', () => {
+        const result = buildPickResult(makeInfo({
+            locator: "getByRole('button', { name: 'Save PDF' })",
+            tag: 'button',
+            text: 'Save PDF',
+        }), null, '- button "Save PDF":\n  - generic: Save PDF\n  - img: ');
+        expect(result.pwCommand).toBe('highlight button "Save PDF"');
+        expect(result.assertPw).toBe('verify-element button "Save PDF"');
+    });
+
     it('does not use URL when link has an accessible name', () => {
         const result = buildPickResult(makeInfo({
             locator: "getByRole('link', { name: 'Home' })",


### PR DESCRIPTION
## Summary
- `parseAriaSnapshot` treated all multi-line snapshots as parent→child, but when the picked element has structural children (generic, img, text), it misidentified the child as the element
- This caused wrong role in pw assertion (`generic` instead of `link`) and truncated name in pw command
- Fix: only treat first line as parent when the first child has an interactive role (button, checkbox, link, etc.). Otherwise, the first line IS the picked element.

## Before / After

**Before:**
```
pw:     highlight link "View bill for account number"          ← truncated, fails with exact match
assert: verify-element generic "View bill for account number"  ← wrong role
```

**After:**
```
pw:     highlight link "View bill for account number 877380717"  ← full name, works
assert: verify-element link "View bill for account number 877380717"  ← correct role
```

## Test plan
- [x] 3 new tests: link with generic children, listitem with checkbox, button with generic children
- [x] All 61 pick-info tests pass
- [x] Manual test on Rogers MyRogers "View bill" link

Closes #843

🤖 Generated with [Claude Code](https://claude.com/claude-code)