### PR TITLE
feat: download-as command and pw-cli --load for JS skills

### DIFF
--- a/packages/cli/src/pw-cli.ts
+++ b/packages/cli/src/pw-cli.ts
@@ -13,11 +13,12 @@
 import { startRepl } from './repl.js';
 import { minimist } from '@playwright-repl/core';
 import { SessionPlayer } from './recorder.js';
+import fs from 'node:fs';
 import http from 'node:http';
 
 const args = minimist(process.argv.slice(2), {
   boolean: ['headed', 'headless', 'bridge', 'http', 'interactive', 'help'],
-  string: ['http-port', 'bridge-port', 'command', 'replay', 'variable'],
+  string: ['http-port', 'bridge-port', 'command', 'replay', 'variable', 'load'],
   alias: { h: 'help' },
 });
 
@@ -37,6 +38,28 @@ Examples:
   pw-cli "await page.title()"
   pw-cli "screenshot"
 `);
+  process.exit(0);
+}
+
+// --load: load .js file as a global function definition in the service worker
+if (args.load) {
+  const httpPort = args['http-port'] ? parseInt(args['http-port'] as string, 10) : 9223;
+  const filename = args.load as string;
+  if (!fs.existsSync(filename)) { console.error(`File not found: ${filename}`); process.exit(1); }
+  const script = fs.readFileSync(filename, 'utf-8');
+  const result = await new Promise<{ text?: string; isError?: boolean }>((resolve, reject) => {
+    const body = JSON.stringify({ command: script });
+    const req = http.request({ hostname: '127.0.0.1', port: httpPort, path: '/run', method: 'POST', headers: { 'Content-Type': 'application/json', 'Content-Length': Buffer.byteLength(body) } }, res => {
+      let data = '';
+      res.on('data', (chunk: string) => data += chunk);
+      res.on('end', () => { try { resolve(JSON.parse(data)); } catch { reject(new Error('Invalid response')); } });
+    });
+    req.on('error', reject);
+    req.write(body);
+    req.end();
+  }).catch((e: Error) => ({ text: e.message, isError: true }));
+  if (result.isError) { console.error(result.text); process.exit(1); }
+  console.log(`✓ Loaded ${filename}`);
   process.exit(0);
 }
 

--- a/packages/core/src/resolve.ts
+++ b/packages/core/src/resolve.ts
@@ -169,6 +169,9 @@ export const COMMANDS: Record<string, CommandInfo> = {
                          examples: ['video-chapter "Login flow"', 'video-chapter "Setup" --duration 3000'] },
   'tracing-start':     { desc: 'Start trace recording', options: [] },
   'tracing-stop':      { desc: 'Stop tracing and save trace file', options: [] },
+  'download-as':       { desc: 'Set filename for next download', options: [],
+                         usage: 'download-as <filename>',
+                         examples: ['download-as bills/rogers-2026-03.pdf'] },
   'install-browser':   { desc: 'Install browser', options: [] },
   'list':              { desc: 'List sessions', options: [] },
   'close-all':         { desc: 'Close all sessions', options: [] },
@@ -187,7 +190,7 @@ export const CATEGORIES: Record<string, string[]> = {
   'State':          ['state-save', 'state-load'],
   'Video':          ['video-start', 'video-stop', 'video-chapter'],
   'Tracing':        ['tracing-start', 'tracing-stop'],
-  'Other':          ['dialog-accept', 'dialog-dismiss', 'route', 'route-list', 'unroute', 'resize', 'pdf', 'upload', 'config-print'],
+  'Other':          ['dialog-accept', 'dialog-dismiss', 'route', 'route-list', 'unroute', 'resize', 'pdf', 'upload', 'download-as', 'config-print'],
 };
 
 /** Commands that mutate the page — snapshot should be attached when includeSnapshot is on. */

--- a/packages/extension/src/background.ts
+++ b/packages/extension/src/background.ts
@@ -704,6 +704,14 @@ async function handleBridgeCommand(msg: {
     }
   }
 
+  // ── Download as ────────────────────────────────────────────────────────────
+  if (cmd.startsWith('download-as')) {
+    const path = cmd.slice('download-as'.length).trim().replace(/^["']|["']$/g, '');
+    if (!path) return { text: 'Usage: download-as <filename>', isError: true };
+    globalThis.__downloadFilename = path;
+    return { text: `Next download will save as: ${path}`, isError: false };
+  }
+
   if (!currentPage) {
     const tabId = await getActiveTabId();
     if (tabId) await attachToTab(tabId);
@@ -894,5 +902,17 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
   return false;
 });
 
+// ─── Download filename override ─────────────────────────────────────────────
+// When __downloadFilename is set (via `download-as` command), rename the next
+// Chrome download to that path (relative to Downloads folder).
+chrome.downloads.onDeterminingFilename.addListener((_item, suggest) => {
+  if (globalThis.__downloadFilename) {
+    const filename = globalThis.__downloadFilename;
+    globalThis.__downloadFilename = undefined;
+    suggest({ filename });
+  }
+});
+
 // Expose stable globals for swDebugEval — functions that never change go here, not inside attachToTab
+globalThis.downloadAs = (filename: string) => { globalThis.__downloadFilename = filename; };
 globalThis.attachToTab = attachToTab;

--- a/packages/extension/src/panel/lib/commands.ts
+++ b/packages/extension/src/panel/lib/commands.ts
@@ -461,6 +461,11 @@ function resolveArgs(args: ParsedArgs): ParsedArgs | DirectExecution {
     return { jsExpr: call(waitMs, ms) };
   }
 
+  // ── Download as ─────────────────────────────────────────────
+  // Handled directly by handleBridgeCommand
+  if (cmdName === 'download-as')
+    return args;
+
   // ── Eval ────────────────────────────────────────────────────
   if (cmdName === 'eval') {
     const code = args._[1] || '';

--- a/packages/extension/types.d.ts
+++ b/packages/extension/types.d.ts
@@ -6,6 +6,8 @@ declare var __consoleMessages: string[];
 declare var __networkRequests: Array<{ status: number; method: string; url: string; type: string }>;
 declare var __activeRoutes: string[];
 declare var __dialogMode: 'accept' | 'dismiss' | undefined;
+declare var __downloadFilename: string | undefined;
+declare var downloadAs: (filename: string) => void;
 
 // Exposed on globalThis for serviceWorker.evaluate() / VS Code CDP injection
 declare var attachToTab: (tabId: number) => Promise<{ ok: boolean; url?: string; error?: string }>;

--- a/packages/stagecraft/skills/rogers/download-bill.js
+++ b/packages/stagecraft/skills/rogers/download-bill.js
@@ -1,17 +1,21 @@
 /**
  * Download Rogers bill PDFs for specified billing periods.
+ * Uses global `page` from the service worker context.
  *
- * @param {import('playwright').Page} page
  * @param {string[]} periods - Billing period labels, e.g. ["January 24, 2026", "February 24, 2026"]
+ * @param {string} [filename] - Save path relative to Downloads, e.g. "bills/rogers-2026-03.pdf"
  */
-async function downloadRogersBill(page, periods) {
-  await page.goto('https://www.rogers.com/consumer/self-serve/overview');
+async function downloadRogersBill(periods, filename) {
+  await page.goto('https://www.rogers.com/consumer/self-serve/overview', { waitUntil: 'domcontentloaded' });
   await page.getByText('View your bill').filter({ visible: true }).first().click();
   await page.getByText('Save PDF').click();
 
+  await page.getByText('Download one or more bills').waitFor();
   for (const period of periods) {
-    await page.getByText(period, { exact: true }).first().click();
+    await page.getByRole('checkbox', { name: period }).check();
   }
 
+  if (filename) downloadAs(filename);
   await page.getByText('Download bills').click();
+  return filename || 'Downloads folder (default name)';
 }

--- a/packages/stagecraft/skills/rogers/download-bill.pw
+++ b/packages/stagecraft/skills/rogers/download-bill.pw
@@ -9,4 +9,5 @@ goto https://www.rogers.com/consumer/self-serve/overview
 click "View your bill" --exact
 click "Save PDF"
 check "{{billing_period}}"
+download-as {{filename}}
 click "Download bills"


### PR DESCRIPTION
## Summary

- Adds `download-as <path>` .pw command — sets filename for next Chrome download via `chrome.downloads.onDeterminingFilename`
- Adds `downloadAs(filename)` JS global for .js skills
- Adds `pw-cli --load file.js` — loads JS file as global function definitions in the service worker
- Updates Rogers bill download skill with download support, reliable `goto`, and proper checkbox targeting

## Investigation findings

- `page.waitForEvent('download')` does **not** work in playwright-crx — times out and crashes the extension
- `page.goto()` with default `waitUntil: 'load'` hangs inside `cdpEval` on heavy pages — use `domcontentloaded` instead

## Usage

**.pw files:**
```pw
download-as bills/rogers-2026-03.pdf
click "Download bills"
```

**JS skills:**
```js
downloadAs('bills/rogers-2026-03.pdf');
await page.getByText('Download bills').click();
```

**Loading JS skills:**
```bash
pw-cli --load skills/rogers/download-bill.js
pw-cli "await downloadRogersBill(['March 24, 2026'], 'bills/rogers.pdf')"
```

## Test plan

- [x] `download-as` sets filename, verified file in Downloads folder
- [x] `downloadAs()` JS global works in extension context
- [x] `pw-cli --load` defines functions as globals, callable afterward
- [x] Rogers skill downloads bill with custom filename end-to-end
- [x] All 195 existing tests pass

Closes #845

🤖 Generated with [Claude Code](https://claude.com/claude-code)