### PR TITLE
fix: stale tab state blocks all future connections

### DIFF
--- a/packages/extension/src/background.ts
+++ b/packages/extension/src/background.ts
@@ -186,7 +186,15 @@ function isAttachableUrl(url: string | undefined): boolean {
 }
 
 async function getActiveTabId(): Promise<number | null> {
-  if (activeTabId) return activeTabId;
+  if (activeTabId) {
+    // Validate cached tab is still alive and attachable
+    try {
+      const tab = await chrome.tabs.get(activeTabId);
+      if (isAttachableUrl(tab.url)) return activeTabId;
+    } catch { /* tab no longer exists */ }
+    activeTabId = null;
+    currentPage = null;
+  }
   // Try focused window first
   const [focused] = await chrome.tabs.query({ active: true, lastFocusedWindow: true });
   if (focused?.id && isAttachableUrl(focused.url)) return focused.id;
@@ -211,6 +219,10 @@ async function attachToTab(tabId: number): Promise<{ ok: boolean; url?: string; 
     if (url.startsWith('chrome://') ||
         (url.startsWith('chrome-extension://') && !url.startsWith(ownOrigin)) ||
         url.startsWith('https://chromewebstore.google.com')) {
+      if (activeTabId === tabId) {
+        activeTabId = null;
+        currentPage = null;
+      }
       return { ok: false, error: 'Cannot attach to this page — Chrome restricts extension access. Navigate to a regular webpage first.' };
     }
 
@@ -710,6 +722,17 @@ async function handleBridgeCommand(msg: {
     if (!path) return { text: 'Usage: download-as <filename>', isError: true };
     globalThis.__downloadFilename = path;
     return { text: `Next download will save as: ${path}`, isError: false };
+  }
+
+  // Validate existing page connection is still alive (#849)
+  if (currentPage) {
+    try {
+      await currentPage.title();
+    } catch {
+      console.debug('[pw-repl] stale page detected, clearing state');
+      currentPage = null;
+      activeTabId = null;
+    }
   }
 
   if (!currentPage) {

--- a/packages/extension/test/background.test.ts
+++ b/packages/extension/test/background.test.ts
@@ -4,6 +4,7 @@ import { describe, it, expect, vi, beforeEach, type Mock } from "vitest";
 
 interface MockPage {
   url: ReturnType<typeof vi.fn>;
+  title: ReturnType<typeof vi.fn>;
   on: ReturnType<typeof vi.fn>;
 }
 
@@ -42,7 +43,7 @@ vi.mock('@playwright-repl/playwright-crx/test', () => ({
 }));
 
 vi.mock('@playwright-repl/playwright-crx', () => {
-  mockPage = { url: vi.fn().mockReturnValue('https://example.com'), on: vi.fn() } as MockPage;
+  mockPage = { url: vi.fn().mockReturnValue('https://example.com'), title: vi.fn().mockResolvedValue('Example'), on: vi.fn() } as MockPage;
   const mockContext = { pages: vi.fn().mockReturnValue([mockPage]) };
   mockCrxApp = {
     attach: vi.fn().mockResolvedValue(mockPage),
@@ -84,7 +85,7 @@ describe("background.ts message handlers", () => {
     mockDetectMode = vi.fn().mockReturnValue('js');
 
     // Reset playwright-crx mocks
-    mockPage = { url: vi.fn().mockReturnValue('https://example.com'), on: vi.fn() };
+    mockPage = { url: vi.fn().mockReturnValue('https://example.com'), title: vi.fn().mockResolvedValue('Example'), on: vi.fn() };
     const mockContext = { pages: vi.fn().mockReturnValue([mockPage]) };
     mockCrxApp = {
       attach: vi.fn().mockResolvedValue(mockPage),


### PR DESCRIPTION
## Summary
- `getActiveTabId()` now validates the cached `activeTabId` via `chrome.tabs.get()` + `isAttachableUrl()` before returning it — stale or restricted tabs fall through to tab discovery
- `attachToTab()` clears `activeTabId` on the restricted-URL early return path, so the cache doesn't permanently point at an unusable tab
- `handleBridgeCommand()` proactively checks `currentPage.title()` before executing (same pattern as `pickElement()`) — dead pages get cleared without relying on specific error string matching

## Test plan
- [x] Unit tests pass (91 tests, added `title` mock to `MockPage`)
- [x] Typecheck passes
- [x] Build passes
- [ ] Manual: start bridge, navigate to `chrome://settings`, run `snapshot` → should fail gracefully, then switch to a valid tab → should auto-recover

Closes #849

🤖 Generated with [Claude Code](https://claude.com/claude-code)