### PR TITLE
feat: CDP relay for bridge mode — real Playwright page objects

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -138,8 +138,12 @@ jobs:
         run: pnpm exec playwright install chromium chrome
         working-directory: packages/cli
 
-      - name: Run CLI E2E tests
+      - name: Run CLI E2E tests (default mode)
         run: node dist/playwright-repl.js --headless --replay examples/
+        working-directory: packages/cli
+
+      - name: Run CLI E2E tests (relay mode)
+        run: node dist/playwright-repl.js --relay --headless --replay examples/
         working-directory: packages/cli
 
   extension:

--- a/STAGECRAFT-PLAN.md
+++ b/STAGECRAFT-PLAN.md
@@ -1,0 +1,208 @@
+# Stagecraft Plan — T2 Tax Return Use Case
+
+Issue: https://github.com/stevez/playwright-repl/issues/829
+
+## Use Case
+
+Automate T2 tax return preparation: download bills from various websites, extract into Excel, compile for filing. This is repeated annual work with many different bill sources. Use Stagecraft to generate .pw files, create skills, manage them, and expose to Claude Cowork.
+
+## What .pw Skills Can and Can't Do
+
+`.pw` files are browser keyword commands (`goto`, `click`, `fill`, `snapshot`, `press`, etc.). They **only navigate and interact** with the browser — they cannot download files, read PDFs, write Excel, or do computation.
+
+A `.pw` skill can navigate to a billing page, click through menus, and click the "Download" button — but the actual file download is a browser/OS-level action outside `.pw` scope.
+
+```
+.pw skills (browser navigation):     Agent responsibilities (everything else):
+├── navigate-to-bell-bill.pw         ├── Handle file downloads
+├── navigate-to-hydro-bill.pw        ├── Read downloaded PDFs
+├── navigate-to-insurance-bill.pw    ├── Extract fields (date, amount, vendor, category)
+└── ...                              ├── Compile into Excel
+                                     └── Categorize for T2 filing
+```
+
+The agent **orchestrates**: calls .pw skills to navigate the browser to the right place, then handles downloads, extraction, and processing with its own capabilities.
+
+## Skills Structure
+
+```
+skills/
+├── tax/
+│   ├── download-bell-bill/
+│   │   ├── SKILL.md
+│   │   └── download-bell-bill.pw
+│   ├── download-hydro-bill/
+│   │   ├── SKILL.md
+│   │   └── download-hydro-bill.pw
+│   └── download-insurance-bill/
+│       ├── SKILL.md
+│       └── download-insurance-bill.pw
+```
+
+Each skill = `SKILL.md` (metadata) + `.pw` recipe (browser automation steps only).
+
+### SKILL.md Format
+
+```markdown
+name: download-bell-bill
+description: Download latest Bell Canada bill as PDF
+preconditions: Must be logged into bell.ca (or have credentials in vault)
+parameters:
+  - billing_period: "2025-Q4" (optional, defaults to latest)
+output: PDF file path
+category: tax/bills/telecom
+```
+
+## Design Decisions
+
+### Authentication / Session Reuse
+
+Two approaches:
+
+1. **Bridge mode** (primary) — connect to user's real Chrome session via Dramaturg bridge. User is already logged into bill sites. Cowork runs skills against existing cookies/sessions.
+2. **Headless with credential vault** (future) — skills carry auth steps, credentials stored securely. For unattended/scheduled runs.
+
+Bridge mode is the natural starting point for this use case.
+
+### Skill Authoring Flow
+
+1. Open bill site in Chrome with Dramaturg installed
+2. Record the navigation flow (login, find billing page, download PDF)
+3. Dramaturg produces a `.pw` file
+4. Run `stagecraft skill create download-bell-bill` — wraps .pw with SKILL.md
+5. Test: `stagecraft skill run download-bell-bill`
+6. Repeat for each bill source
+
+### Consumption by Agents (Cowork)
+
+The agent (Cowork/Claude) is the orchestrator. It uses the existing `run_command` MCP tool for everything — navigation, recording, replay. No new MCP tools needed.
+
+The agent's knowledge of how to record and use skills comes from a **skill file / agent.md** — instructions, not code:
+
+```markdown
+# Skill: Record a browser workflow
+
+When asked to create a .pw script for a repeated task:
+1. run_command("start-recording <name>.pw")
+2. Navigate the site using run_command (goto, click, fill, etc.)
+3. run_command("stop-recording")
+
+The recorder converts ref IDs to stable text locators automatically.
+
+To replay a saved skill:
+1. run_command("replay <name>.pw")
+```
+
+The agent decides which bills to fetch, records reusable .pw scripts, then handles downloads, PDF parsing, and Excel compilation with its own capabilities.
+
+### Stagecraft Components (Driven by Use Case)
+
+No new MCP tools needed. Recording and replay are `.pw` commands exposed through the existing `run_command` tool. Agent knowledge lives in skill files / agent.md.
+
+| Need | How |
+|------|-----|
+| Record a workflow | `start-recording` / `stop-recording` commands (via `run_command`) |
+| Replay a workflow | `replay <name>.pw` command (via `run_command`) |
+| Agent knows how to use them | Skill file / agent.md with instructions |
+| Store .pw files + metadata | Skills library (filesystem) |
+| List / manage skills | CLI `stagecraft list` (future) |
+| See what's happening | Web dashboard (nice-to-have, future) |
+
+## Implementation Phases
+
+### Phase 1: Recording Commands
+
+- Add `start-recording` / `stop-recording` as .pw commands in `packages/core`
+- Move `SessionRecorder` from `packages/cli` to `packages/core` (shared by CLI + MCP)
+- Add ref-to-locator resolution using snapshot data at record time
+- Both CLI and MCP get recording for free through existing `run_command`
+
+### Phase 2: Prove the Loop
+
+- Write a skill file (agent.md) with recording instructions
+- Have Cowork record 2-3 bill navigation flows via MCP
+- Verify the output .pw files use stable text locators
+- Replay them — confirm they work across sessions
+- Document friction
+
+### Phase 3: Skill Library
+
+- Define SKILL.md schema (metadata + parameters)
+- Skills directory convention (where skills live on disk)
+- CLI `stagecraft list` / `stagecraft run <skill>`
+
+### Phase 4: Dashboard (future)
+
+- Web dashboard: execution log, skills catalog
+- Error handling: session expired, element not found, retry logic
+
+## Ref-to-Locator Conversion
+
+### Problem
+
+When an AI agent navigates via MCP, it uses ephemeral ref IDs (`click e5`). These break on replay because refs are reassigned each `snapshot`. Human recording via Dramaturg captures stable DOM locators, but AI-side recording does not.
+
+### Solution: Resolve at Record Time Using Snapshot
+
+The snapshot already maps every ref to its accessible name and role. Conversion is just a lookup — must happen at record time because the mapping only exists during the session.
+
+```
+Snapshot contains:   e5 → "Download Bill" (button)
+                     e12 → "View Statement" (link)
+
+Agent runs:          click e5        → recorder writes: click "Download Bill"
+                     click e12       → recorder writes: click "View Statement"
+```
+
+No post-processing needed. The recorder intercepts each command, looks up the ref in the current snapshot, and writes the stable locator directly.
+
+### Where it lives
+
+- `packages/core` — recorder + ref-to-locator resolution (shared by CLI and MCP)
+- Automatic: every recorded command uses stable locators
+- Edge case: if a ref has no accessible name, flag for manual review
+
+## Template Variables in .pw Files
+
+`.pw` files support `{{variable}}` placeholders, substituted at replay time via `--variable key=value`:
+
+```pw
+goto https://www.rogers.com/consumer/self-serve/overview
+click "View your bill"
+click "Save PDF"
+check "{{billing_period}}"
+click "Download bills"
+```
+
+```
+replay skills/rogers/download-bill.pw --variable billing_period="January 24, 2026"
+```
+
+### How it works
+
+- `replay` reads the .pw file, replaces `{{key}}` with the `--variable key=value` arg, then runs each line
+- Multiple variables: `--variable a="x" --variable b="y"`
+- No loops, no conditionals — just string replacement
+- For complex logic (loops, conditionals), use `.js` skills instead
+
+### Agent workflow
+
+The agent:
+1. Reads SKILL.md to know what variables are needed
+2. Reads the page (snapshot) to discover available values
+3. Calls `replay` with the right `--variable` args
+4. For multiple values (e.g. 3 billing periods), calls `replay` 3 times or generates the script itself
+
+### .pw vs .js skills
+
+- `.pw` — simple, replayable, parameterized with `{{variables}}`
+- `.js` — full Playwright API, loops, conditionals, complex logic
+- Both live in the skills directory, SKILL.md describes which to use
+
+## Open Questions
+
+- Where do skills live on disk? Per-project? Global `~/.stagecraft/skills/`?
+- How does output pass between skills? (e.g., downloaded PDF path -> extract step)
+- How to handle sites that require 2FA during automation?
+- Should SKILL.md support versioning/changelog?
+- How much intelligence goes in the skill vs. the agent? (e.g., does the skill handle "bill not found" or does the agent?)

