### PR TITLE
fix: sync extension informal label fallback with core (#800)

### DIFF
--- a/packages/extension/e2e/page-scripts/fixture.html
+++ b/packages/extension/e2e/page-scripts/fixture.html
@@ -59,6 +59,26 @@
     <li>Clean house <input type="checkbox" aria-label="Clean house"></li>
   </ul>
 
+  <!-- Same-row selects: two selects in one <tr>, each in its own <td> (#800) -->
+  <table border="1" cellpadding="5">
+    <tr class="Attribut1">
+      <td>
+        <span>Select*</span>
+        <select name="select1" id="select1">
+          <option value="value1">Value 1</option>
+          <option value="value2">Value 2</option>
+        </select>
+      </td>
+      <td>
+        <span>Select/Type*</span>
+        <select name="select2" id="select2">
+          <option value="type1">Type 1</option>
+          <option value="type2">Type 2</option>
+        </select>
+      </td>
+    </tr>
+  </table>
+
   <!-- Duplicate sections for --in text-only tests -->
   <fieldset>
     <legend>Billing Address</legend>

--- a/packages/extension/e2e/page-scripts/page-scripts.spec.ts
+++ b/packages/extension/e2e/page-scripts/page-scripts.spec.ts
@@ -201,6 +201,15 @@ test.describe('selectByText', () => {
         await selectByText(page, 'Size', 'l', undefined);
         expect(await page.inputValue('#size-select')).toBe('l');
     });
+
+    test('informal label picks same-cell select, not first in row (#800)', async ({ page }) => {
+        // Two selects in the same <tr>, each in its own <td> with a label span.
+        // selectByText("Select/Type*") must find select2 (same cell), not select1.
+        await selectByText(page, 'Select/Type*', 'type2', undefined);
+        expect(await page.inputValue('#select2')).toBe('type2');
+        // select1 must remain unchanged
+        expect(await page.inputValue('#select1')).toBe('value1');
+    });
 });
 
 test.describe('checkByText / uncheckByText', () => {

--- a/packages/extension/e2e/recording/fixture.html
+++ b/packages/extension/e2e/recording/fixture.html
@@ -32,6 +32,27 @@
         <li class="todo-item"><span>only item</span><button class="destroy">Delete</button></li>
     </ul>
 
+    <!-- Same-row selects: two selects in one row, each in its own cell (#800) -->
+    <h2>Same-Cell Select</h2>
+    <table border="1" cellpadding="5">
+        <tr class="Attribut1">
+            <td>
+                <span>Select*</span>
+                <select name="select1" id="select1">
+                    <option value="value1">Value 1</option>
+                    <option value="value2">Value 2</option>
+                </select>
+            </td>
+            <td>
+                <span>Select/Type*</span>
+                <select name="select2" id="select2">
+                    <option value="type1">Type 1</option>
+                    <option value="type2">Type 2</option>
+                </select>
+            </td>
+        </tr>
+    </table>
+
     <!-- Legacy table form: labels in adjacent cells, no <label> association (#768) -->
     <h2>Legacy Form</h2>
     <table border="1" cellpadding="5">

--- a/packages/extension/e2e/recording/recording.spec.ts
+++ b/packages/extension/e2e/recording/recording.spec.ts
@@ -102,6 +102,20 @@ test.describe('Recording flow', () => {
       expect(editorText).toContain('click');
     });
 
+    test('selecting from second combobox in same row records correct locator (#800)', async ({ sidePanel, testPage }) => {
+      await sidePanel.startRecording();
+
+      await testPage.bringToFront();
+      await testPage.locator('#select2').selectOption('type2');
+
+      await sidePanel.waitForEditorText('select');
+      const editorText = await sidePanel.getEditorText();
+      // Should use the informal label from the same cell, not CSS or the wrong label
+      expect(editorText).toContain('"Select/Type*"');
+      expect(editorText).toContain('"Type 2"');
+      expect(editorText).not.toContain('css');
+    });
+
     test('filling input in legacy table form uses informal label (#768)', async ({ sidePanel, testPage }) => {
       await sidePanel.startRecording();
 

--- a/packages/extension/src/panel/lib/page-scripts.ts
+++ b/packages/extension/src/panel/lib/page-scripts.ts
@@ -163,7 +163,7 @@ export async function fillByText(page, text, value, nth?, exact?) {
     // Informal label fallback: find text, walk up DOM to locate a nearby input
     if (await loc.count() === 0) {
       const sel = await page.getByText(text).first().evaluate((el: Element) => {
-        let a: Element | null = el.closest('tr') || el.parentElement;
+        let a: Element | null = el.closest('td, th') || el.closest('tr') || el.parentElement;
         while (a && a !== document.body) {
           const inp = a.querySelector('input:not([type=hidden]):not([type=checkbox]):not([type=radio]), textarea, [contenteditable="true"]');
           if (inp) {
@@ -195,7 +195,7 @@ export async function selectByText(page, text, value, nth?, exact?) {
     // Informal label fallback: find text, walk up DOM to locate a nearby select
     if (await loc.count() === 0) {
       const sel = await page.getByText(text).first().evaluate((el: Element) => {
-        let a: Element | null = el.closest('tr') || el.parentElement;
+        let a: Element | null = el.closest('td, th') || el.closest('tr') || el.parentElement;
         while (a && a !== document.body) {
           const s = a.querySelector('select');
           if (s) {


### PR DESCRIPTION
## Summary
- Apply the same `el.closest('td, th')` fix from core's `page-scripts.ts` to the extension's copy, ensuring `selectByText` and `fillByText` pick the select/input in the same cell rather than the first one in the row
- Add e2e tests for same-row select disambiguation (page-scripts + recording)

## Test plan
- [x] Page-scripts e2e: `selectByText` with informal label picks same-cell select (58 tests pass)
- [x] Core unit tests: 43 tests pass
- [x] Manual: recording + playback of second combobox in same-row verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)