--- a/packages/cli/src/playwright-repl.ts
+++ b/packages/cli/src/playwright-repl.ts
@@ -17,7 +17,7 @@ import { minimist } from '@playwright-repl/core';
 import { startRepl } from './repl.js';
 
 const args = minimist(process.argv.slice(2), {
-  boolean: ['headed', 'headless', 'persistent', 'help', 'step', 'silent', 'spawn', 'bridge', 'engine', 'include-snapshot', 'verbose', 'http', 'interactive'],
+  boolean: ['headed', 'headless', 'persistent', 'help', 'step', 'silent', 'spawn', 'bridge', 'relay', 'engine', 'include-snapshot', 'verbose', 'http', 'interactive'],
   string: ['session', 'browser', 'profile', 'config', 'replay', 'record', 'connect', 'port', 'cdp-port', 'bridge-port', 'command', 'http-port'],
   alias: { s: 'session', h: 'help', b: 'browser', q: 'silent' },
   default: { session: 'default' },
@@ -115,6 +115,7 @@ startRepl({
   record: args.record as string,
   step: args.step as boolean,
   bridge: args.bridge as boolean,
+  relay: args.relay as boolean,
   engine: args.engine as boolean,
   http: args.http as boolean,
   httpPort: args['http-port'] ? parseInt(args['http-port'] as string, 10) : undefined,

--- a/packages/cli/src/repl.ts
+++ b/packages/cli/src/repl.ts
@@ -5,10 +5,12 @@
  */
 
 import readline from 'node:readline';
+import { createRequire } from 'node:module';
 import path from 'node:path';
 import fs from 'node:fs';
 import os from 'node:os';
 import http from 'node:http';
+import url from 'node:url';
 import {
   replVersion, parseInput, ALIASES, ALL_COMMANDS, buildCompletionItems, c, prettyJson,
   BridgeServer, CDPRelayServer, COMMANDS, CATEGORIES, JS_CATEGORIES,
@@ -847,6 +849,205 @@ async function runBridgeReplayMode(opts: ReplOpts, srv: BridgeServer): Promise<v
   process.exit(failCount > 0 ? 1 : 0);
 }
 
+// ─── Relay execution (keyword + JS) ─────────────────────────────────────────
+
+const AsyncFn = Object.getPrototypeOf(async function () {}).constructor;
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+interface RelayDeps {
+  BrowserBackend: new (config: any, browserContext: any, tools: any[]) => any;
+  browserTools: any[];
+  resolveConfig: (config: any) => Promise<any> | any;
+  commands: Record<string, any>;
+  parseCommand: (command: any, args: any) => { toolName: string; toolParams: Record<string, any> };
+}
+/* eslint-enable @typescript-eslint/no-explicit-any */
+
+let _relayDeps: RelayDeps | undefined;
+
+function loadRelayDeps(): RelayDeps {
+  if (_relayDeps) return _relayDeps;
+  const require = createRequire(import.meta.url);
+  const pwCoreDir = path.dirname(require.resolve('playwright-core/package.json'));
+  const pwCoreReq = (sub: string) => require(path.join(pwCoreDir, sub));
+  _relayDeps = {
+    BrowserBackend:  pwCoreReq('lib/tools/backend/browserBackend.js').BrowserBackend,
+    browserTools:    pwCoreReq('lib/tools/backend/tools.js').browserTools,
+    resolveConfig:   pwCoreReq('lib/tools/mcp/config.js').resolveConfig,
+    commands:        pwCoreReq('lib/tools/cli-daemon/commands.js').commands,
+    parseCommand:    pwCoreReq('lib/tools/cli-daemon/command.js').parseCommand,
+  };
+  return _relayDeps;
+}
+
+function isRelayExpression(code: string): boolean {
+  const trimmed = code.trim();
+  if (trimmed.includes('\n')) return false;
+  const withoutTrailing = trimmed.replace(/;$/, '');
+  if (withoutTrailing.includes(';')) return false;
+  if (/^(const |let |var |if |for |while |switch |try |class |function )/.test(trimmed)) return false;
+  return true;
+}
+
+function formatRelayResult(value: unknown): string {
+  if (value === undefined || value === null) return 'Done';
+  if (typeof value === 'string') return value;
+  if (typeof value === 'number' || typeof value === 'boolean') return String(value);
+  try { return JSON.stringify(value, null, 2); } catch { return String(value); }
+}
+
+function formatToolResult(result: { content: Array<{ type: string; text?: string; data?: string; mimeType?: string }>; isError?: boolean }): { text: string; isError: boolean } {
+  let text = '';
+  for (const item of result.content) {
+    if (item.type === 'text' && !text) text = item.text || '';
+  }
+  return { text: text || 'Done', isError: !!result.isError };
+}
+
+async function relayExec(
+  command: string,
+  page: any,
+  context: any,
+  expect: any,
+  backend: any,
+): Promise<{ text: string; isError: boolean }> {
+  const trimmed = command.trim();
+
+  // Keyword command → resolve args + BrowserBackend
+  const parsed = parseInput(trimmed);
+  if (parsed) {
+    const deps = loadRelayDeps();
+    const cmdName = parsed._[0];
+    if (cmdName && cmdName in deps.commands) {
+      // resolveArgs transforms role-based, text-based, verify, etc. into run-code
+      const resolved = resolveArgs(parsed);
+      const resolvedCmd = deps.commands[resolved._[0]];
+      if (!resolvedCmd) return { text: `Command "${resolved._[0]}" not supported in relay mode.`, isError: true };
+      const { toolName, toolParams } = deps.parseCommand(resolvedCmd, resolved);
+      if (!toolName) return { text: `Command "${cmdName}" not supported in relay mode.`, isError: true };
+      toolParams._meta = { cwd: process.cwd() };
+      try {
+        const response = await backend.callTool(toolName, toolParams);
+        return formatToolResult(response);
+      } catch (e: unknown) {
+        return { text: e instanceof Error ? e.message : String(e), isError: true };
+      }
+    }
+  }
+
+  // JavaScript → AsyncFunction
+  const script = isRelayExpression(trimmed)
+    ? `return ${trimmed.replace(/;$/, '')}`
+    : trimmed;
+  try {
+    const fn = new AsyncFn('page', 'context', 'expect', script);
+    const result = await fn(page, context, expect);
+    return { text: formatRelayResult(result), isError: false };
+  } catch (e: unknown) {
+    return { text: e instanceof Error ? e.message : String(e), isError: true };
+  }
+}
+
+// ─── Relay REPL loop ────────────────────────────────────────────────────────
+
+async function startRelayLoop(
+  opts: ReplOpts,
+  relay: CDPRelayServer,
+  browser: any,
+  page: any,
+  context: any,
+  expect: any,
+  backend: any,
+): Promise<void> {
+  const silent = opts.silent || false;
+  const log = (...args: unknown[]) => { if (!silent) console.log(...args); };
+
+  const historyDir = path.join(os.homedir(), '.playwright-repl');
+  const historyFile = path.join(historyDir, '.repl-history');
+
+  const promptReady = `${c.cyan}relay>${c.reset} `;
+  const promptCont  = `${c.dim}...${c.reset} `;
+
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+    prompt: promptReady,
+    historySize: 500,
+  });
+
+  try {
+    const hist = fs.readFileSync(historyFile, 'utf-8').split('\n').filter(Boolean).reverse();
+    for (const line of hist) (rl as readline.Interface & { history: string[] }).history.push(line);
+  } catch { /* ignore */ }
+
+  let buffer = '';
+  let processing = false;
+  const commandQueue: string[] = [];
+
+  async function handleLine(line: string): Promise<void> {
+    buffer = buffer ? buffer + '\n' + line : line;
+    if (!isComplete(buffer)) {
+      rl.setPrompt(promptCont);
+      return;
+    }
+    const command = buffer.trim();
+    buffer = '';
+    rl.setPrompt(promptReady);
+
+    if (!command || command.startsWith('#')) return;
+
+    // Meta-commands
+    if (command === '.exit' || command === '.quit') {
+      await browser.close().catch(() => {});
+      await relay.close();
+      process.exit(0);
+    }
+    if (command === '.clear') { console.clear(); return; }
+
+    // Record to history
+    try {
+      fs.mkdirSync(path.dirname(historyFile), { recursive: true });
+      fs.appendFileSync(historyFile, command + '\n');
+    } catch { /* ignore */ }
+
+    const startTime = performance.now();
+    const result = await relayExec(command, page, context, expect, backend);
+    const elapsed = (performance.now() - startTime).toFixed(0);
+    if (result.text) {
+      // Pass command name so filterResponse keeps the right sections
+      const parsed = parseInput(command);
+      const cmdName = parsed?._[0];
+      const filtered = filterResponse(result.text, cmdName);
+      if (filtered !== null) {
+        log(result.isError ? `${c.red}${filtered}${c.reset}` : filtered);
+      }
+    }
+    log(`${c.dim}(${elapsed}ms)${c.reset}`);
+  }
+
+  async function processQueue(): Promise<void> {
+    if (processing) return;
+    processing = true;
+    while (commandQueue.length > 0) {
+      await handleLine(commandQueue.shift()!);
+    }
+    processing = false;
+    rl.prompt();
+  }
+
+  rl.prompt();
+  rl.on('line', (line: string) => { commandQueue.push(line); processQueue(); });
+  rl.on('close', async () => {
+    await browser.close().catch(() => {});
+    await relay.close();
+    process.exit(0);
+  });
+  rl.on('SIGINT', () => {
+    if (buffer) { buffer = ''; rl.setPrompt(promptReady); rl.prompt(); }
+    else rl.close();
+  });
+}
+
 // ─── Bridge REPL loop ────────────────────────────────────────────────────────
 
 async function startBridgeLoop(opts: ReplOpts, srv: BridgeServer): Promise<void> {
@@ -1180,11 +1381,50 @@ export async function startRepl(opts: ReplOpts = {}): Promise<void> {
     log('Waiting for extension to connect...');
     await relay.waitForExtension(30000);
     log(`${c.green}✓${c.reset} Extension connected`);
-    log(`${c.dim}Connect Playwright: chromium.connectOverCDP('${relay.cdpEndpoint()}')${c.reset}`);
-    log(`${c.dim}Ctrl+C to exit.${c.reset}\n`);
-    await waitForShutdown(log);
-    await relay.close();
-    process.exit(0);
+
+    // Connect Playwright via CDP
+    const dynamicImport = Function('m', 'return import(m)') as (m: string) => Promise<any>;
+    const { chromium } = await dynamicImport('playwright');
+    const { expect: pwExpect } = await dynamicImport('@playwright/test').catch(() => ({ expect: undefined }));
+    const browser = await chromium.connectOverCDP(relay.cdpEndpoint());
+    const relayCtx = browser.contexts()[0];
+    const relayPage = relayCtx.pages()[0];
+    if (!relayPage) {
+      console.error(`${c.red}✗${c.reset} No page found — make sure a tab is open in Chrome`);
+      await relay.close();
+      process.exit(1);
+    }
+    log(`${c.green}✓${c.reset} Connected to page: ${relayPage.url()}`);
+
+    // Create BrowserBackend for keyword command support
+    const deps = loadRelayDeps();
+    const relayConfig = await deps.resolveConfig({
+      browser: { browserName: 'chromium', launchOptions: {}, contextOptions: { viewport: null }, isolated: false },
+      server: {},
+      network: {},
+      timeouts: { action: 5000, navigation: 15000 },
+    });
+    const relayBackend = new deps.BrowserBackend(relayConfig, relayCtx, deps.browserTools);
+    const cwd = process.cwd();
+    await relayBackend.initialize?.({
+      name: 'playwright-repl',
+      version: replVersion,
+      cwd,
+      roots: [{ uri: url.pathToFileURL(cwd).href, name: 'cwd' }],
+      timestamp: Date.now(),
+    });
+
+    if (opts.command) {
+      const result = await relayExec(opts.command, relayPage, relayCtx, pwExpect, relayBackend);
+      if (result.text) process.stdout.write(result.text + '\n');
+      await browser.close().catch(() => {});
+      await relay.close();
+      process.exit(result.isError ? 1 : 0);
+    }
+
+    log(`${c.dim}Type .help for commands, JavaScript supported${c.reset}\n`);
+    await startRelayLoop(opts, relay, browser, relayPage, relayCtx, pwExpect, relayBackend);
+    return;
   }
 
   // ─── Bridge mode ─────────────────────────────────────────────────

--- a/packages/cli/src/repl.ts
+++ b/packages/cli/src/repl.ts
@@ -5,16 +5,14 @@
  */
 
 import readline from 'node:readline';
-import { createRequire } from 'node:module';
 import path from 'node:path';
 import fs from 'node:fs';
 import os from 'node:os';
 import http from 'node:http';
-import url from 'node:url';
 import {
   replVersion, parseInput, ALIASES, ALL_COMMANDS, buildCompletionItems, c, prettyJson,
   BridgeServer, CDPRelayServer, COMMANDS, CATEGORIES, JS_CATEGORIES,
-  filterResponse as filterResponseBase, resolveArgs,
+  filterResponse as filterResponseBase, resolveArgs, resolveCommand,
   isLocalCommand, handleLocalCommand,
 } from '@playwright-repl/core';
 import type { EngineOpts, ParsedArgs, EngineResult, CompletionItem } from '@playwright-repl/core';
@@ -853,33 +851,6 @@ async function runBridgeReplayMode(opts: ReplOpts, srv: BridgeServer): Promise<v
 
 const AsyncFn = Object.getPrototypeOf(async function () {}).constructor;
 
-/* eslint-disable @typescript-eslint/no-explicit-any */
-interface RelayDeps {
-  BrowserBackend: new (config: any, browserContext: any, tools: any[]) => any;
-  browserTools: any[];
-  resolveConfig: (config: any) => Promise<any> | any;
-  commands: Record<string, any>;
-  parseCommand: (command: any, args: any) => { toolName: string; toolParams: Record<string, any> };
-}
-/* eslint-enable @typescript-eslint/no-explicit-any */
-
-let _relayDeps: RelayDeps | undefined;
-
-function loadRelayDeps(): RelayDeps {
-  if (_relayDeps) return _relayDeps;
-  const require = createRequire(import.meta.url);
-  const pwCoreDir = path.dirname(require.resolve('playwright-core/package.json'));
-  const pwCoreReq = (sub: string) => require(path.join(pwCoreDir, sub));
-  _relayDeps = {
-    BrowserBackend:  pwCoreReq('lib/tools/backend/browserBackend.js').BrowserBackend,
-    browserTools:    pwCoreReq('lib/tools/backend/tools.js').browserTools,
-    resolveConfig:   pwCoreReq('lib/tools/mcp/config.js').resolveConfig,
-    commands:        pwCoreReq('lib/tools/cli-daemon/commands.js').commands,
-    parseCommand:    pwCoreReq('lib/tools/cli-daemon/command.js').parseCommand,
-  };
-  return _relayDeps;
-}
-
 function isRelayExpression(code: string): boolean {
   const trimmed = code.trim();
   if (trimmed.includes('\n')) return false;
@@ -896,42 +867,23 @@ function formatRelayResult(value: unknown): string {
   try { return JSON.stringify(value, null, 2); } catch { return String(value); }
 }
 
-function formatToolResult(result: { content: Array<{ type: string; text?: string; data?: string; mimeType?: string }>; isError?: boolean }): { text: string; isError: boolean } {
-  let text = '';
-  for (const item of result.content) {
-    if (item.type === 'text' && !text) text = item.text || '';
-  }
-  return { text: text || 'Done', isError: !!result.isError };
-}
-
 async function relayExec(
   command: string,
   page: any,
   context: any,
   expect: any,
-  backend: any,
 ): Promise<{ text: string; isError: boolean }> {
   const trimmed = command.trim();
 
-  // Keyword command → resolve args + BrowserBackend
-  const parsed = parseInput(trimmed);
-  if (parsed) {
-    const deps = loadRelayDeps();
-    const cmdName = parsed._[0];
-    if (cmdName && cmdName in deps.commands) {
-      // resolveArgs transforms role-based, text-based, verify, etc. into run-code
-      const resolved = resolveArgs(parsed);
-      const resolvedCmd = deps.commands[resolved._[0]];
-      if (!resolvedCmd) return { text: `Command "${resolved._[0]}" not supported in relay mode.`, isError: true };
-      const { toolName, toolParams } = deps.parseCommand(resolvedCmd, resolved);
-      if (!toolName) return { text: `Command "${cmdName}" not supported in relay mode.`, isError: true };
-      toolParams._meta = { cwd: process.cwd() };
-      try {
-        const response = await backend.callTool(toolName, toolParams);
-        return formatToolResult(response);
-      } catch (e: unknown) {
-        return { text: e instanceof Error ? e.message : String(e), isError: true };
-      }
+  // Keyword command → resolveCommand → jsExpr → direct execution
+  const resolved = resolveCommand(trimmed);
+  if (resolved) {
+    try {
+      const fn = new AsyncFn('page', 'context', 'expect', resolved.jsExpr);
+      const result = await fn(page, context, expect);
+      return { text: formatRelayResult(result), isError: false };
+    } catch (e: unknown) {
+      return { text: e instanceof Error ? e.message : String(e), isError: true };
     }
   }
 
@@ -948,16 +900,113 @@ async function relayExec(
   }
 }
 
-// ─── Relay REPL loop ────────────────────────────────────────────────────────
+// ─── Relay replay mode ──────────────────────────────────────────────────────
 
-async function startRelayLoop(
+async function runRelayReplayMode(
   opts: ReplOpts,
-  relay: CDPRelayServer,
+  relay: CDPRelayServer | null,
   browser: any,
   page: any,
   context: any,
   expect: any,
-  backend: any,
+): Promise<void> {
+  const silent = opts.silent || false;
+  const log = (...args: unknown[]) => { if (!silent) console.log(...args); };
+
+  const files = resolveReplayFiles(opts.replay!, ['.pw', '.js']);
+  if (files.length === 0) {
+    console.error(`${c.red}Error:${c.reset} No .pw or .js files found`);
+    await browser.close().catch(() => {});
+    if (relay) await relay.close();
+    process.exit(1);
+  }
+
+  const results: { file: string; passed: boolean; commands: number; error?: string }[] = [];
+  const totalStart = performance.now();
+
+  if (files.length > 1) log(`${c.blue}▶${c.reset} Running ${c.bold}${files.length}${c.reset} files\n`);
+
+  for (const file of files) {
+    const basename = path.basename(file);
+    const commands = loadReplayFile(file);
+    const prefixed = files.length > 1;
+
+    if (prefixed) log(`${c.blue}▶${c.reset} ${c.bold}${basename}${c.reset}`);
+    else log(`${c.blue}▶${c.reset} Replaying ${c.bold}${file}${c.reset} (${commands.length} commands)\n`);
+
+    const fileStart = performance.now();
+    let commandsRun = 0;
+    let passed = true;
+    let errorMsg: string | undefined;
+
+    for (const cmd of commands) {
+      commandsRun++;
+      const indent = prefixed ? '  ' : '';
+      log(`${indent}${c.dim}[${commandsRun}/${commands.length}]${c.reset} ${cmd}`);
+
+      const startTime = performance.now();
+      const result = await relayExec(cmd, page, context, expect);
+      const elapsed = (performance.now() - startTime).toFixed(0);
+
+      if (result.text && result.text !== 'Done') {
+        log(`${indent}${result.isError ? `${c.red}${result.text}${c.reset}` : result.text}`);
+      }
+      log(`${indent}${c.dim}(${elapsed}ms)${c.reset}`);
+
+      if (result.isError) {
+        passed = false;
+        errorMsg = `failed at [${commandsRun}/${commands.length}]: ${cmd}`;
+        break;
+      }
+
+      if (opts.step && commandsRun < commands.length) {
+        await new Promise<void>((resolve) => {
+          process.stdout.write(`${c.dim}  Press Enter to continue...${c.reset}`);
+          process.stdin.once('data', () => { process.stdout.write('\r\x1b[K'); resolve(); });
+        });
+      }
+    }
+
+    const fileElapsed = ((performance.now() - fileStart) / 1000).toFixed(1);
+    if (prefixed) {
+      const status = passed ? `${c.green}PASS${c.reset}` : `${c.red}FAIL${c.reset}`;
+      log(`  ${status} ${basename} ${c.dim}(${fileElapsed}s)${c.reset}\n`);
+    } else if (passed) {
+      log(`\n${c.green}✓${c.reset} Replay complete`);
+    }
+
+    results.push({ file: basename, passed, commands: commandsRun, error: errorMsg });
+  }
+
+  // Multi-file summary
+  if (files.length > 1) {
+    const totalElapsed = ((performance.now() - totalStart) / 1000).toFixed(1);
+    const passCount = results.filter(r => r.passed).length;
+    const failCount = results.filter(r => !r.passed).length;
+
+    log(`${c.bold}─── Results ───${c.reset}`);
+    for (const r of results) {
+      const icon = r.passed ? `${c.green}✓${c.reset}` : `${c.red}✗${c.reset}`;
+      log(`  ${icon} ${r.file}${r.error ? ` — ${r.error}` : ''}`);
+    }
+    log(`\n${passCount} passed, ${failCount} failed (${results.length} total, ${totalElapsed}s)`);
+  }
+
+  await browser.close().catch(() => {});
+  if (relay) await relay.close();
+  const failCount = results.filter(r => !r.passed).length;
+  process.exit(failCount > 0 ? 1 : 0);
+}
+
+// ─── Relay REPL loop ────────────────────────────────────────────────────────
+
+async function startRelayLoop(
+  opts: ReplOpts,
+  relay: CDPRelayServer | null,
+  browser: any,
+  page: any,
+  context: any,
+  expect: any,
 ): Promise<void> {
   const silent = opts.silent || false;
   const log = (...args: unknown[]) => { if (!silent) console.log(...args); };
@@ -999,7 +1048,7 @@ async function startRelayLoop(
     // Meta-commands
     if (command === '.exit' || command === '.quit') {
       await browser.close().catch(() => {});
-      await relay.close();
+      if (relay) await relay.close();
       process.exit(0);
     }
     if (command === '.clear') { console.clear(); return; }
@@ -1011,7 +1060,7 @@ async function startRelayLoop(
     } catch { /* ignore */ }
 
     const startTime = performance.now();
-    const result = await relayExec(command, page, context, expect, backend);
+    const result = await relayExec(command, page, context, expect);
     const elapsed = (performance.now() - startTime).toFixed(0);
     if (result.text) {
       // Pass command name so filterResponse keeps the right sections
@@ -1039,7 +1088,7 @@ async function startRelayLoop(
   rl.on('line', (line: string) => { commandQueue.push(line); processQueue(); });
   rl.on('close', async () => {
     await browser.close().catch(() => {});
-    await relay.close();
+    if (relay) await relay.close();
     process.exit(0);
   });
   rl.on('SIGINT', () => {
@@ -1374,56 +1423,63 @@ export async function startRepl(opts: ReplOpts = {}): Promise<void> {
   // ─── Relay-only mode ───────────────────────────────────────────────
 
   if (opts.relay && !opts.bridge) {
-    const relay = new CDPRelayServer();
-    await relay.start();
-    log(`CDP relay listening on ${relay.cdpEndpoint()}`);
-    log(`Extension endpoint: ${relay.relayEndpoint()}`);
-    log('Waiting for extension to connect...');
-    await relay.waitForExtension(30000);
-    log(`${c.green}✓${c.reset} Extension connected`);
-
-    // Connect Playwright via CDP
     const dynamicImport = Function('m', 'return import(m)') as (m: string) => Promise<any>;
     const { chromium } = await dynamicImport('playwright');
     const { expect: pwExpect } = await dynamicImport('@playwright/test').catch(() => ({ expect: undefined }));
-    const browser = await chromium.connectOverCDP(relay.cdpEndpoint());
-    const relayCtx = browser.contexts()[0];
-    const relayPage = relayCtx.pages()[0];
-    if (!relayPage) {
-      console.error(`${c.red}✗${c.reset} No page found — make sure a tab is open in Chrome`);
-      await relay.close();
-      process.exit(1);
+
+    let browser: any;
+    let relayCtx: any;
+    let relayPage: any;
+    let relay: CDPRelayServer | null = null;
+
+    const headless = opts.headed === false; // explicit --headless
+
+    if (!headless) {
+      // Headed (default): connect to existing Chrome via extension + CDP relay
+      relay = new CDPRelayServer();
+      await relay.start();
+      log(`CDP relay listening on ${relay.cdpEndpoint()}`);
+      log(`Extension endpoint: ${relay.relayEndpoint()}`);
+      log('Waiting for extension to connect...');
+      await relay.waitForExtension(30000);
+      log(`${c.green}✓${c.reset} Extension connected`);
+      browser = await chromium.connectOverCDP(relay.cdpEndpoint());
+      relayCtx = browser.contexts()[0];
+      relayPage = relayCtx.pages()[0];
+      if (!relayPage) {
+        console.error(`${c.red}✗${c.reset} No page found — make sure a tab is open in Chrome`);
+        await relay.close();
+        process.exit(1);
+      }
+    } else {
+      // Headless: launch browser directly — no extension needed
+      log(`${c.dim}Launching headless browser...${c.reset}`);
+      browser = await chromium.launch({ headless: true });
+      relayCtx = await browser.newContext();
+      relayPage = await relayCtx.newPage();
     }
+
     log(`${c.green}✓${c.reset} Connected to page: ${relayPage.url()}`);
 
-    // Create BrowserBackend for keyword command support
-    const deps = loadRelayDeps();
-    const relayConfig = await deps.resolveConfig({
-      browser: { browserName: 'chromium', launchOptions: {}, contextOptions: { viewport: null }, isolated: false },
-      server: {},
-      network: {},
-      timeouts: { action: 5000, navigation: 15000 },
-    });
-    const relayBackend = new deps.BrowserBackend(relayConfig, relayCtx, deps.browserTools);
-    const cwd = process.cwd();
-    await relayBackend.initialize?.({
-      name: 'playwright-repl',
-      version: replVersion,
-      cwd,
-      roots: [{ uri: url.pathToFileURL(cwd).href, name: 'cwd' }],
-      timestamp: Date.now(),
-    });
+    const cleanup = async () => {
+      await browser.close().catch(() => {});
+      if (relay) await relay.close();
+    };
 
     if (opts.command) {
-      const result = await relayExec(opts.command, relayPage, relayCtx, pwExpect, relayBackend);
+      const result = await relayExec(opts.command, relayPage, relayCtx, pwExpect);
       if (result.text) process.stdout.write(result.text + '\n');
-      await browser.close().catch(() => {});
-      await relay.close();
+      await cleanup();
       process.exit(result.isError ? 1 : 0);
     }
 
+    if (opts.replay && opts.replay.length > 0) {
+      await runRelayReplayMode(opts, relay, browser, relayPage, relayCtx, pwExpect);
+      return;
+    }
+
     log(`${c.dim}Type .help for commands, JavaScript supported${c.reset}\n`);
-    await startRelayLoop(opts, relay, browser, relayPage, relayCtx, pwExpect, relayBackend);
+    await startRelayLoop(opts, relay, browser, relayPage, relayCtx, pwExpect);
     return;
   }
 

--- a/packages/cli/src/repl.ts
+++ b/packages/cli/src/repl.ts
@@ -1201,12 +1201,7 @@ export async function startRepl(opts: ReplOpts = {}): Promise<void> {
       relay = new CDPRelayServer();
       await relay.start();
       log(`CDP relay listening on ${relay.cdpEndpoint()}`);
-      // When extension connects to bridge, tell it to also connect to the relay
-      srv.onConnect(async () => {
-        const relayUrl = relay!.relayEndpoint();
-        await srv.run(`chrome.runtime.sendMessage({ type: 'cdp-relay-connect', relayUrl: '${relayUrl}' })`);
-        log(`${c.green}✓${c.reset} Extension connected to CDP relay`);
-      });
+      // Extension auto-connects to relay (bridge port + 1)
     }
     if (opts.command) {
       await srv.waitForConnection(30000);

--- a/packages/cli/src/repl.ts
+++ b/packages/cli/src/repl.ts
@@ -11,7 +11,7 @@ import os from 'node:os';
 import http from 'node:http';
 import {
   replVersion, parseInput, ALIASES, ALL_COMMANDS, buildCompletionItems, c, prettyJson,
-  BridgeServer, COMMANDS, CATEGORIES, JS_CATEGORIES,
+  BridgeServer, CDPRelayServer, COMMANDS, CATEGORIES, JS_CATEGORIES,
   filterResponse as filterResponseBase, resolveArgs,
   isLocalCommand, handleLocalCommand,
 } from '@playwright-repl/core';
@@ -30,6 +30,7 @@ export interface ReplOpts extends EngineOpts {
   command?: string;
   bridge?: boolean;
   bridgePort?: number;
+  relay?: boolean;
   engine?: boolean;
   http?: boolean;
   httpPort?: number;
@@ -1123,7 +1124,7 @@ export async function startRepl(opts: ReplOpts = {}): Promise<void> {
 
   // ─── Standalone mode (new: serviceWorker.evaluate) ─────────────
 
-  if (!opts.bridge && !opts.connect && !opts.engine) {
+  if (!opts.bridge && !opts.relay && !opts.connect && !opts.engine) {
     const { EvaluateConnection, findExtensionPath } = await import('@playwright-repl/core');
     const extPath = process.env.VITEST ? null : findExtensionPath(import.meta.url);
     if (extPath) {
@@ -1169,6 +1170,23 @@ export async function startRepl(opts: ReplOpts = {}): Promise<void> {
     }
   }
 
+  // ─── Relay-only mode ───────────────────────────────────────────────
+
+  if (opts.relay && !opts.bridge) {
+    const relay = new CDPRelayServer();
+    await relay.start();
+    log(`CDP relay listening on ${relay.cdpEndpoint()}`);
+    log(`Extension endpoint: ${relay.relayEndpoint()}`);
+    log('Waiting for extension to connect...');
+    await relay.waitForExtension(30000);
+    log(`${c.green}✓${c.reset} Extension connected`);
+    log(`${c.dim}Connect Playwright: chromium.connectOverCDP('${relay.cdpEndpoint()}')${c.reset}`);
+    log(`${c.dim}Ctrl+C to exit.${c.reset}\n`);
+    await waitForShutdown(log);
+    await relay.close();
+    process.exit(0);
+  }
+
   // ─── Bridge mode ─────────────────────────────────────────────────
 
   if (opts.bridge) {
@@ -1176,6 +1194,20 @@ export async function startRepl(opts: ReplOpts = {}): Promise<void> {
     const srv = new BridgeServer();
     await srv.start(port, { silent: !!opts.command });
     log(`Bridge server listening on ws://localhost:${port}`);
+
+    // Start CDP relay alongside bridge when --relay is specified
+    let relay: CDPRelayServer | null = null;
+    if (opts.relay) {
+      relay = new CDPRelayServer();
+      await relay.start();
+      log(`CDP relay listening on ${relay.cdpEndpoint()}`);
+      // When extension connects to bridge, tell it to also connect to the relay
+      srv.onConnect(async () => {
+        const relayUrl = relay!.relayEndpoint();
+        await srv.run(`chrome.runtime.sendMessage({ type: 'cdp-relay-connect', relayUrl: '${relayUrl}' })`);
+        log(`${c.green}✓${c.reset} Extension connected to CDP relay`);
+      });
+    }
     if (opts.command) {
       await srv.waitForConnection(30000);
       const result = await srv.run(opts.command);

--- a/packages/core/src/cdp-relay-server.ts
+++ b/packages/core/src/cdp-relay-server.ts
@@ -181,10 +181,12 @@ export class CDPRelayServer {
 
     private async _handlePlaywrightMessage(message: CDPCommand) {
         const { id, sessionId, method, params } = message;
+        console.error(`[cdp-relay] ← PW: ${method} (id=${id})`);
         try {
             const result = await this._handleCDPCommand(method, params, sessionId);
             this._sendToPlaywright({ id, sessionId, result });
         } catch (e) {
+            console.error(`[cdp-relay] ✗ ${method}: ${(e as Error).message}`);
             this._sendToPlaywright({ id, sessionId, error: { message: (e as Error).message } });
         }
     }
@@ -246,6 +248,7 @@ export class CDPRelayServer {
         };
 
         this._extensionConnection.onmessage = (method, params) => {
+            console.error(`[cdp-relay] ← EXT: ${method}`, (params as { method?: string })?.method || '');
             if (method === 'forwardCDPEvent') {
                 const p = params as { method: string; sessionId?: string; params?: unknown };
                 this._sendToPlaywright({

--- a/packages/core/src/cdp-relay-server.ts
+++ b/packages/core/src/cdp-relay-server.ts
@@ -196,6 +196,8 @@ export class CDPRelayServer {
             case 'Browser.getVersion':
                 return { protocolVersion: '1.3', product: 'Chrome/Dramaturg-Bridge', userAgent: 'CDP-Bridge-Server/1.0.0' };
             case 'Browser.setDownloadBehavior':
+                // chrome.debugger is tab-level — can't handle browser-level commands.
+                // Downloads use `download-as` / chrome.downloads API instead.
                 return {};
             case 'Target.setAutoAttach': {
                 // Forward child session handling

--- a/packages/core/src/cdp-relay-server.ts
+++ b/packages/core/src/cdp-relay-server.ts
@@ -1,0 +1,268 @@
+/**
+ * CDP Relay Server — bridges Playwright MCP and Dramaturg extension.
+ *
+ * Two WebSocket endpoints on one HTTP server:
+ *   /cdp/{uuid}       — Playwright connectOverCDP() connects here
+ *   /relay/{uuid}     — Extension connects here (via offscreen document)
+ *
+ * Protocol (v1): extension receives `attachToTab` and `forwardCDPCommand`,
+ * sends back `forwardCDPEvent`. The relay translates between standard CDP
+ * (Playwright side) and the wrapped extension protocol.
+ */
+
+import http from 'node:http';
+import { WebSocketServer, WebSocket } from 'ws';
+
+// ─── Protocol types (v1, matches Playwright 1.59) ────────────────────────────
+
+export type ExtensionCommand = {
+    'attachToTab': { params: Record<string, never> };
+    'forwardCDPCommand': { params: { method: string; sessionId?: string; params?: unknown } };
+};
+
+export type ExtensionEvents = {
+    'forwardCDPEvent': { params: { method: string; sessionId?: string; params?: unknown } };
+};
+
+type CDPCommand = { id: number; sessionId?: string; method: string; params?: unknown };
+type CDPResponse = { id?: number; sessionId?: string; method?: string; params?: unknown; result?: unknown; error?: { code?: number; message: string } };
+
+// ─── ExtensionConnection ─────────────────────────────────────────────────────
+
+class ExtensionConnection {
+    private readonly _ws: WebSocket;
+    private readonly _callbacks = new Map<number, { resolve: (o: unknown) => void; reject: (e: Error) => void }>();
+    private _lastId = 0;
+
+    onmessage?: <M extends keyof ExtensionEvents>(method: M, params: ExtensionEvents[M]['params']) => void;
+    onclose?: (self: ExtensionConnection, reason: string) => void;
+
+    constructor(ws: WebSocket) {
+        this._ws = ws;
+        this._ws.on('message', (data) => this._onMessage(data));
+        this._ws.on('close', (code, reason) => this._onClose(code, String(reason)));
+        this._ws.on('error', () => { /* logged by relay */ });
+    }
+
+    async send<M extends keyof ExtensionCommand>(method: M, params: ExtensionCommand[M]['params']): Promise<unknown> {
+        if (this._ws.readyState !== WebSocket.OPEN)
+            throw new Error(`WebSocket not open (state: ${this._ws.readyState})`);
+        const id = ++this._lastId;
+        this._ws.send(JSON.stringify({ id, method, params }));
+        return new Promise((resolve, reject) => {
+            this._callbacks.set(id, { resolve, reject });
+        });
+    }
+
+    close(message: string) {
+        if (this._ws.readyState === WebSocket.OPEN)
+            this._ws.close(1000, message);
+    }
+
+    private _onMessage(data: unknown) {
+        let msg: { id?: number; method?: string; params?: unknown; result?: unknown; error?: string };
+        try { msg = JSON.parse(String(data)); } catch { this._ws.close(); return; }
+
+        if (msg.id && this._callbacks.has(msg.id)) {
+            const cb = this._callbacks.get(msg.id)!;
+            this._callbacks.delete(msg.id);
+            if (msg.error) cb.reject(new Error(msg.error));
+            else cb.resolve(msg.result);
+        } else if (!msg.id && msg.method) {
+            this.onmessage?.(msg.method as keyof ExtensionEvents, msg.params as ExtensionEvents[keyof ExtensionEvents]['params']);
+        }
+    }
+
+    private _onClose(_code: number, reason: string) {
+        for (const cb of this._callbacks.values()) cb.reject(new Error('WebSocket closed'));
+        this._callbacks.clear();
+        this.onclose?.(this, reason);
+    }
+}
+
+// ─── CDPRelayServer ──────────────────────────────────────────────────────────
+
+export class CDPRelayServer {
+    private _httpServer: http.Server;
+    private _wss: WebSocketServer;
+    private _playwrightConnection: WebSocket | null = null;
+    private _extensionConnection: ExtensionConnection | null = null;
+    private _connectedTabInfo: { targetInfo: unknown; sessionId: string } | undefined;
+    private _nextSessionId = 1;
+    private _cdpPath: string;
+    private _relayPath: string;
+    private _extensionWaiters: Array<{ resolve: () => void; reject: (err: Error) => void; timer: ReturnType<typeof setTimeout> }> = [];
+
+    constructor() {
+        this._cdpPath = '/cdp';
+        this._relayPath = '/relay';
+        this._httpServer = http.createServer();
+        this._wss = new WebSocketServer({ server: this._httpServer });
+        this._wss.on('connection', (ws, req) => this._onConnection(ws, req));
+    }
+
+    /** Start the HTTP + WebSocket server. Default port 9877. */
+    async start(port = 9877): Promise<void> {
+        await new Promise<void>((resolve, reject) => {
+            this._httpServer.on('listening', resolve);
+            this._httpServer.on('error', reject);
+            this._httpServer.listen(port, '127.0.0.1');
+        });
+    }
+
+    get port(): number {
+        return (this._httpServer.address() as { port: number }).port;
+    }
+
+    /** Endpoint for Playwright connectOverCDP(). */
+    cdpEndpoint(): string {
+        return `ws://127.0.0.1:${this.port}${this._cdpPath}`;
+    }
+
+    /** Endpoint for the extension to connect to. */
+    relayEndpoint(): string {
+        return `ws://127.0.0.1:${this.port}${this._relayPath}`;
+    }
+
+    get extensionConnected(): boolean {
+        return this._extensionConnection !== null;
+    }
+
+    /** Wait for the extension to connect via the /relay/ endpoint. */
+    async waitForExtension(timeoutMs = 10000): Promise<void> {
+        if (this._extensionConnection) return;
+        return new Promise((resolve, reject) => {
+            const timer = setTimeout(() => {
+                this._extensionWaiters = this._extensionWaiters.filter(w => w.resolve !== resolve);
+                reject(new Error('Extension connection timeout'));
+            }, timeoutMs);
+            this._extensionWaiters.push({ resolve, reject, timer });
+        });
+    }
+
+    async close(): Promise<void> {
+        this._playwrightConnection?.close();
+        this._extensionConnection?.close('Server stopped');
+        this._wss.close();
+        await new Promise<void>(r => this._httpServer.close(() => r()));
+    }
+
+    // ── Connection routing ─────────────────────────────────────────────────
+
+    private _onConnection(ws: WebSocket, req: http.IncomingMessage) {
+        const url = new URL(`http://localhost${req.url}`);
+        if (url.pathname === this._cdpPath) this._handlePlaywrightConnection(ws);
+        else if (url.pathname === this._relayPath) this._handleExtensionConnection(ws);
+        else ws.close(4004, 'Invalid path');
+    }
+
+    // ── Playwright (CDP client) side ───────────────────────────────────────
+
+    private _handlePlaywrightConnection(ws: WebSocket) {
+        if (this._playwrightConnection) { ws.close(1000, 'Another CDP client already connected'); return; }
+        this._playwrightConnection = ws;
+
+        ws.on('message', async (data) => {
+            try {
+                const message: CDPCommand = JSON.parse(String(data));
+                await this._handlePlaywrightMessage(message);
+            } catch (e) {
+                console.error('[cdp-relay] error handling Playwright message:', (e as Error).message);
+            }
+        });
+
+        ws.on('close', () => {
+            if (this._playwrightConnection !== ws) return;
+            this._playwrightConnection = null;
+            this._extensionConnection?.close('Playwright client disconnected');
+            this._resetExtension();
+        });
+    }
+
+    private async _handlePlaywrightMessage(message: CDPCommand) {
+        const { id, sessionId, method, params } = message;
+        try {
+            const result = await this._handleCDPCommand(method, params, sessionId);
+            this._sendToPlaywright({ id, sessionId, result });
+        } catch (e) {
+            this._sendToPlaywright({ id, sessionId, error: { message: (e as Error).message } });
+        }
+    }
+
+    private async _handleCDPCommand(method: string, params: unknown, sessionId?: string): Promise<unknown> {
+        switch (method) {
+            case 'Browser.getVersion':
+                return { protocolVersion: '1.3', product: 'Chrome/Dramaturg-Bridge', userAgent: 'CDP-Bridge-Server/1.0.0' };
+            case 'Browser.setDownloadBehavior':
+                return {};
+            case 'Target.setAutoAttach': {
+                // Forward child session handling
+                if (sessionId) break;
+                // Simulate auto-attach with real target info
+                const { targetInfo } = await this._extensionConnection!.send('attachToTab', {}) as { targetInfo: unknown };
+                this._connectedTabInfo = {
+                    targetInfo,
+                    sessionId: `pw-tab-${this._nextSessionId++}`,
+                };
+                this._sendToPlaywright({
+                    method: 'Target.attachedToTarget',
+                    params: {
+                        sessionId: this._connectedTabInfo.sessionId,
+                        targetInfo: { ...(this._connectedTabInfo.targetInfo as Record<string, unknown>), attached: true },
+                        waitingForDebugger: false,
+                    },
+                });
+                return {};
+            }
+            case 'Target.getTargetInfo':
+                return this._connectedTabInfo?.targetInfo;
+        }
+        return await this._forwardToExtension(method, params, sessionId);
+    }
+
+    private async _forwardToExtension(method: string, params: unknown, sessionId?: string): Promise<unknown> {
+        if (!this._extensionConnection) throw new Error('Extension not connected');
+        // Strip top-level sessionId (relay-only concept)
+        if (this._connectedTabInfo?.sessionId === sessionId) sessionId = undefined;
+        return await this._extensionConnection.send('forwardCDPCommand', { sessionId, method, params });
+    }
+
+    private _sendToPlaywright(message: CDPResponse) {
+        this._playwrightConnection?.send(JSON.stringify(message));
+    }
+
+    // ── Extension side ─────────────────────────────────────────────────────
+
+    private _handleExtensionConnection(ws: WebSocket) {
+        if (this._extensionConnection) { ws.close(1000, 'Another extension already connected'); return; }
+        this._extensionConnection = new ExtensionConnection(ws);
+
+        this._extensionConnection.onclose = (c, reason) => {
+            if (this._extensionConnection !== c) return;
+            this._resetExtension();
+            if (this._playwrightConnection?.readyState === WebSocket.OPEN)
+                this._playwrightConnection.close(1000, `Extension disconnected: ${reason}`);
+            this._playwrightConnection = null;
+        };
+
+        this._extensionConnection.onmessage = (method, params) => {
+            if (method === 'forwardCDPEvent') {
+                const p = params as { method: string; sessionId?: string; params?: unknown };
+                this._sendToPlaywright({
+                    sessionId: p.sessionId || this._connectedTabInfo?.sessionId,
+                    method: p.method,
+                    params: p.params,
+                });
+            }
+        };
+
+        // Flush waiters
+        for (const w of this._extensionWaiters) { clearTimeout(w.timer); w.resolve(); }
+        this._extensionWaiters = [];
+    }
+
+    private _resetExtension() {
+        this._connectedTabInfo = undefined;
+        this._extensionConnection = null;
+    }
+}

--- a/packages/core/src/cdp-relay-server.ts
+++ b/packages/core/src/cdp-relay-server.ts
@@ -181,12 +181,10 @@ export class CDPRelayServer {
 
     private async _handlePlaywrightMessage(message: CDPCommand) {
         const { id, sessionId, method, params } = message;
-        console.error(`[cdp-relay] ← PW: ${method} (id=${id})`);
         try {
             const result = await this._handleCDPCommand(method, params, sessionId);
             this._sendToPlaywright({ id, sessionId, result });
         } catch (e) {
-            console.error(`[cdp-relay] ✗ ${method}: ${(e as Error).message}`);
             this._sendToPlaywright({ id, sessionId, error: { message: (e as Error).message } });
         }
     }
@@ -250,7 +248,6 @@ export class CDPRelayServer {
         };
 
         this._extensionConnection.onmessage = (method, params) => {
-            console.error(`[cdp-relay] ← EXT: ${method}`, (params as { method?: string })?.method || '');
             if (method === 'forwardCDPEvent') {
                 const p = params as { method: string; sessionId?: string; params?: unknown };
                 this._sendToPlaywright({

--- a/packages/core/src/command-scripts.ts
+++ b/packages/core/src/command-scripts.ts
@@ -1,0 +1,485 @@
+// @ts-nocheck — Intentionally untyped so fn.toString() works for inline eval.
+/**
+ * Pure Playwright page-script functions for command execution.
+ *
+ * Each function takes (page, ...args) and returns a result string.
+ * Used by both the extension (via fn.toString() + eval) and relay (direct call).
+ *
+ * Chrome-dependent functions (tab-*, console, network, dialog, route)
+ * are NOT included — those live in platform-specific extensions.
+ */
+
+// ─── Navigation ─────────────────────────────────────────────────────────────
+
+export async function gotoUrl(page, url) {
+  await page.goto(url);
+  return 'Navigated to ' + url;
+}
+
+export async function reloadPage(page) {
+  await page.reload();
+  return 'Reloaded';
+}
+
+export async function goBack(page) {
+  await page.goBack();
+  return page.url();
+}
+
+export async function goForward(page) {
+  await page.goForward();
+  return page.url();
+}
+
+// ─── Timing ─────────────────────────────────────────────────────────────────
+
+export async function waitMs(page, ms) {
+  await page.waitForTimeout(ms);
+  return 'Waited ' + ms + 'ms';
+}
+
+// ─── Page info ──────────────────────────────────────────────────────────────
+
+export async function getTitle(page) {
+  return await page.title();
+}
+
+export async function getUrl(page) {
+  return page.url();
+}
+
+// ─── Eval / Run Code ────────────────────────────────────────────────────────
+
+export async function evalCode(page, code) {
+  const result = await page.evaluate(code);
+  return result !== undefined ? JSON.stringify(result) : 'undefined';
+}
+
+export async function runCode(page, code) {
+  const AsyncFunction = runCode.constructor;
+  const trimmed = code.trim();
+  const isFnExpr = /^(async\s*)?\(|^(async\s+)?function\b/.test(trimmed);
+  const body = isFnExpr ? `return (${trimmed})(page)` : `return ${trimmed}`;
+  const fn = new AsyncFunction('page', body);
+  const result = await fn(page);
+  return result != null && typeof result !== 'object' ? String(result) : 'Done';
+}
+
+// ─── Screenshot / Snapshot / PDF ────────────────────────────────────────────
+
+export async function takeScreenshot(page, fullPage) {
+  const data = await page.screenshot({ type: 'jpeg', fullPage: !!fullPage });
+  return { __image: data.toString('base64'), mimeType: 'image/jpeg' };
+}
+
+export async function takeSnapshot(page) {
+  if (typeof page.ariaSnapshot === 'function') {
+    return await page.ariaSnapshot({ mode: 'ai' });
+  }
+  if (typeof page._snapshotForAI === 'function') {
+    const result = await page._snapshotForAI();
+    return result.full ?? String(result);
+  }
+  const title = await page.title();
+  const url = page.url();
+  return 'Title: ' + title + '\nURL: ' + url;
+}
+
+export async function takePdf(page) {
+  const data = await page.pdf();
+  return { __image: data.toString('base64'), mimeType: 'application/pdf' };
+}
+
+// ─── Ref-based actions ──────────────────────────────────────────────────────
+
+export async function refAction(page, ref, action, value) {
+  const loc = page.locator('aria-ref=' + ref);
+  if (await loc.count() === 0) throw new Error('Element ' + ref + ' not found. Run snapshot first.');
+  if (value !== undefined) await loc[action](value);
+  else await loc[action]();
+  return 'Done';
+}
+
+// ─── Press / Type ───────────────────────────────────────────────────────────
+
+export async function pressKey(page, target, key) {
+  if (!target || target === key) {
+    await page.keyboard.press(target);
+    return 'Pressed ' + target;
+  }
+  const isRef = /^e\d+$/.test(target);
+  if (isRef) {
+    await page.locator('aria-ref=' + target).press(key);
+    return 'Pressed ' + key;
+  }
+  let loc = page.getByText(target, { exact: true });
+  if (await loc.count() === 0) loc = page.getByRole('textbox', { name: target });
+  if (await loc.count() === 0) loc = page.getByRole('combobox', { name: target });
+  if (await loc.count() === 0) loc = page.getByPlaceholder(target);
+  if (await loc.count() === 0) loc = page.getByText(target);
+  if (await loc.count() > 1) {
+    const visible = loc.filter({ visible: true });
+    const vc = await visible.count();
+    if (vc >= 1) loc = vc === 1 ? visible : visible.first();
+    else loc = loc.first();
+  }
+  await loc.press(key);
+  return 'Pressed ' + key;
+}
+
+export async function typeText(page, text) {
+  await page.keyboard.type(text);
+  return 'Typed';
+}
+
+// ─── Highlight ──────────────────────────────────────────────────────────────
+
+export async function highlightByText(page, text, nth?, exact?) {
+  let loc = exact ? page.getByText(text, { exact: true }) : page.getByText(text);
+  const count = await loc.count();
+  if (nth !== undefined) loc = loc.filter({ visible: true }).nth(nth);
+  await loc.highlight();
+  return nth !== undefined
+    ? 'Highlighted 1 of ' + count
+    : 'Highlighted ' + count + ' element' + (count !== 1 ? 's' : '');
+}
+
+export async function highlightByRole(page, role, name, nth, inRole?, inText?) {
+  const isUrl = role === 'link' && name && /^\/|^https?:\/\//.test(name);
+  const roleOpts = (name && !isUrl) ? { name, exact: true } : {};
+  let loc = isUrl ? page.locator('a[href^="' + name + '"]:not([aria-hidden="true"])') : page.getByRole(role, roleOpts);
+  if (inRole !== undefined && inText !== undefined) {
+    const cr = ({ list: 'listitem' })[inRole] || inRole;
+    loc = page.getByRole(cr).filter({ hasText: inText }).getByRole(role, roleOpts);
+  } else if (inText !== undefined) {
+    for (const r of ['region', 'group', 'article', 'listitem', 'dialog', 'form']) {
+      const scoped = page.getByRole(r).filter({ hasText: inText }).getByRole(role, roleOpts);
+      if (await scoped.count() > 0) { loc = scoped; break; }
+    }
+  }
+  const count = await loc.count();
+  if (nth !== undefined) loc = loc.nth(nth);
+  await loc.highlight();
+  return nth !== undefined
+    ? 'Highlighted 1 of ' + count
+    : 'Highlighted ' + count + ' element' + (count !== 1 ? 's' : '');
+}
+
+export async function highlightBySelector(page, selector, nth?) {
+  let loc = page.locator(selector);
+  const count = await loc.count();
+  if (nth !== undefined) loc = loc.filter({ visible: true }).nth(nth);
+  await loc.highlight();
+  return nth !== undefined
+    ? 'Highlighted 1 of ' + count
+    : 'Highlighted ' + count + ' element' + (count !== 1 ? 's' : '');
+}
+
+export async function highlightByRef(page, ref) {
+  const loc = page.locator('aria-ref=' + ref);
+  await loc.highlight();
+  return 'Highlighted';
+}
+
+export async function clearHighlight(page) {
+  await page.locator('#__pw_clear__').highlight().catch(() => {});
+  return 'Cleared';
+}
+
+// ─── Chaining (>> selectors) ────────────────────────────────────────────────
+
+export async function chainAction(page, selector, action, value) {
+  let loc = page.locator(selector);
+  if (await loc.count() > 1) {
+    const noHidden = page.locator(selector + ':not([aria-hidden="true"])');
+    if (await noHidden.count() === 1) { loc = noHidden; }
+    else {
+      const visible = loc.filter({ visible: true });
+      const vc = await visible.count();
+      if (vc >= 1) loc = vc === 1 ? visible : visible.first();
+      else loc = loc.first();
+    }
+  }
+  try {
+    if (value !== undefined) await loc[action](value);
+    else await loc[action]();
+  } catch {
+    if (value !== undefined) await loc[action](value, { force: true });
+    else await loc[action]({ force: true });
+  }
+  return 'Done';
+}
+
+// ─── Storage: localStorage ──────────────────────────────────────────────────
+
+export async function localStorageGet(page, key) {
+  return await page.evaluate(k => localStorage.getItem(k), key);
+}
+
+export async function localStorageSet(page, key, value) {
+  await page.evaluate(([k, v]) => localStorage.setItem(k, v), [key, value]);
+  return 'Set';
+}
+
+export async function localStorageDelete(page, key) {
+  await page.evaluate(k => localStorage.removeItem(k), key);
+  return 'Deleted';
+}
+
+export async function localStorageClear(page) {
+  await page.evaluate(() => localStorage.clear());
+  return 'Cleared';
+}
+
+export async function localStorageList(page) {
+  const items = await page.evaluate(() => {
+    const result = {};
+    for (let i = 0; i < localStorage.length; i++) {
+      const k = localStorage.key(i);
+      result[k] = localStorage.getItem(k);
+    }
+    return result;
+  });
+  return JSON.stringify(items, null, 2);
+}
+
+// ─── Storage: sessionStorage ────────────────────────────────────────────────
+
+export async function sessionStorageGet(page, key) {
+  return await page.evaluate(k => sessionStorage.getItem(k), key);
+}
+
+export async function sessionStorageSet(page, key, value) {
+  await page.evaluate(([k, v]) => sessionStorage.setItem(k, v), [key, value]);
+  return 'Set';
+}
+
+export async function sessionStorageDelete(page, key) {
+  await page.evaluate(k => sessionStorage.removeItem(k), key);
+  return 'Deleted';
+}
+
+export async function sessionStorageClear(page) {
+  await page.evaluate(() => sessionStorage.clear());
+  return 'Cleared';
+}
+
+export async function sessionStorageList(page) {
+  const items = await page.evaluate(() => {
+    const result = {};
+    for (let i = 0; i < sessionStorage.length; i++) {
+      const k = sessionStorage.key(i);
+      result[k] = sessionStorage.getItem(k);
+    }
+    return result;
+  });
+  return JSON.stringify(items, null, 2);
+}
+
+// ─── Cookies ────────────────────────────────────────────────────────────────
+
+export async function cookieList(page) {
+  const cookies = await page.context().cookies();
+  return JSON.stringify(cookies, null, 2);
+}
+
+export async function cookieGet(page, name) {
+  const cookies = await page.context().cookies();
+  const c = cookies.find(c => c.name === name);
+  return c ? JSON.stringify(c, null, 2) : 'Cookie not found: ' + name;
+}
+
+export async function cookieSet(page, name, value) {
+  const url = page.url();
+  await page.context().addCookies([{ name, value, url }]);
+  return 'Cookie set: ' + name;
+}
+
+export async function cookieDelete(page, name) {
+  await page.context().clearCookies({ name });
+  return 'Cookie deleted: ' + name;
+}
+
+export async function cookieClear(page) {
+  await page.context().clearCookies();
+  return 'Cleared';
+}
+
+// ─── Console / Network (relay state on page.__relay) ────────────────────────
+// Each function is self-contained — ensureRelayState is inlined so fn.toString() works.
+
+export async function getConsoleMessages(page, clear) {
+  if (!page.__relay) {
+    page.__relay = { console: [], network: [], dialogMode: null, routes: [] };
+    page.on('console', (msg) => { page.__relay.console.push('[' + msg.type() + '] ' + msg.text()); });
+    page.on('response', (resp) => { const url = resp.url(); if (url.startsWith('chrome-extension://')) return; const req = resp.request(); page.__relay.network.push({ status: resp.status(), method: req.method(), url, type: req.resourceType() }); });
+    page.on('dialog', async (dialog) => { if (page.__relay.dialogMode === 'accept') await dialog.accept(); else if (page.__relay.dialogMode === 'dismiss') await dialog.dismiss(); });
+  }
+  if (clear) { page.__relay.console = []; return 'Console cleared'; }
+  return page.__relay.console.length === 0 ? 'No console messages (listening...)' : page.__relay.console.join('\n');
+}
+
+export async function getNetworkRequests(page, clear, includeStatic) {
+  if (!page.__relay) {
+    page.__relay = { console: [], network: [], dialogMode: null, routes: [] };
+    page.on('console', (msg) => { page.__relay.console.push('[' + msg.type() + '] ' + msg.text()); });
+    page.on('response', (resp) => { const url = resp.url(); if (url.startsWith('chrome-extension://')) return; const req = resp.request(); page.__relay.network.push({ status: resp.status(), method: req.method(), url, type: req.resourceType() }); });
+    page.on('dialog', async (dialog) => { if (page.__relay.dialogMode === 'accept') await dialog.accept(); else if (page.__relay.dialogMode === 'dismiss') await dialog.dismiss(); });
+  }
+  if (clear) { page.__relay.network = []; return 'Network log cleared'; }
+  let reqs = page.__relay.network;
+  if (!includeStatic) {
+    const skip = new Set(['stylesheet', 'image', 'font', 'media', 'other']);
+    reqs = reqs.filter(r => !skip.has(r.type));
+  }
+  return reqs.length === 0
+    ? 'No network requests (listening...)'
+    : reqs.map(r => r.status + ' ' + r.method + ' ' + r.url).join('\n');
+}
+
+export async function setDialogAccept(page) {
+  if (!page.__relay) {
+    page.__relay = { console: [], network: [], dialogMode: null, routes: [] };
+    page.on('console', (msg) => { page.__relay.console.push('[' + msg.type() + '] ' + msg.text()); });
+    page.on('response', (resp) => { const url = resp.url(); if (url.startsWith('chrome-extension://')) return; const req = resp.request(); page.__relay.network.push({ status: resp.status(), method: req.method(), url, type: req.resourceType() }); });
+    page.on('dialog', async (dialog) => { if (page.__relay.dialogMode === 'accept') await dialog.accept(); else if (page.__relay.dialogMode === 'dismiss') await dialog.dismiss(); });
+  }
+  page.__relay.dialogMode = 'accept';
+  return 'Dialogs will be auto-accepted';
+}
+
+export async function setDialogDismiss(page) {
+  if (!page.__relay) {
+    page.__relay = { console: [], network: [], dialogMode: null, routes: [] };
+    page.on('console', (msg) => { page.__relay.console.push('[' + msg.type() + '] ' + msg.text()); });
+    page.on('response', (resp) => { const url = resp.url(); if (url.startsWith('chrome-extension://')) return; const req = resp.request(); page.__relay.network.push({ status: resp.status(), method: req.method(), url, type: req.resourceType() }); });
+    page.on('dialog', async (dialog) => { if (page.__relay.dialogMode === 'accept') await dialog.accept(); else if (page.__relay.dialogMode === 'dismiss') await dialog.dismiss(); });
+  }
+  page.__relay.dialogMode = 'dismiss';
+  return 'Dialogs will be auto-dismissed';
+}
+
+// ─── Routes ─────────────────────────────────────────────────────────────────
+
+export async function addRoute(page, pattern) {
+  if (!page.__relay) page.__relay = { console: [], network: [], dialogMode: null, routes: [] };
+  const handler = route => route.abort();
+  await page.route(pattern, handler);
+  page.__relay.routes.push({ pattern, handler });
+  return 'Route added (blocked): ' + pattern;
+}
+
+export async function listRoutes(page) {
+  const routes = (page.__relay && page.__relay.routes) || [];
+  return routes.length === 0 ? 'No active routes' : routes.map(r => r.pattern).join('\n');
+}
+
+export async function removeRoute(page, pattern) {
+  const routes = (page.__relay && page.__relay.routes) || [];
+  if (routes.length === 0) return 'No routes to remove';
+  const idx = routes.findIndex(r => r.pattern === pattern);
+  if (idx === -1) return 'Route not found: ' + pattern;
+  await page.unroute(pattern, routes[idx].handler);
+  routes.splice(idx, 1);
+  return 'Route removed: ' + pattern;
+}
+
+// ─── Tracing ────────────────────────────────────────────────────────────────
+
+export async function tracingStart(page) {
+  await page.context().tracing.start({ screenshots: true, snapshots: true });
+  return 'Tracing started';
+}
+
+export async function tracingStop(page) {
+  const fs = await import('fs');
+  const path = await import('path');
+  const os = await import('os');
+  const d = new Date();
+  const pad = n => String(n).padStart(2, '0');
+  const timestamp = d.getFullYear() + '-' + pad(d.getMonth() + 1) + '-' + pad(d.getDate()) + 'T' + pad(d.getHours()) + '-' + pad(d.getMinutes()) + '-' + pad(d.getSeconds());
+  const dir = path.join(os.homedir(), 'pw-traces');
+  fs.mkdirSync(dir, { recursive: true });
+  const tracePath = path.join(dir, 'trace-' + timestamp + '.zip');
+  await page.context().tracing.stop({ path: tracePath });
+  const size = fs.statSync(tracePath).size;
+  const sizeStr = size < 1024 * 1024 ? (size / 1024).toFixed(0) + ' KB' : (size / (1024 * 1024)).toFixed(1) + ' MB';
+  return 'Trace saved to ' + tracePath + ' (' + sizeStr + ')';
+}
+
+// ─── Video ──────────────────────────────────────────────────────────────────
+
+export async function videoStart(page) {
+  const CDP = await page.context().newCDPSession(page);
+  await CDP.send('Page.startScreencast', { format: 'jpeg', quality: 80, everyNthFrame: 2 });
+  page.__videoSession = CDP;
+  page.__videoFrames = [];
+  page.__videoStartTime = Date.now();
+  CDP.on('Page.screencastFrame', (params) => {
+    if (page.__videoFrames) page.__videoFrames.push(params.data);
+    CDP.send('Page.screencastFrameAck', { sessionId: params.sessionId }).catch(() => {});
+  });
+  return 'Video recording started (screencast)';
+}
+
+export async function videoStop(page) {
+  if (!page.__videoSession) return 'Not recording';
+  await page.__videoSession.send('Page.stopScreencast');
+  const frames = page.__videoFrames || [];
+  const duration = Math.round((Date.now() - (page.__videoStartTime || 0)) / 1000);
+  page.__videoSession = null;
+  page.__videoFrames = null;
+  page.__videoStartTime = null;
+  return 'Video stopped (' + duration + 's, ' + frames.length + ' frames captured)';
+}
+
+// ─── Tabs (Playwright context.pages) ────────────────────────────────────────
+
+export async function tabList(page) {
+  const pages = page.context().pages();
+  return JSON.stringify(pages.map((p, i) => ({
+    index: i,
+    title: '',
+    url: p.url(),
+    current: p === page,
+  })), null, 2);
+}
+
+export async function tabNew(page, url) {
+  const newPage = await page.context().newPage();
+  if (url) await newPage.goto(url);
+  return 'Opened new tab' + (url ? ': ' + url : '');
+}
+
+export async function tabClose(page, index) {
+  const pages = page.context().pages();
+  const target = index !== undefined ? pages[parseInt(index)] : page;
+  if (!target) throw new Error('Tab ' + (index !== undefined ? index : 'current') + ' not found');
+  const url = target.url();
+  await target.close();
+  return 'Closed: ' + url;
+}
+
+export async function tabSelect(page, index) {
+  const pages = page.context().pages();
+  const target = pages[parseInt(index)];
+  if (!target) throw new Error('Tab ' + index + ' not found');
+  await target.bringToFront();
+  return 'Selected tab ' + index + ': ' + target.url();
+}
+
+// ─── Drag / Resize ──────────────────────────────────────────────────────────
+
+export async function dragDrop(page, source, target) {
+  let srcLoc = /^e\d+$/.test(source) ? page.locator('aria-ref=' + source) : page.getByText(source);
+  let tgtLoc = /^e\d+$/.test(target) ? page.locator('aria-ref=' + target) : page.getByText(target);
+  if (await srcLoc.count() > 1) srcLoc = srcLoc.filter({ visible: true }).first();
+  if (await tgtLoc.count() > 1) tgtLoc = tgtLoc.filter({ visible: true }).first();
+  await srcLoc.dragTo(tgtLoc);
+  return 'Dragged';
+}
+
+export async function resizeViewport(page, width, height) {
+  await page.setViewportSize({ width: parseInt(width), height: parseInt(height) });
+  return 'Resized to ' + width + 'x' + height;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -16,6 +16,7 @@ export {
 export type { EngineOpts, EngineResult, ParsedArgs } from './types.js';
 export { filterResponse } from './filter.js';
 export { BridgeServer } from './bridge-server.js';
+export { CDPRelayServer } from './cdp-relay-server.js';
 export { EvaluateConnection, findExtensionPath } from './evaluate-connection.js';
 export type { CompletionItem } from './completion-data.js';
 export type { CommandInfo } from './resolve.js';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -23,6 +23,8 @@ export type { CommandInfo } from './resolve.js';
 export { parseSnapshot, refToLocator, allRefLocators } from './snapshot-parser.js';
 export type { SnapshotNode, LocatorResult, RefLocatorEntry } from './snapshot-parser.js';
 export { isLocalCommand, handleLocalCommand, isVideoCommand, handleVideoCommand, isTracingCommand, handleTracingCommand } from './local-commands.js';
+export { resolveCommand } from './resolve-command.js';
+export type { ResolvedCommand } from './resolve-command.js';
 export type { LocalCommandResult } from './local-commands.js';
 export { buildSystemPrompt, buildUserMessage, buildGrammarReference } from './prompt-builder.js';
 export type { PromptContext, PromptOptions } from './prompt-builder.js';

--- a/packages/core/src/resolve-command.ts
+++ b/packages/core/src/resolve-command.ts
@@ -1,0 +1,442 @@
+// @ts-nocheck — Functions are stringified via fn.toString() for eval contexts.
+/**
+ * Resolve a keyword command to a JavaScript expression string.
+ *
+ * This is the "common layer" — pure Playwright API only.
+ * Platform-specific commands (Chrome tabs, Node.js video, etc.) are handled
+ * by extending this in the extension or relay packages.
+ *
+ * Returns { jsExpr } for known commands, or null if unrecognised.
+ */
+
+import {
+  verifyText, verifyElement, verifyValue, verifyList,
+  verifyTitle, verifyUrl, verifyNoText, verifyNoElement,
+  verifyVisible, verifyCssVisible, verifyCssElement, verifyCssNoElement, verifyCssValue,
+  verifyInputValue, waitForText,
+  actionByText, fillByText, selectByText, checkByText, uncheckByText,
+  actionByRole, fillByRole, selectByRole, pressKeyByRole,
+} from './page-scripts.js';
+
+import {
+  gotoUrl, reloadPage, goBack, goForward,
+  waitMs, getTitle, getUrl,
+  evalCode, runCode,
+  takeScreenshot, takeSnapshot, takePdf,
+  refAction, pressKey, typeText,
+  highlightByText, highlightByRole, highlightBySelector, highlightByRef, clearHighlight,
+  chainAction,
+  localStorageGet, localStorageSet, localStorageDelete, localStorageClear, localStorageList,
+  sessionStorageGet, sessionStorageSet, sessionStorageDelete, sessionStorageClear, sessionStorageList,
+  cookieList, cookieGet, cookieSet, cookieDelete, cookieClear,
+  dragDrop, resizeViewport,
+  getConsoleMessages, getNetworkRequests, setDialogAccept, setDialogDismiss,
+  addRoute, listRoutes, removeRoute,
+  tracingStart, tracingStop,
+  videoStart, videoStop,
+  tabList, tabNew, tabClose, tabSelect,
+} from './command-scripts.js';
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+/** Serialize a value for inline JS — undefined becomes the literal `undefined` */
+function ser(v) {
+  if (v === undefined) return 'undefined';
+  return JSON.stringify(v);
+}
+
+/** Build a JS expression that calls a page-script function (page is expected in scope) */
+function call(fn, ...args) {
+  return `return await (${fn.toString()})(page, ${args.map(ser).join(', ')})`;
+}
+
+/**
+ * Build a scoped JS expression — finds the nearest ancestor containing inText,
+ * then calls fn with the scoped locator as `page`.
+ */
+function callScoped(fn, inText, _targetText, ...args) {
+  const anchorCode = `(async () => { const __e = page.getByText(${ser(inText)}, { exact: true }); return (await __e.count()) > 0 ? __e : page.getByText(${ser(inText)}); })()`;
+  const fallbackCheck = `(await ${anchorCode}).first().evaluate((el) => {
+          const S = new Set(['FIELDSET','SECTION','ARTICLE','DETAILS','DIALOG','FORM']);
+          let a = el.parentElement;
+          while (a && a !== document.body) {
+            if (S.has(a.tagName) || a.hasAttribute('role')) {
+              const id = '__pw_in_' + Math.random().toString(36).slice(2);
+              a.setAttribute('data-pw-in', id);
+              return '[data-pw-in="' + id + '"]';
+            }
+            a = a.parentElement;
+          }
+          return null;
+        })`;
+  return `return await (async () => {
+    let __scope = page;
+    const __roles = ['group', 'article', 'listitem', 'region', 'dialog', 'form'];
+    for (const __r of __roles) {
+      const __c = page.getByRole(__r).filter({ hasText: ${ser(inText)} });
+      if (await __c.count() > 0) { __scope = __c.first(); break; }
+    }
+    if (__scope === page) {
+      try {
+        const __sel = await ${fallbackCheck};
+        if (__sel) __scope = page.locator(__sel);
+      } catch {}
+    }
+    if (__scope !== page) {
+      const __tc = await __scope.getByText(${ser(_targetText)}).count().catch(() => 0);
+      if (__tc === 0) __scope = page;
+    }
+    try {
+      return await (${fn.toString()})(__scope, ${args.map(ser).join(', ')});
+    } finally {
+      if (typeof page.evaluate === 'function')
+        await page.evaluate(() => document.querySelectorAll('[data-pw-in]').forEach(el => el.removeAttribute('data-pw-in'))).catch(() => {});
+    }
+  })()`;
+}
+
+// ─── Tokenizer ──────────────────────────────────────────────────────────────
+
+const BOOLEAN_OPTIONS = new Set([
+  'headed', 'persistent', 'extension', 'submit', 'clear',
+  'fullPage', 'includeStatic', 'exact',
+]);
+
+function tokenize(line) {
+  const tokens = [];
+  let current = '';
+  let inQuote = null;
+  let parenDepth = 0;
+  for (let i = 0; i < line.length; i++) {
+    const ch = line[i];
+    if (inQuote) {
+      if (ch === inQuote) { inQuote = null; if (parenDepth > 0) current += ch; }
+      else current += ch;
+    } else if (ch === '"' || ch === "'") {
+      inQuote = ch;
+      if (parenDepth > 0) current += ch;
+    } else if (ch === '(') { parenDepth++; current += ch; }
+    else if (ch === ')') { parenDepth = Math.max(0, parenDepth - 1); current += ch; }
+    else if ((ch === ' ' || ch === '\t') && parenDepth === 0) {
+      if (current) { tokens.push(current); current = ''; }
+    } else current += ch;
+  }
+  if (current) tokens.push(current);
+  return tokens;
+}
+
+// ─── Parse input ────────────────────────────────────────────────────────────
+
+const RAW_COMMANDS = new Set(['run-code', 'eval']);
+
+function parseInput(line) {
+  const tokens = tokenize(line);
+  if (tokens.length === 0) return null;
+  tokens[0] = tokens[0].toLowerCase();
+  if (RAW_COMMANDS.has(tokens[0])) {
+    const cmdLen = line.match(/^\s*\S+/)[0].length;
+    const rest = line.slice(cmdLen).trim();
+    return rest ? { _: [tokens[0], rest] } : { _: [tokens[0]] };
+  }
+  const positional = [];
+  const opts = {};
+  let i = 0;
+  while (i < tokens.length) {
+    if (tokens[i].startsWith('--')) {
+      const key = tokens[i].slice(2);
+      if (BOOLEAN_OPTIONS.has(key)) { opts[key] = true; i++; }
+      else if (key === 'in' && i + 2 < tokens.length && !tokens[i + 1].startsWith('--') && !tokens[i + 2].startsWith('--') && /^[a-z]+$/.test(tokens[i + 1])) {
+        opts['in-role'] = tokens[i + 1]; opts['in-text'] = tokens[i + 2]; i += 3;
+      } else if (key === 'in' && i + 1 < tokens.length && !tokens[i + 1].startsWith('--')) {
+        opts['in-text'] = tokens[i + 1]; i += 2;
+      } else if (i + 1 < tokens.length && !tokens[i + 1].startsWith('--')) {
+        opts[key] = tokens[i + 1]; i += 2;
+      } else { opts[key] = true; i++; }
+    } else { positional.push(tokens[i]); i++; }
+  }
+  return { _: positional, ...opts };
+}
+
+// ─── Resolve ────────────────────────────────────────────────────────────────
+
+function resolveArgs(args) {
+  const cmdName = args._[0];
+
+  // ── Verify unified ──
+  if (cmdName === 'verify') {
+    const subType = args._[1];
+    const rest = args._.slice(2);
+    if (rest[0] === 'css' && rest.length >= 2) {
+      const selector = rest.slice(1).join(' ');
+      if (subType === 'visible') return { jsExpr: call(verifyCssVisible, selector) };
+      if (subType === 'element') return { jsExpr: call(verifyCssElement, selector) };
+      if (subType === 'no-element') return { jsExpr: call(verifyCssNoElement, selector) };
+      if (subType === 'value' && rest.length >= 3) {
+        const sel = rest.slice(1, -1).join(' ');
+        return { jsExpr: call(verifyCssValue, sel, rest[rest.length - 1]) };
+      }
+    }
+    if (subType === 'title' && rest.length > 0) return { jsExpr: call(verifyTitle, rest.join(' ')) };
+    if (subType === 'url' && rest.length > 0) return { jsExpr: call(verifyUrl, rest.join(' ')) };
+    if (subType === 'text' && rest.length > 0) return { jsExpr: call(verifyText, rest.join(' ')) };
+    if (subType === 'no-text' && rest.length > 0) return { jsExpr: call(verifyNoText, rest.join(' ')) };
+    if (subType === 'element' && rest.length >= 2) return { jsExpr: call(verifyElement, rest[0], rest.slice(1).join(' ')) };
+    if (subType === 'no-element' && rest.length >= 2) return { jsExpr: call(verifyNoElement, rest[0], rest.slice(1).join(' ')) };
+    if (subType === 'value' && rest.length >= 2) return { jsExpr: call(verifyValue, rest[0], rest.slice(1).join(' ')) };
+    if (subType === 'list' && rest.length >= 2) return { jsExpr: call(verifyList, rest[0], rest.slice(1)) };
+  }
+
+  // ── Verify css subcommand ──
+  const CSS_VERIFY = { 'verify-visible': verifyCssVisible, 'verify-element': verifyCssElement, 'verify-no-element': verifyCssNoElement };
+  if (CSS_VERIFY[cmdName] && args._[1] === 'css' && args._.length >= 3) {
+    return { jsExpr: call(CSS_VERIFY[cmdName], args._.slice(2).join(' ')) };
+  }
+  if (cmdName === 'verify-value' && args._[1] === 'css' && args._.length >= 4) {
+    return { jsExpr: call(verifyCssValue, args._.slice(2, -1).join(' '), args._[args._.length - 1]) };
+  }
+
+  // ── Legacy verify-* ──
+  const TEXT_VERIFY = new Set(['verify-text', 'verify-no-text', 'verify-title', 'verify-url']);
+  const ELEMENT_VERIFY = new Set(['verify-element', 'verify-no-element', 'verify-visible']);
+  const verifyFns = {
+    'verify-text': verifyText, 'verify-element': verifyElement, 'verify-visible': verifyVisible,
+    'verify-value': verifyValue, 'verify-list': verifyList, 'verify-title': verifyTitle,
+    'verify-url': verifyUrl, 'verify-no-text': verifyNoText, 'verify-no-element': verifyNoElement,
+  };
+  if (verifyFns[cmdName]) {
+    const pos = args._.slice(1);
+    const fn = verifyFns[cmdName];
+    if (TEXT_VERIFY.has(cmdName)) { const text = pos.join(' '); if (text) return { jsExpr: call(fn, text) }; }
+    else if (ELEMENT_VERIFY.has(cmdName)) { if (pos[0] && pos.length >= 2) return { jsExpr: call(fn, pos[0], pos.slice(1).join(' ')) }; }
+    else if (cmdName === 'verify-value' && pos[0] && pos.length >= 2) {
+      const isRef = /^e\d+$/.test(pos[0]);
+      return { jsExpr: call(isRef ? verifyValue : verifyInputValue, pos[0], pos.slice(1).join(' ')) };
+    }
+    else if (pos[0] && pos.length >= 2) {
+      const rest = cmdName === 'verify-list' ? pos.slice(1) : pos.slice(1).join(' ');
+      return { jsExpr: call(fn, pos[0], rest) };
+    }
+  }
+
+  // ── Wait-for-text ──
+  if (cmdName === 'wait-for-text') {
+    const text = args._.slice(1).join(' ');
+    if (text) return { jsExpr: call(waitForText, text) };
+  }
+
+  // ── Navigation ──
+  if (cmdName === 'goto' || cmdName === 'open') {
+    const url = args._[1];
+    if (url) return { jsExpr: call(gotoUrl, url) };
+  }
+  if (cmdName === 'reload') return { jsExpr: call(reloadPage) };
+  if (cmdName === 'go-back') return { jsExpr: call(goBack) };
+  if (cmdName === 'go-forward') return { jsExpr: call(goForward) };
+
+  // ── Page info ──
+  if (cmdName === 'title') return { jsExpr: call(getTitle) };
+  if (cmdName === 'url') return { jsExpr: call(getUrl) };
+
+  // ── Wait ──
+  if (cmdName === 'wait') {
+    const ms = parseInt(args._[1]) || 1000;
+    return { jsExpr: call(waitMs, ms) };
+  }
+
+  // ── Eval / Run code ──
+  if (cmdName === 'eval') return { jsExpr: call(evalCode, args._[1] || '') };
+  if (cmdName === 'run-code') return { jsExpr: call(runCode, args._[1] || '') };
+
+  // ── Screenshot / PDF / Snapshot ──
+  if (cmdName === 'screenshot') return { jsExpr: `return JSON.stringify(await (${takeScreenshot.toString()})(page, ${!!(args.fullPage)}))` };
+  if (cmdName === 'pdf') return { jsExpr: `return JSON.stringify(await (${takePdf.toString()})(page))` };
+  if (cmdName === 'snapshot') return { jsExpr: call(takeSnapshot) };
+
+  // ── Highlight ──
+  if (cmdName === 'highlight') {
+    if (args.clear) return { jsExpr: call(clearHighlight) };
+    const loc = args._[1];
+    if (loc) {
+      if (/^e\d+$/.test(loc)) return { jsExpr: call(highlightByRef, loc) };
+      if (loc === 'css') {
+        const selector = args._.slice(2).join(' ');
+        if (selector) return { jsExpr: call(highlightBySelector, selector, args.nth !== undefined ? parseInt(String(args.nth), 10) : undefined) };
+      }
+      const nth = args.nth !== undefined ? parseInt(String(args.nth), 10) : undefined;
+      const exact = args.exact ? true : undefined;
+      const inRole = args['in-role'] !== undefined ? String(args['in-role']) : undefined;
+      const inText = args['in-text'] !== undefined ? String(args['in-text']) : undefined;
+      if (/^[a-z]+$/.test(loc) && (args._.length >= 3 || inText !== undefined || nth !== undefined)) {
+        const name = args._.length >= 3 ? args._.slice(2).join(' ') : '';
+        if (inText && !inRole) return { jsExpr: callScoped(highlightByRole, inText, name, loc, name, nth) };
+        return { jsExpr: call(highlightByRole, loc, name, nth, inRole, inText) };
+      }
+      if (inText && !inRole) return { jsExpr: callScoped(highlightByText, inText, loc, loc, nth, exact) };
+      return { jsExpr: call(highlightByText, loc, nth, exact) };
+    }
+  }
+
+  // ── CSS subcommand ──
+  const CSS_ACTIONS = { click: 'click', dblclick: 'dblclick', hover: 'hover', check: 'check', uncheck: 'uncheck', fill: 'fill', select: 'selectOption' };
+  if (CSS_ACTIONS[cmdName] && args._[1] === 'css') {
+    const needsValue = cmdName === 'fill' || cmdName === 'select';
+    const selectorParts = needsValue ? args._.slice(2, -1) : args._.slice(2);
+    const selector = selectorParts.join(' ');
+    const value = needsValue ? args._[args._.length - 1] : undefined;
+    if (selector) return { jsExpr: call(chainAction, selector, CSS_ACTIONS[cmdName], value) };
+  }
+
+  // ── >> chaining ──
+  const CHAIN_ACTIONS = { click: 'click', dblclick: 'dblclick', hover: 'hover', check: 'check', uncheck: 'uncheck', fill: 'fill', select: 'selectOption' };
+  if (CHAIN_ACTIONS[cmdName] && args._.some(a => a.includes('>>'))) {
+    const action = CHAIN_ACTIONS[cmdName];
+    const positional = args._.slice(1);
+    let lastChainIdx = -1;
+    for (let i = 0; i < positional.length; i++) {
+      if (positional[i] === '>>' || positional[i].includes('>>')) lastChainIdx = i;
+    }
+    const selectorEnd = positional[lastChainIdx] !== '>>' && positional[lastChainIdx]?.includes('>>')
+      ? lastChainIdx : lastChainIdx + 1;
+    const selector = positional.slice(0, selectorEnd + 1).join(' ');
+    const rest = positional.slice(selectorEnd + 1).join(' ');
+    return { jsExpr: call(chainAction, selector, action, rest || undefined) };
+  }
+
+  // ── Role-based actions ──
+  const ROLE_ACTIONS = { click: 'click', dblclick: 'dblclick', hover: 'hover', check: 'check', uncheck: 'uncheck' };
+  const inTextForRole = args['in-text'] !== undefined ? String(args['in-text']) : undefined;
+  const nthForRole = args.nth !== undefined ? parseInt(String(args.nth), 10) : undefined;
+  if (args._[1] && /^[a-z]+$/.test(args._[1]) && !args._.some(a => a.includes('>>')) && (args._.length >= 3 || inTextForRole !== undefined || nthForRole !== undefined)) {
+    const role = args._[1];
+    const nth = nthForRole;
+    const inRole = args['in-role'] !== undefined ? String(args['in-role']) : undefined;
+    const inText = inTextForRole;
+    if (ROLE_ACTIONS[cmdName]) {
+      const name = args._.length >= 3 ? args._.slice(2).join(' ') : '';
+      if (inText && !inRole) return { jsExpr: callScoped(actionByRole, inText, name, role, name, ROLE_ACTIONS[cmdName], nth) };
+      return { jsExpr: call(actionByRole, role, name, ROLE_ACTIONS[cmdName], nth, inRole, inText) };
+    }
+    if (cmdName === 'fill') return { jsExpr: call(fillByRole, role, args._[2], args._.slice(3).join(' ') || '', nth, inRole, inText) };
+    if (cmdName === 'select') return { jsExpr: call(selectByRole, role, args._[2], args._.slice(3).join(' ') || '', nth, inRole, inText) };
+    if (cmdName === 'press') return { jsExpr: call(pressKeyByRole, role, args._[2], args._.slice(3).join(' ') || '', nth, inRole, inText) };
+  }
+
+  // ── Text-based actions ──
+  const textFns = { click: actionByText, dblclick: actionByText, hover: actionByText, fill: fillByText, select: selectByText, check: checkByText, uncheck: uncheckByText };
+  if (textFns[cmdName] && args._[1] && !/^e\d+$/.test(args._[1]) && !args._.some(a => a.includes('>>'))) {
+    const textArg = args._[1];
+    const extraArgs = args._.slice(2);
+    const fn = textFns[cmdName];
+    const nth = args.nth !== undefined ? parseInt(String(args.nth), 10) : undefined;
+    const exact = args.exact ? true : undefined;
+    const inText = args['in-text'] !== undefined ? String(args['in-text']) : undefined;
+    if (fn === actionByText) {
+      if (inText) return { jsExpr: callScoped(fn, inText, textArg, textArg, cmdName, nth, exact) };
+      return { jsExpr: call(fn, textArg, cmdName, nth, exact) };
+    }
+    if (cmdName === 'fill' || cmdName === 'select') {
+      if (inText) return { jsExpr: callScoped(fn, inText, textArg, textArg, extraArgs[0] || '', nth, exact) };
+      return { jsExpr: call(fn, textArg, extraArgs[0] || '', nth, exact) };
+    }
+    if (inText) return { jsExpr: callScoped(fn, inText, textArg, textArg, nth, exact) };
+    return { jsExpr: call(fn, textArg, nth, exact) };
+  }
+
+  // ── Ref-based actions ──
+  const REF_ACTIONS = { click: 'click', dblclick: 'dblclick', hover: 'hover', check: 'check', uncheck: 'uncheck', fill: 'fill', select: 'selectOption', type: 'fill' };
+  if (REF_ACTIONS[cmdName] && args._[1] && /^e\d+$/.test(args._[1])) {
+    const ref = args._[1];
+    const value = args._.slice(2).join(' ') || undefined;
+    return { jsExpr: call(refAction, ref, REF_ACTIONS[cmdName], value) };
+  }
+
+  // ── Press ──
+  if (cmdName === 'press') {
+    const pos = args._.slice(1);
+    if (pos.length === 1) return { jsExpr: call(pressKey, pos[0], pos[0]) };
+    if (pos.length >= 2) return { jsExpr: call(pressKey, pos[0], pos[1]) };
+  }
+
+  // ── Type ──
+  if (cmdName === 'type') {
+    const text = args._.slice(1).join(' ');
+    if (text) return { jsExpr: call(typeText, text) };
+  }
+
+  // ── Locator ──
+  if (cmdName === 'locator') {
+    const ref = args._[1];
+    if (ref) return { jsExpr: `return (await page.locator(${ser('aria-ref=' + ref)}).normalize()).toString()` };
+  }
+
+  // ── localStorage ──
+  if (cmdName === 'localstorage-get') return { jsExpr: call(localStorageGet, args._[1]) };
+  if (cmdName === 'localstorage-set') return { jsExpr: call(localStorageSet, args._[1], args._.slice(2).join(' ')) };
+  if (cmdName === 'localstorage-delete') return { jsExpr: call(localStorageDelete, args._[1]) };
+  if (cmdName === 'localstorage-clear') return { jsExpr: call(localStorageClear) };
+  if (cmdName === 'localstorage-list') return { jsExpr: call(localStorageList) };
+
+  // ── sessionStorage ──
+  if (cmdName === 'sessionstorage-get') return { jsExpr: call(sessionStorageGet, args._[1]) };
+  if (cmdName === 'sessionstorage-set') return { jsExpr: call(sessionStorageSet, args._[1], args._.slice(2).join(' ')) };
+  if (cmdName === 'sessionstorage-delete') return { jsExpr: call(sessionStorageDelete, args._[1]) };
+  if (cmdName === 'sessionstorage-clear') return { jsExpr: call(sessionStorageClear) };
+  if (cmdName === 'sessionstorage-list') return { jsExpr: call(sessionStorageList) };
+
+  // ── Cookies ──
+  if (cmdName === 'cookie-list') return { jsExpr: call(cookieList) };
+  if (cmdName === 'cookie-get') return { jsExpr: call(cookieGet, args._[1]) };
+  if (cmdName === 'cookie-set') return { jsExpr: call(cookieSet, args._[1], args._.slice(2).join(' ')) };
+  if (cmdName === 'cookie-delete') return { jsExpr: call(cookieDelete, args._[1]) };
+  if (cmdName === 'cookie-clear') return { jsExpr: call(cookieClear) };
+
+  // ── Drag / Resize ──
+  if (cmdName === 'drag' && args._[1] && args._[2]) return { jsExpr: call(dragDrop, args._[1], args._[2]) };
+  if (cmdName === 'resize' && args._[1] && args._[2]) return { jsExpr: call(resizeViewport, args._[1], args._[2]) };
+
+  // ── Console / Network ──
+  if (cmdName === 'console') return { jsExpr: call(getConsoleMessages, args.clear) };
+  if (cmdName === 'network') return { jsExpr: call(getNetworkRequests, args.clear, args.includeStatic) };
+
+  // ── Dialog ──
+  if (cmdName === 'dialog-accept') return { jsExpr: call(setDialogAccept) };
+  if (cmdName === 'dialog-dismiss') return { jsExpr: call(setDialogDismiss) };
+
+  // ── Routes ──
+  if (cmdName === 'route' && args._[1]) return { jsExpr: call(addRoute, args._[1]) };
+  if (cmdName === 'route-list') return { jsExpr: call(listRoutes) };
+  if (cmdName === 'unroute' && args._[1]) return { jsExpr: call(removeRoute, args._[1]) };
+
+  // ── Tracing ──
+  if (cmdName === 'tracing-start') return { jsExpr: call(tracingStart) };
+  if (cmdName === 'tracing-stop') return { jsExpr: call(tracingStop) };
+
+  // ── Video ──
+  if (cmdName === 'video-start') return { jsExpr: call(videoStart) };
+  if (cmdName === 'video-stop') return { jsExpr: call(videoStop) };
+
+  // ── Tabs ──
+  if (cmdName === 'tab-list') return { jsExpr: call(tabList) };
+  if (cmdName === 'tab-new') return { jsExpr: call(tabNew, args._[1]) };
+  if (cmdName === 'tab-close') return { jsExpr: call(tabClose, args._[1] !== undefined ? parseInt(String(args._[1])) : undefined) };
+  if (cmdName === 'tab-select') return { jsExpr: call(tabSelect, args._[1] !== undefined ? parseInt(String(args._[1])) : undefined) };
+
+  return null;
+}
+
+// ─── Public API ─────────────────────────────────────────────────────────────
+
+export interface ResolvedCommand {
+  jsExpr: string;
+}
+
+/**
+ * Resolve a keyword command string to a JavaScript expression.
+ * Returns { jsExpr } for known pure-Playwright commands, or null if unrecognised.
+ * The jsExpr expects `page` to be in scope.
+ */
+export function resolveCommand(input: string): ResolvedCommand | null {
+  const args = parseInput(input.trim());
+  if (!args) return null;
+  return resolveArgs(args);
+}

--- a/packages/extension/src/background.ts
+++ b/packages/extension/src/background.ts
@@ -107,14 +107,8 @@ async function ensureOffscreen() {
 // Web Store installs: always create offscreen doc (auto-connect to bridge).
 // Development installs (--load-extension): only create if bridgePort was previously
 // configured, to avoid connecting to a real bridge during CLI/tests/VS Code.
-chrome.management.getSelf().then(async (info) => {
-  if (info.installType === 'normal') {
-    ensureOffscreen().catch(e => console.warn('[pw-repl] offscreen document creation failed:', e));
-  } else {
-    const { bridgePort } = await chrome.storage.local.get(['bridgePort']);
-    if (bridgePort) ensureOffscreen().catch(e => console.warn('[pw-repl] offscreen document creation failed:', e));
-  }
-});
+// Always create offscreen document — needed for both bridge and CDP relay connections
+ensureOffscreen().catch(e => console.warn('[pw-repl] offscreen document creation failed:', e));
 
 // Re-check offscreen doc periodically — Chrome may kill it after idle.
 chrome.alarms.create('ensure-offscreen', { periodInMinutes: 1 });
@@ -882,6 +876,14 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
     sendResponse({ ok: true });
     return false;
   }
+  if (msg.type === 'cdp-relay-connect') {
+    // Forward relay URL to offscreen document
+    ensureOffscreen().then(() => {
+      chrome.runtime.sendMessage({ type: 'cdp-relay-connect', relayUrl: msg.relayUrl });
+    });
+    sendResponse({ ok: true });
+    return false;
+  }
   if (msg.type === 'get-bridge-port') {
     chrome.storage.local.get(['bridgePort']).then(s => sendResponse((s.bridgePort as number) || 9876));
     return true;
@@ -922,7 +924,72 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
     return true;
   }
 
+  // ── CDP Relay: attach debugger to tab ──
+  if (msg.type === 'cdp-attach-tab') {
+    (async () => {
+      const tabId = await getActiveTabId();
+      if (!tabId) { sendResponse({ error: 'No active tab' }); return; }
+      const tab = await chrome.tabs.get(tabId);
+      // Detach first if already attached (from previous session)
+      await new Promise<void>(r => chrome.debugger.detach({ tabId }, () => { void chrome.runtime.lastError; r(); }));
+      await new Promise<void>((resolve, reject) => {
+        chrome.debugger.attach({ tabId }, '1.3', () => {
+          if (chrome.runtime.lastError) reject(new Error(chrome.runtime.lastError.message));
+          else resolve();
+        });
+      });
+      globalThis.__cdpRelayTabId = tabId;
+      sendResponse({
+        result: {
+          targetInfo: {
+            targetId: String(tabId),
+            type: 'page',
+            title: tab.title || '',
+            url: tab.url || '',
+            attached: false,
+            canAccessOpener: false,
+            browserContextId: 'default',
+          },
+        },
+      });
+    })().catch(e => sendResponse({ error: String(e) }));
+    return true;
+  }
+
+  // ── CDP Relay: forward CDP command via chrome.debugger ──
+  if (msg.type === 'cdp-command') {
+    const { method, params, sessionId } = msg as { type: string; method: string; params?: unknown; sessionId?: string };
+    const target = sessionId ? { targetId: sessionId } : { tabId: globalThis.__cdpRelayTabId };
+    chrome.debugger.sendCommand(target as chrome.debugger.Debuggee, method, params as Record<string, unknown>, (result) => {
+      if (chrome.runtime.lastError) sendResponse({ error: chrome.runtime.lastError.message });
+      else sendResponse({ result });
+    });
+    return true;
+  }
+
   return false;
+});
+
+// ─── CDP Relay: forward debugger events to offscreen ────────────────────────
+
+const __cdpRelayActive = true; // TODO: toggle based on relay connection state
+chrome.debugger.onEvent.addListener((source, method, params) => {
+  if (!__cdpRelayActive) return;
+  chrome.runtime.sendMessage({
+    type: 'cdp-event',
+    method,
+    params,
+    sessionId: source.targetId,
+    tabId: source.tabId,
+  }).catch(() => { /* offscreen may not be ready */ });
+});
+
+chrome.debugger.onDetach.addListener((source) => {
+  if (!__cdpRelayActive) return;
+  chrome.runtime.sendMessage({
+    type: 'cdp-detach',
+    tabId: source.tabId,
+  }).catch(() => {});
 });
 
 // ─── Download filename override ─────────────────────────────────────────────

--- a/packages/extension/src/background.ts
+++ b/packages/extension/src/background.ts
@@ -107,8 +107,14 @@ async function ensureOffscreen() {
 // Web Store installs: always create offscreen doc (auto-connect to bridge).
 // Development installs (--load-extension): only create if bridgePort was previously
 // configured, to avoid connecting to a real bridge during CLI/tests/VS Code.
-// Always create offscreen document — needed for both bridge and CDP relay connections
-ensureOffscreen().catch(e => console.warn('[pw-repl] offscreen document creation failed:', e));
+chrome.management.getSelf().then(async (info) => {
+  if (info.installType === 'normal') {
+    ensureOffscreen().catch(e => console.warn('[pw-repl] offscreen document creation failed:', e));
+  } else {
+    const { bridgePort } = await chrome.storage.local.get(['bridgePort']);
+    if (bridgePort) ensureOffscreen().catch(e => console.warn('[pw-repl] offscreen document creation failed:', e));
+  }
+});
 
 // Re-check offscreen doc periodically — Chrome may kill it after idle.
 chrome.alarms.create('ensure-offscreen', { periodInMinutes: 1 });

--- a/packages/extension/src/background.ts
+++ b/packages/extension/src/background.ts
@@ -979,16 +979,12 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
 });
 
 // ─── CDP Relay: forward debugger events to offscreen ────────────────────────
+// Only forward events when relay is active (i.e. a tab has been attached via cdp-attach-tab).
+// Without this guard, every chrome.debugger event from playwright-crx would be intercepted.
 
-const __cdpRelayActive = true; // TODO: toggle based on relay connection state
 chrome.debugger.onEvent.addListener((source, method, params) => {
-  if (!__cdpRelayActive) return;
-  // Only forward events from the relay tab
-  if (source.tabId !== globalThis.__cdpRelayTabId) {
-    console.debug('[cdp-relay] skip event from tab', source.tabId, '(relay tab:', globalThis.__cdpRelayTabId, '):', method);
-    return;
-  }
-  console.debug('[cdp-relay] ← event:', method);
+  if (!globalThis.__cdpRelayTabId) return;
+  if (source.tabId !== globalThis.__cdpRelayTabId) return;
   chrome.runtime.sendMessage({
     type: 'cdp-event',
     method,
@@ -999,7 +995,7 @@ chrome.debugger.onEvent.addListener((source, method, params) => {
 });
 
 chrome.debugger.onDetach.addListener((source) => {
-  if (!__cdpRelayActive) return;
+  if (!globalThis.__cdpRelayTabId) return;
   chrome.runtime.sendMessage({
     type: 'cdp-detach',
     tabId: source.tabId,

--- a/packages/extension/src/background.ts
+++ b/packages/extension/src/background.ts
@@ -939,6 +939,7 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
         });
       });
       globalThis.__cdpRelayTabId = tabId;
+      console.debug('[cdp-relay] attached to tab:', tabId);
       sendResponse({
         result: {
           targetInfo: {
@@ -960,9 +961,15 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
   if (msg.type === 'cdp-command') {
     const { method, params, sessionId } = msg as { type: string; method: string; params?: unknown; sessionId?: string };
     const target = sessionId ? { targetId: sessionId } : { tabId: globalThis.__cdpRelayTabId };
+    console.debug('[cdp-relay] →', method, JSON.stringify(params ?? {}).slice(0, 100));
     chrome.debugger.sendCommand(target as chrome.debugger.Debuggee, method, params as Record<string, unknown>, (result) => {
-      if (chrome.runtime.lastError) sendResponse({ error: chrome.runtime.lastError.message });
-      else sendResponse({ result });
+      if (chrome.runtime.lastError) {
+        console.debug('[cdp-relay] ✗', method, chrome.runtime.lastError.message);
+        sendResponse({ error: chrome.runtime.lastError.message });
+      } else {
+        console.debug('[cdp-relay] ✓', method);
+        sendResponse({ result });
+      }
     });
     return true;
   }
@@ -975,6 +982,12 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
 const __cdpRelayActive = true; // TODO: toggle based on relay connection state
 chrome.debugger.onEvent.addListener((source, method, params) => {
   if (!__cdpRelayActive) return;
+  // Only forward events from the relay tab
+  if (source.tabId !== globalThis.__cdpRelayTabId) {
+    console.debug('[cdp-relay] skip event from tab', source.tabId, '(relay tab:', globalThis.__cdpRelayTabId, '):', method);
+    return;
+  }
+  console.debug('[cdp-relay] ← event:', method);
   chrome.runtime.sendMessage({
     type: 'cdp-event',
     method,

--- a/packages/extension/src/background.ts
+++ b/packages/extension/src/background.ts
@@ -929,30 +929,25 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
     (async () => {
       const tabId = await getActiveTabId();
       if (!tabId) { sendResponse({ error: 'No active tab' }); return; }
-      const tab = await chrome.tabs.get(tabId);
+      const debuggee: chrome.debugger.Debuggee = { tabId };
       // Detach first if already attached (from previous session)
-      await new Promise<void>(r => chrome.debugger.detach({ tabId }, () => { void chrome.runtime.lastError; r(); }));
+      await new Promise<void>(r => chrome.debugger.detach(debuggee, () => { void chrome.runtime.lastError; r(); }));
       await new Promise<void>((resolve, reject) => {
-        chrome.debugger.attach({ tabId }, '1.3', () => {
+        chrome.debugger.attach(debuggee, '1.3', () => {
           if (chrome.runtime.lastError) reject(new Error(chrome.runtime.lastError.message));
           else resolve();
         });
       });
       globalThis.__cdpRelayTabId = tabId;
       console.debug('[cdp-relay] attached to tab:', tabId);
-      sendResponse({
-        result: {
-          targetInfo: {
-            targetId: String(tabId),
-            type: 'page',
-            title: tab.title || '',
-            url: tab.url || '',
-            attached: false,
-            canAccessOpener: false,
-            browserContextId: 'default',
-          },
-        },
-      });
+      // Get REAL CDP target info (not chrome.tabs — Playwright needs correct frame IDs)
+      const result = await new Promise<unknown>((resolve, reject) => {
+        chrome.debugger.sendCommand(debuggee, 'Target.getTargetInfo', {}, (r) => {
+          if (chrome.runtime.lastError) reject(new Error(chrome.runtime.lastError.message));
+          else resolve(r);
+        });
+      }) as { targetInfo?: unknown };
+      sendResponse({ result: { targetInfo: result?.targetInfo } });
     })().catch(e => sendResponse({ error: String(e) }));
     return true;
   }
@@ -960,9 +955,9 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
   // ── CDP Relay: forward CDP command via chrome.debugger ──
   if (msg.type === 'cdp-command') {
     const { method, params, sessionId } = msg as { type: string; method: string; params?: unknown; sessionId?: string };
-    const target = sessionId ? { targetId: sessionId } : { tabId: globalThis.__cdpRelayTabId };
+    const debuggerSession = { tabId: globalThis.__cdpRelayTabId!, sessionId } as chrome.debugger.Debuggee;
     console.debug('[cdp-relay] →', method, JSON.stringify(params ?? {}).slice(0, 100));
-    chrome.debugger.sendCommand(target as chrome.debugger.Debuggee, method, params as Record<string, unknown>, (result) => {
+    chrome.debugger.sendCommand(debuggerSession, method, params as Record<string, unknown>, (result) => {
       if (chrome.runtime.lastError) {
         console.debug('[cdp-relay] ✗', method, chrome.runtime.lastError.message);
         sendResponse({ error: chrome.runtime.lastError.message });
@@ -992,7 +987,7 @@ chrome.debugger.onEvent.addListener((source, method, params) => {
     type: 'cdp-event',
     method,
     params,
-    sessionId: source.targetId,
+    sessionId: (source as { sessionId?: string }).sessionId,
     tabId: source.tabId,
   }).catch(() => { /* offscreen may not be ready */ });
 });

--- a/packages/extension/src/background.ts
+++ b/packages/extension/src/background.ts
@@ -962,13 +962,10 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
   if (msg.type === 'cdp-command') {
     const { method, params, sessionId } = msg as { type: string; method: string; params?: unknown; sessionId?: string };
     const debuggerSession = { tabId: globalThis.__cdpRelayTabId!, sessionId } as chrome.debugger.Debuggee;
-    console.debug('[cdp-relay] →', method, JSON.stringify(params ?? {}).slice(0, 100));
     chrome.debugger.sendCommand(debuggerSession, method, params as Record<string, unknown>, (result) => {
       if (chrome.runtime.lastError) {
-        console.debug('[cdp-relay] ✗', method, chrome.runtime.lastError.message);
         sendResponse({ error: chrome.runtime.lastError.message });
       } else {
-        console.debug('[cdp-relay] ✓', method);
         sendResponse({ result });
       }
     });

--- a/packages/extension/src/offscreen/offscreen.ts
+++ b/packages/extension/src/offscreen/offscreen.ts
@@ -230,13 +230,6 @@ chrome.runtime.onMessage.addListener((msg: { type: string; port?: number; stream
     }
 });
 
-// Auto-connect to relay: try bridge port + 1, retry periodically
-setInterval(() => {
-    if (!relayWs || relayWs.readyState !== WebSocket.OPEN) {
-        connectRelay(`ws://127.0.0.1:${lastPort + 1}/relay`);
-    }
-}, 5000);
-
 // ─── CDP Relay WebSocket ────────────────────────────────────────────────────
 
 let relayWs: WebSocket | null = null;

--- a/packages/extension/src/offscreen/offscreen.ts
+++ b/packages/extension/src/offscreen/offscreen.ts
@@ -234,6 +234,13 @@ chrome.runtime.onMessage.addListener((msg: { type: string; port?: number; stream
 
 let relayWs: WebSocket | null = null;
 
+// Periodic health check — same pattern as bridge (10s interval)
+setInterval(() => {
+    if (lastPort && (!relayWs || relayWs.readyState !== WebSocket.OPEN)) {
+        connectRelay(`ws://127.0.0.1:${lastPort + 1}/relay`);
+    }
+}, 10000);
+
 function connectRelay(url: string) {
     if (relayWs) { relayWs.onclose = null; relayWs.close(); relayWs = null; }
 

--- a/packages/extension/src/offscreen/offscreen.ts
+++ b/packages/extension/src/offscreen/offscreen.ts
@@ -214,6 +214,68 @@ chrome.runtime.onMessage.addListener((msg: { type: string; port?: number; stream
             ws.send(JSON.stringify({ _event: true, ...msg }));
         }
     }
+
+    // ── CDP Relay ───────────────────────────────────────────────────────────
+    if (msg.type === 'cdp-relay-connect') {
+        const relayUrl = (msg as { type: string; relayUrl: string }).relayUrl;
+        connectRelay(relayUrl);
+    }
+
+    // Forward chrome.debugger events from background → relay WebSocket
+    if (msg.type === 'cdp-event') {
+        const { method, params, sessionId } = msg as { type: string; method: string; params?: unknown; sessionId?: string };
+        if (relayWs?.readyState === WebSocket.OPEN) {
+            relayWs.send(JSON.stringify({ method: 'forwardCDPEvent', params: { method, params, sessionId } }));
+        }
+    }
 });
+
+// Auto-connect to relay: try bridge port + 1, retry periodically
+setInterval(() => {
+    if (!relayWs || relayWs.readyState !== WebSocket.OPEN) {
+        connectRelay(`ws://127.0.0.1:${lastPort + 1}/relay`);
+    }
+}, 5000);
+
+// ─── CDP Relay WebSocket ────────────────────────────────────────────────────
+
+let relayWs: WebSocket | null = null;
+
+function connectRelay(url: string) {
+    if (relayWs) { relayWs.onclose = null; relayWs.close(); relayWs = null; }
+
+    relayWs = new WebSocket(url);
+
+    relayWs.onopen = () => {
+        console.debug(`[pw-repl] CDP relay connected to ${url}`);
+    };
+
+    relayWs.onmessage = async (e) => {
+        const msg = JSON.parse(e.data as string) as { id: number; method: string; params: unknown };
+
+        try {
+            const result = await chrome.runtime.sendMessage({
+                type: msg.method === 'attachToTab' ? 'cdp-attach-tab' : 'cdp-command',
+                ...(msg.method === 'attachToTab' ? {} : (msg.params as Record<string, unknown>)),
+            });
+
+            if (relayWs?.readyState === WebSocket.OPEN) {
+                if (result?.error) relayWs.send(JSON.stringify({ id: msg.id, error: result.error }));
+                else relayWs.send(JSON.stringify({ id: msg.id, result: result?.result ?? {} }));
+            }
+        } catch (err) {
+            if (relayWs?.readyState === WebSocket.OPEN) {
+                relayWs.send(JSON.stringify({ id: msg.id, error: String(err) }));
+            }
+        }
+    };
+
+    relayWs.onclose = () => {
+        console.debug('[pw-repl] CDP relay disconnected');
+        relayWs = null;
+    };
+
+    relayWs.onerror = () => {};
+}
 
 export {};

--- a/packages/extension/types.d.ts
+++ b/packages/extension/types.d.ts
@@ -8,6 +8,7 @@ declare var __activeRoutes: string[];
 declare var __dialogMode: 'accept' | 'dismiss' | undefined;
 declare var __downloadFilename: string | undefined;
 declare var downloadAs: (filename: string) => void;
+declare var __cdpRelayTabId: number | undefined;
 
 // Exposed on globalThis for serviceWorker.evaluate() / VS Code CDP injection
 declare var attachToTab: (tabId: number) => Promise<{ ok: boolean; url?: string; error?: string }>;

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -8,6 +8,7 @@ import pkg from '../package.json' with { type: 'json' };
 import { createBridgeRunner } from './bridge.js';
 import { createEvaluateRunner } from './evaluate.js';
 import { createStandaloneRunner } from './standalone.js';
+import { createRelayRunner } from './relay.js';
 import { logStartup, logEvent, logToolCall, logToolResult, logError, logHttp, LOG_FILE } from './logger.js';
 import type { Runner } from './types.js';
 // ─── Process exit handlers — log why the process dies ───────────────────────
@@ -37,12 +38,15 @@ process.on('exit', (code) => {
 
 const argv = process.argv.slice(2);
 const standalone = argv.includes('--standalone');
+const relay = argv.includes('--relay');
 const headed = argv.includes('--headed');
 
 // ─── Create runner ───────────────────────────────────────────────────────────
 
 let runnerModule;
-if (standalone) {
+if (relay) {
+    runnerModule = await createRelayRunner(argv);
+} else if (standalone) {
     // Try evaluate mode (extension + JS support), fall back to Engine (keyword only)
     try {
         runnerModule = await createEvaluateRunner(argv);
@@ -55,7 +59,8 @@ if (standalone) {
 
 const { runner, descriptions } = runnerModule;
 
-logStartup(standalone ? 'standalone' : 'bridge', `log → ${LOG_FILE}`);
+const mode = relay ? 'relay' : standalone ? 'standalone' : 'bridge';
+logStartup(mode, `log → ${LOG_FILE}`);
 
 // ─── HTTP server for --command --http piggybacking ──────────────────────────
 

--- a/packages/mcp/src/relay.ts
+++ b/packages/mcp/src/relay.ts
@@ -1,14 +1,12 @@
 /**
  * Relay runner — connects to Chrome via CDP relay for real Playwright page objects.
  *
- * Supports both keyword commands (via BrowserBackend) and JavaScript (via AsyncFunction).
+ * Keywords resolve to JS expressions via resolveCommand (pure Playwright API).
  * JS scripts execute in Node.js with full access to filesystem, npm packages, and streams.
+ * No BrowserBackend — direct execution against the real page object.
  */
 
-import { createRequire } from 'node:module';
-import path from 'node:path';
-import url from 'node:url';
-import { CDPRelayServer, parseInput, resolveArgs, UPDATE_COMMANDS, ALL_COMMANDS, replVersion } from '@playwright-repl/core';
+import { CDPRelayServer, resolveCommand, UPDATE_COMMANDS } from '@playwright-repl/core';
 import type { EngineResult } from '@playwright-repl/core';
 import type { RunnerModule } from './types.js';
 import { logEvent } from './logger.js';
@@ -16,40 +14,6 @@ import { logEvent } from './logger.js';
 import type { Browser, BrowserContext, Page } from '@playwright/test';
 
 const AsyncFunction = Object.getPrototypeOf(async function () {}).constructor;
-
-// ─── Playwright backend deps (same pattern as Engine) ───────────────────────
-
-/* eslint-disable @typescript-eslint/no-explicit-any */
-interface PlaywrightDeps {
-    BrowserBackend: new (config: any, browserContext: any, tools: any[]) => any;
-    browserTools: any[];
-    resolveConfig: (config: any) => Promise<any> | any;
-    commands: Record<string, any>;
-    parseCommand: (command: any, args: any) => { toolName: string; toolParams: Record<string, any> };
-}
-/* eslint-enable @typescript-eslint/no-explicit-any */
-
-let _deps: PlaywrightDeps | undefined;
-
-function loadDeps(): PlaywrightDeps {
-    if (_deps) return _deps;
-    const require = createRequire(import.meta.url);
-    // Resolve playwright-core through @playwright/test → playwright → playwright-core chain (pnpm strict mode)
-    const pwTestDir = path.dirname(require.resolve('@playwright/test/package.json'));
-    const pwTestReq = createRequire(path.join(pwTestDir, 'package.json'));
-    const pwDir = path.dirname(pwTestReq.resolve('playwright/package.json'));
-    const pwReq = createRequire(path.join(pwDir, 'package.json'));
-    const pwCoreDir = path.dirname(pwReq.resolve('playwright-core/package.json'));
-    const pwCoreReq = (sub: string) => require(path.join(pwCoreDir, sub));
-    _deps = {
-        BrowserBackend:  pwCoreReq('lib/tools/backend/browserBackend.js').BrowserBackend,
-        browserTools:    pwCoreReq('lib/tools/backend/tools.js').browserTools,
-        resolveConfig:   pwCoreReq('lib/tools/mcp/config.js').resolveConfig,
-        commands:        pwCoreReq('lib/tools/cli-daemon/commands.js').commands,
-        parseCommand:    pwCoreReq('lib/tools/cli-daemon/command.js').parseCommand,
-    };
-    return _deps;
-}
 
 // ─── Descriptions ───────────────────────────────────────────────────────────
 
@@ -82,21 +46,26 @@ function isSingleExpression(code: string): boolean {
     return true;
 }
 
-function formatJsResult(value: unknown): string {
-    if (value === undefined || value === null) return 'Done';
-    if (typeof value === 'string') return value;
-    if (typeof value === 'number' || typeof value === 'boolean') return String(value);
-    try { return JSON.stringify(value, null, 2); } catch { return String(value); }
-}
+function formatResult(value: unknown): EngineResult {
+    if (value === undefined || value === null) return { text: 'Done', isError: false };
 
-function formatToolResult(result: { content: Array<{ type: string; text?: string; data?: string; mimeType?: string }>; isError?: boolean }): EngineResult {
-    let text: string | undefined;
-    let image: string | undefined;
-    for (const item of result.content) {
-        if (item.type === 'text' && !text) text = item.text;
-        if (item.type === 'image' && !image) image = `data:${item.mimeType || 'image/png'};base64,${item.data}`;
+    // Screenshot/PDF: { __image, mimeType }
+    if (typeof value === 'string') {
+        try {
+            const obj = JSON.parse(value);
+            if (obj && typeof obj === 'object' && '__image' in obj) {
+                return { text: '', isError: false, image: `data:${obj.mimeType};base64,${obj.__image}` };
+            }
+        } catch { /* not JSON */ }
+        return { text: value, isError: false };
     }
-    return { isError: result.isError, text, image };
+    if (typeof value === 'object' && value !== null && '__image' in value) {
+        const img = value as { __image: string; mimeType: string };
+        return { text: '', isError: false, image: `data:${img.mimeType};base64,${img.__image}` };
+    }
+    if (typeof value === 'number' || typeof value === 'boolean') return { text: String(value), isError: false };
+    try { return { text: JSON.stringify(value, null, 2), isError: false }; }
+    catch { return { text: String(value), isError: false }; }
 }
 
 // ─── Runner ─────────────────────────────────────────────────────────────────
@@ -120,25 +89,20 @@ export async function createRelayRunner(
     let context: BrowserContext | null = null;
     let page: Page | null = null;
     let expect: typeof import('@playwright/test').expect;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    let backend: any = null;
 
     async function ensureConnected(): Promise<{ page: Page; context: BrowserContext }> {
-        // Already connected and alive
         if (browser && page) {
             try {
-                await page.title(); // health check
+                await page.title();
                 return { page, context: context! };
             } catch {
                 logEvent('Page connection stale, reconnecting...');
                 browser = null;
                 context = null;
                 page = null;
-                backend = null;
             }
         }
 
-        // Wait for extension to connect to relay
         if (!relay.extensionConnected) {
             console.error('Waiting for extension to connect...');
             logEvent('Waiting for extension...');
@@ -147,7 +111,6 @@ export async function createRelayRunner(
             logEvent('Extension connected');
         }
 
-        // Connect Playwright via CDP
         const pwModule = '@playwright/test';
         const pw = await (Function('m', 'return import(m)')(pwModule)) as typeof import('@playwright/test');
         expect = pw.expect;
@@ -156,98 +119,34 @@ export async function createRelayRunner(
         context = browser.contexts()[0];
         page = context.pages()[0];
 
-        if (!page) {
-            throw new Error('No page found — make sure a tab is open in Chrome');
-        }
-
-        // Create BrowserBackend for keyword command support
-        const deps = loadDeps();
-        const config = await deps.resolveConfig({
-            browser: { browserName: 'chromium', launchOptions: {}, contextOptions: { viewport: null }, isolated: false },
-            server: {},
-            network: {},
-            timeouts: { action: 5000, navigation: 15000 },
-        });
-        backend = new deps.BrowserBackend(config, context, deps.browserTools);
-        const cwd = process.cwd();
-        await backend.initialize?.({
-            name: 'playwright-repl',
-            version: replVersion,
-            cwd,
-            roots: [{ uri: url.pathToFileURL(cwd).href, name: 'cwd' }],
-            timestamp: Date.now(),
-        });
+        if (!page) throw new Error('No page found — make sure a tab is open in Chrome');
 
         logEvent(`Connected to page: ${page.url()}`);
         console.error(`Connected to page: ${page.url()}`);
         return { page, context };
     }
 
-    // ── JS execution ────────────────────────────────────────────────────────
-
-    async function executeJS(script: string): Promise<EngineResult> {
-        const { page: p, context: ctx } = await ensureConnected();
-
+    async function executeExpr(jsExpr: string): Promise<EngineResult> {
+        const { page: p } = await ensureConnected();
         try {
-            const fn = new AsyncFunction('page', 'context', 'expect', script);
-            const result = await fn(p, ctx, expect);
-            return { text: formatJsResult(result), isError: false };
+            const fn = new AsyncFunction('page', 'context', 'expect', jsExpr);
+            const result = await fn(p, context, expect);
+            return formatResult(result);
         } catch (e: unknown) {
             const msg = e instanceof Error ? e.message : String(e);
-
-            // Stale page — try reconnecting once
             if (msg.includes('Target closed') || msg.includes('TargetClosedError')) {
-                browser = null; context = null; page = null; backend = null;
+                browser = null; context = null; page = null;
                 try {
-                    const { page: p2, context: ctx2 } = await ensureConnected();
-                    const fn = new AsyncFunction('page', 'context', 'expect', script);
-                    const result = await fn(p2, ctx2, expect);
-                    return { text: formatJsResult(result), isError: false };
+                    const { page: p2 } = await ensureConnected();
+                    const fn = new AsyncFunction('page', 'context', 'expect', jsExpr);
+                    const result = await fn(p2, context, expect);
+                    return formatResult(result);
                 } catch (retryErr: unknown) {
                     return { text: retryErr instanceof Error ? retryErr.message : String(retryErr), isError: true };
                 }
             }
-
             return { text: msg, isError: true };
         }
-    }
-
-    // ── Keyword execution ───────────────────────────────────────────────────
-
-    async function executeKeyword(args: ReturnType<typeof parseInput>): Promise<EngineResult> {
-        await ensureConnected();
-        if (!backend) throw new Error('Backend not initialized');
-
-        const deps = loadDeps();
-        // resolveArgs transforms role-based, text-based, verify, etc. into run-code
-        const resolved = resolveArgs(args!);
-        const command = deps.commands[resolved._[0]];
-        if (!command) {
-            return { text: `Unknown command: ${resolved._[0]}`, isError: true };
-        }
-
-        const { toolName, toolParams } = deps.parseCommand(command, resolved);
-        if (!toolName) {
-            return { text: `Command "${args!._[0]}" is not supported in relay mode.`, isError: true };
-        }
-
-        toolParams._meta = { cwd: process.cwd() };
-        try {
-            const response = await backend.callTool(toolName, toolParams);
-            return formatToolResult(response);
-        } catch (e: unknown) {
-            return { text: e instanceof Error ? e.message : String(e), isError: true };
-        }
-    }
-
-    // ── Detect mode: keyword or JS ──────────────────────────────────────────
-
-    function isKeywordCommand(command: string): boolean {
-        const parsed = parseInput(command);
-        if (!parsed) return false;
-        const cmdName = parsed._[0];
-        if (!cmdName) return false;
-        return ALL_COMMANDS.includes(cmdName);
     }
 
     return {
@@ -256,21 +155,24 @@ export async function createRelayRunner(
             async runCommand(command: string): Promise<EngineResult> {
                 const trimmed = command.trim();
 
-                // Keyword command → BrowserBackend
-                if (isKeywordCommand(trimmed)) {
-                    const parsed = parseInput(trimmed)!;
-                    const cmdName = parsed._[0];
-                    const isUpdate = UPDATE_COMMANDS.has(cmdName);
-                    const result = await executeKeyword(parsed);
+                // Keyword command → resolveCommand → jsExpr → direct execution
+                const resolved = resolveCommand(trimmed);
+                if (resolved) {
+                    const result = await executeExpr(resolved.jsExpr);
+                    if (result.isError) return result;
 
                     // Auto-append snapshot for update commands
-                    if (!result.isError && isUpdate) {
-                        const snap = await executeKeyword(parseInput('snapshot')!).catch(() => null);
-                        if (snap && !snap.isError && snap.text) {
-                            const resultText = result.text?.trim() || '';
-                            result.text = resultText
-                                ? `### Result\n${resultText}\n### Snapshot\n${snap.text}`
-                                : `### Snapshot\n${snap.text}`;
+                    const cmdName = trimmed.split(/\s+/)[0].toLowerCase();
+                    if (UPDATE_COMMANDS.has(cmdName)) {
+                        const snapResolved = resolveCommand('snapshot');
+                        if (snapResolved) {
+                            const snap = await executeExpr(snapResolved.jsExpr).catch(() => null);
+                            if (snap && !snap.isError && snap.text) {
+                                const resultText = result.text?.trim() || '';
+                                result.text = resultText
+                                    ? `### Result\n${resultText}\n### Snapshot\n${snap.text}`
+                                    : `### Snapshot\n${snap.text}`;
+                            }
                         }
                     }
                     return result;
@@ -280,27 +182,27 @@ export async function createRelayRunner(
                 const script = isSingleExpression(trimmed)
                     ? `return ${trimmed.replace(/;$/, '')}`
                     : trimmed;
-                return executeJS(script);
+                return executeExpr(script);
             },
 
             async runScript(script: string, language: 'pw' | 'javascript'): Promise<EngineResult> {
                 if (language === 'pw') {
-                    // Run each line as a keyword command
                     const lines = script.split('\n').map(l => l.trim()).filter(l => l && !l.startsWith('#'));
                     const output: string[] = [];
                     for (const line of lines) {
-                        const parsed = parseInput(line);
-                        if (!parsed) continue;
-                        const result = await executeKeyword(parsed);
-                        const mark = result.isError ? '\u2717' : '\u2713';
-                        output.push(`${mark} ${line}${result.text ? `\n  ${result.text}` : ''}`);
-                        if (result.isError) {
+                        const resolved = resolveCommand(line);
+                        if (!resolved) {
+                            output.push(`\u2717 ${line}\n  Unknown command`);
                             return { text: output.join('\n'), isError: true };
                         }
+                        const result = await executeExpr(resolved.jsExpr);
+                        const mark = result.isError ? '\u2717' : '\u2713';
+                        output.push(`${mark} ${line}${result.text ? `\n  ${result.text}` : ''}`);
+                        if (result.isError) return { text: output.join('\n'), isError: true };
                     }
                     return { text: output.join('\n'), isError: false };
                 }
-                return executeJS(script);
+                return executeExpr(script);
             },
         },
     };

--- a/packages/mcp/src/relay.ts
+++ b/packages/mcp/src/relay.ts
@@ -1,0 +1,307 @@
+/**
+ * Relay runner — connects to Chrome via CDP relay for real Playwright page objects.
+ *
+ * Supports both keyword commands (via BrowserBackend) and JavaScript (via AsyncFunction).
+ * JS scripts execute in Node.js with full access to filesystem, npm packages, and streams.
+ */
+
+import { createRequire } from 'node:module';
+import path from 'node:path';
+import url from 'node:url';
+import { CDPRelayServer, parseInput, resolveArgs, UPDATE_COMMANDS, ALL_COMMANDS, replVersion } from '@playwright-repl/core';
+import type { EngineResult } from '@playwright-repl/core';
+import type { RunnerModule } from './types.js';
+import { logEvent } from './logger.js';
+
+import type { Browser, BrowserContext, Page } from '@playwright/test';
+
+const AsyncFunction = Object.getPrototypeOf(async function () {}).constructor;
+
+// ─── Playwright backend deps (same pattern as Engine) ───────────────────────
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+interface PlaywrightDeps {
+    BrowserBackend: new (config: any, browserContext: any, tools: any[]) => any;
+    browserTools: any[];
+    resolveConfig: (config: any) => Promise<any> | any;
+    commands: Record<string, any>;
+    parseCommand: (command: any, args: any) => { toolName: string; toolParams: Record<string, any> };
+}
+/* eslint-enable @typescript-eslint/no-explicit-any */
+
+let _deps: PlaywrightDeps | undefined;
+
+function loadDeps(): PlaywrightDeps {
+    if (_deps) return _deps;
+    const require = createRequire(import.meta.url);
+    // Resolve playwright-core through @playwright/test → playwright → playwright-core chain (pnpm strict mode)
+    const pwTestDir = path.dirname(require.resolve('@playwright/test/package.json'));
+    const pwTestReq = createRequire(path.join(pwTestDir, 'package.json'));
+    const pwDir = path.dirname(pwTestReq.resolve('playwright/package.json'));
+    const pwReq = createRequire(path.join(pwDir, 'package.json'));
+    const pwCoreDir = path.dirname(pwReq.resolve('playwright-core/package.json'));
+    const pwCoreReq = (sub: string) => require(path.join(pwCoreDir, sub));
+    _deps = {
+        BrowserBackend:  pwCoreReq('lib/tools/backend/browserBackend.js').BrowserBackend,
+        browserTools:    pwCoreReq('lib/tools/backend/tools.js').browserTools,
+        resolveConfig:   pwCoreReq('lib/tools/mcp/config.js').resolveConfig,
+        commands:        pwCoreReq('lib/tools/cli-daemon/commands.js').commands,
+        parseCommand:    pwCoreReq('lib/tools/cli-daemon/command.js').parseCommand,
+    };
+    return _deps;
+}
+
+// ─── Descriptions ───────────────────────────────────────────────────────────
+
+import { descriptions as bridgeDescriptions } from './bridge.js';
+
+export const descriptions = {
+    ...bridgeDescriptions,
+
+    runCommand: bridgeDescriptions.runCommand + `
+
+RELAY MODE BONUS: Since this server runs in relay mode, JavaScript commands execute in Node.js with real Playwright page objects. You get full access to:
+  - Filesystem (fs, path)
+  - npm packages (await import('exceljs'))
+  - Local modules (await import('./helpers.mjs'))
+  - No timeout limits`,
+
+    runScript: bridgeDescriptions.runScript + `
+
+RELAY MODE BONUS: language='javascript' scripts execute in Node.js with full access to filesystem, npm packages, streams, and child processes. No timeout limits.`,
+};
+
+// ─── Script execution ───────────────────────────────────────────────────────
+
+function isSingleExpression(code: string): boolean {
+    const trimmed = code.trim();
+    if (trimmed.includes('\n')) return false;
+    const withoutTrailing = trimmed.replace(/;$/, '');
+    if (withoutTrailing.includes(';')) return false;
+    if (/^(const |let |var |if |for |while |switch |try |class |function )/.test(trimmed)) return false;
+    return true;
+}
+
+function formatJsResult(value: unknown): string {
+    if (value === undefined || value === null) return 'Done';
+    if (typeof value === 'string') return value;
+    if (typeof value === 'number' || typeof value === 'boolean') return String(value);
+    try { return JSON.stringify(value, null, 2); } catch { return String(value); }
+}
+
+function formatToolResult(result: { content: Array<{ type: string; text?: string; data?: string; mimeType?: string }>; isError?: boolean }): EngineResult {
+    let text: string | undefined;
+    let image: string | undefined;
+    for (const item of result.content) {
+        if (item.type === 'text' && !text) text = item.text;
+        if (item.type === 'image' && !image) image = `data:${item.mimeType || 'image/png'};base64,${item.data}`;
+    }
+    return { isError: result.isError, text, image };
+}
+
+// ─── Runner ─────────────────────────────────────────────────────────────────
+
+export async function createRelayRunner(
+    argv: string[],
+): Promise<RunnerModule> {
+    const portIdx = argv.indexOf('--port');
+    const port = portIdx !== -1
+        ? parseInt(argv[portIdx + 1])
+        : (process.env.RELAY_PORT ? parseInt(process.env.RELAY_PORT) : 9877);
+
+    const relay = new CDPRelayServer();
+    await relay.start(port);
+    console.error(`playwright-repl CDP relay listening on ${relay.cdpEndpoint()}`);
+    console.error(`Extension endpoint: ${relay.relayEndpoint()}`);
+    logEvent(`Relay listening on ${relay.cdpEndpoint()}`);
+
+    // Playwright connection — established lazily on first command
+    let browser: Browser | null = null;
+    let context: BrowserContext | null = null;
+    let page: Page | null = null;
+    let expect: typeof import('@playwright/test').expect;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let backend: any = null;
+
+    async function ensureConnected(): Promise<{ page: Page; context: BrowserContext }> {
+        // Already connected and alive
+        if (browser && page) {
+            try {
+                await page.title(); // health check
+                return { page, context: context! };
+            } catch {
+                logEvent('Page connection stale, reconnecting...');
+                browser = null;
+                context = null;
+                page = null;
+                backend = null;
+            }
+        }
+
+        // Wait for extension to connect to relay
+        if (!relay.extensionConnected) {
+            console.error('Waiting for extension to connect...');
+            logEvent('Waiting for extension...');
+            await relay.waitForExtension(30000);
+            console.error('Extension connected');
+            logEvent('Extension connected');
+        }
+
+        // Connect Playwright via CDP
+        const pwModule = '@playwright/test';
+        const pw = await (Function('m', 'return import(m)')(pwModule)) as typeof import('@playwright/test');
+        expect = pw.expect;
+
+        browser = await pw.chromium.connectOverCDP(relay.cdpEndpoint());
+        context = browser.contexts()[0];
+        page = context.pages()[0];
+
+        if (!page) {
+            throw new Error('No page found — make sure a tab is open in Chrome');
+        }
+
+        // Create BrowserBackend for keyword command support
+        const deps = loadDeps();
+        const config = await deps.resolveConfig({
+            browser: { browserName: 'chromium', launchOptions: {}, contextOptions: { viewport: null }, isolated: false },
+            server: {},
+            network: {},
+            timeouts: { action: 5000, navigation: 15000 },
+        });
+        backend = new deps.BrowserBackend(config, context, deps.browserTools);
+        const cwd = process.cwd();
+        await backend.initialize?.({
+            name: 'playwright-repl',
+            version: replVersion,
+            cwd,
+            roots: [{ uri: url.pathToFileURL(cwd).href, name: 'cwd' }],
+            timestamp: Date.now(),
+        });
+
+        logEvent(`Connected to page: ${page.url()}`);
+        console.error(`Connected to page: ${page.url()}`);
+        return { page, context };
+    }
+
+    // ── JS execution ────────────────────────────────────────────────────────
+
+    async function executeJS(script: string): Promise<EngineResult> {
+        const { page: p, context: ctx } = await ensureConnected();
+
+        try {
+            const fn = new AsyncFunction('page', 'context', 'expect', script);
+            const result = await fn(p, ctx, expect);
+            return { text: formatJsResult(result), isError: false };
+        } catch (e: unknown) {
+            const msg = e instanceof Error ? e.message : String(e);
+
+            // Stale page — try reconnecting once
+            if (msg.includes('Target closed') || msg.includes('TargetClosedError')) {
+                browser = null; context = null; page = null; backend = null;
+                try {
+                    const { page: p2, context: ctx2 } = await ensureConnected();
+                    const fn = new AsyncFunction('page', 'context', 'expect', script);
+                    const result = await fn(p2, ctx2, expect);
+                    return { text: formatJsResult(result), isError: false };
+                } catch (retryErr: unknown) {
+                    return { text: retryErr instanceof Error ? retryErr.message : String(retryErr), isError: true };
+                }
+            }
+
+            return { text: msg, isError: true };
+        }
+    }
+
+    // ── Keyword execution ───────────────────────────────────────────────────
+
+    async function executeKeyword(args: ReturnType<typeof parseInput>): Promise<EngineResult> {
+        await ensureConnected();
+        if (!backend) throw new Error('Backend not initialized');
+
+        const deps = loadDeps();
+        // resolveArgs transforms role-based, text-based, verify, etc. into run-code
+        const resolved = resolveArgs(args!);
+        const command = deps.commands[resolved._[0]];
+        if (!command) {
+            return { text: `Unknown command: ${resolved._[0]}`, isError: true };
+        }
+
+        const { toolName, toolParams } = deps.parseCommand(command, resolved);
+        if (!toolName) {
+            return { text: `Command "${args!._[0]}" is not supported in relay mode.`, isError: true };
+        }
+
+        toolParams._meta = { cwd: process.cwd() };
+        try {
+            const response = await backend.callTool(toolName, toolParams);
+            return formatToolResult(response);
+        } catch (e: unknown) {
+            return { text: e instanceof Error ? e.message : String(e), isError: true };
+        }
+    }
+
+    // ── Detect mode: keyword or JS ──────────────────────────────────────────
+
+    function isKeywordCommand(command: string): boolean {
+        const parsed = parseInput(command);
+        if (!parsed) return false;
+        const cmdName = parsed._[0];
+        if (!cmdName) return false;
+        return ALL_COMMANDS.includes(cmdName);
+    }
+
+    return {
+        descriptions,
+        runner: {
+            async runCommand(command: string): Promise<EngineResult> {
+                const trimmed = command.trim();
+
+                // Keyword command → BrowserBackend
+                if (isKeywordCommand(trimmed)) {
+                    const parsed = parseInput(trimmed)!;
+                    const cmdName = parsed._[0];
+                    const isUpdate = UPDATE_COMMANDS.has(cmdName);
+                    const result = await executeKeyword(parsed);
+
+                    // Auto-append snapshot for update commands
+                    if (!result.isError && isUpdate) {
+                        const snap = await executeKeyword(parseInput('snapshot')!).catch(() => null);
+                        if (snap && !snap.isError && snap.text) {
+                            const resultText = result.text?.trim() || '';
+                            result.text = resultText
+                                ? `### Result\n${resultText}\n### Snapshot\n${snap.text}`
+                                : `### Snapshot\n${snap.text}`;
+                        }
+                    }
+                    return result;
+                }
+
+                // JavaScript → AsyncFunction
+                const script = isSingleExpression(trimmed)
+                    ? `return ${trimmed.replace(/;$/, '')}`
+                    : trimmed;
+                return executeJS(script);
+            },
+
+            async runScript(script: string, language: 'pw' | 'javascript'): Promise<EngineResult> {
+                if (language === 'pw') {
+                    // Run each line as a keyword command
+                    const lines = script.split('\n').map(l => l.trim()).filter(l => l && !l.startsWith('#'));
+                    const output: string[] = [];
+                    for (const line of lines) {
+                        const parsed = parseInput(line);
+                        if (!parsed) continue;
+                        const result = await executeKeyword(parsed);
+                        const mark = result.isError ? '\u2717' : '\u2713';
+                        output.push(`${mark} ${line}${result.text ? `\n  ${result.text}` : ''}`);
+                        if (result.isError) {
+                            return { text: output.join('\n'), isError: true };
+                        }
+                    }
+                    return { text: output.join('\n'), isError: false };
+                }
+                return executeJS(script);
+            },
+        },
+    };
+}


### PR DESCRIPTION
## Summary

Adds CDP relay infrastructure so Node.js can get real Playwright page objects when connecting to the user's existing Chrome via the extension. Also supports headless mode for CI without the extension.

- CDP relay server (`CDPRelayServer`) with dual WebSocket endpoints
- Extension forwards `chrome.debugger` commands/events via offscreen document
- `playwright-repl --relay` starts interactive REPL with keyword + JS support
- `playwright-repl --relay --headless --replay examples/` runs tests without extension
- `playwright-repl-mcp --relay` starts MCP server in relay mode
- `resolveCommand` in core resolves keywords to JS expressions — no BrowserBackend needed
- All 11 example files pass in relay headless mode (~3s total, down from ~100s with BrowserBackend)

## Architecture

```
Relay (headed): keyword → resolveCommand → jsExpr → connectOverCDP → chrome.debugger → tab
Relay (headless): keyword → resolveCommand → jsExpr → chromium.launch() → page API
```

Both paths skip BrowserBackend entirely — keywords resolve to the same Playwright API calls that the extension uses.

## Three-layer page-scripts

```
core/command-scripts.ts          ← common: goto, click, fill, snapshot, verify, cookies, etc.
core/resolve-command.ts          ← keyword → jsExpr resolver (pure Playwright)
                                    │
                ┌───────────────────┼───────────────────┐
                ▼                                       ▼
extension/commands.ts            relay runner
  Chrome API overrides:            Node.js equivalents:
    tab-* (chrome.tabs)              tab-* (context.pages)
    video (tabCapture)               video (CDP screencast)
    console (__consoleMessages)      console (page.on)
    etc.                             etc.
```

## What works

- [x] `connectOverCDP` connects and gets page objects
- [x] All keyword commands via `resolveCommand` (no BrowserBackend)
- [x] JavaScript with `page`, `context`, `expect` globals
- [x] `import()` for npm packages and local files
- [x] Headless mode (`--relay --headless`) — no extension needed
- [x] Replay mode (`--relay --replay examples/`)
- [x] MCP relay server (`playwright-repl-mcp --relay`)
- [x] HTTP endpoint (`pw-cli` commands)
- [x] console, network, dialog, route commands (page.on listeners)
- [x] tracing (context.tracing)
- [x] video (CDP screencast)
- [x] tabs (context.pages)
- [x] All 11 example files pass
- [x] CI benchmark: default + relay side by side

## Performance

| Mode | Time (11 files) |
|---|---|
| Relay headless (resolveCommand) | ~3s |
| Default (evaluate + extension) | ~4-9s |
| Relay with BrowserBackend (before) | ~100s |

## Test

```bash
# Headless replay (CI)
playwright-repl --relay --headless --replay examples/

# Interactive REPL (headed, connects to Chrome extension)
playwright-repl --relay

# MCP server
playwright-repl-mcp --relay

# Single command
playwright-repl --relay --headless --command "await page.title()"
```

Closes #847

🤖 Generated with [Claude Code](https://claude.com/claude-code)