### PR TITLE
fix: remove character limits in recorder locator generation

### DIFF
--- a/packages/extension/src/content/locator.ts
+++ b/packages/extension/src/content/locator.ts
@@ -103,7 +103,7 @@ export function getAccessibleName(el: Element): string {
     ]);
     if (role && NAME_FROM_CONTENT.has(role)) {
         const text = accumulatedText(el);
-        if (text && text.length <= 80) return text;
+        if (text) return text;
     }
 
     // alt for images
@@ -163,7 +163,7 @@ export function getInformalLabel(el: Element): string {
         let prev: Element | null = current.previousElementSibling;
         while (prev) {
             const text = normalizeText(prev.textContent);
-            if (text && text.length <= 80) return text;
+            if (text) return text;
             prev = prev.previousElementSibling;
         }
         current = current.parentElement;
@@ -194,7 +194,7 @@ function getContextText(ancestor: Element, exclude: Element): string {
                 continue;
             }
             const text = normalizeText(child.textContent || '');
-            if (text && text.length <= 50) return text;
+            if (text) return text;
         }
         return '';
     }
@@ -215,14 +215,14 @@ function findContainerAncestor(el: Element): { ancestor: Element; role: string }
 // ─── Heading-based context disambiguation ────────────────────────────────
 
 /**
- * Find the first short leaf text in an element, skipping button content.
+ * Find the first leaf text in an element, skipping button content.
  * Generic approach — works for headings, banners, labels, or any structure.
  */
 function findLeafText(node: Node): string {
     for (const child of node.childNodes) {
         if (child.nodeType === Node.TEXT_NODE) {
             const text = normalizeText(child.textContent || '');
-            if (text && text.length >= 2 && text.length <= 50) return text;
+            if (text && text.length >= 2) return text;
         }
         if (child.nodeType === Node.ELEMENT_NODE) {
             const el = child as Element;
@@ -292,7 +292,7 @@ function tryAncestorContext(el: Element, role: string, name: string, matches: El
     if (!container) return null;
 
     const contextText = getContextText(container.ancestor, el);
-    if (!contextText || contextText.length > 50) return null;
+    if (!contextText) return null;
 
     // Verify uniqueness: only one match's container ancestor should contain this text
     let count = 0;

--- a/packages/extension/test/content/locator.test.ts
+++ b/packages/extension/test/content/locator.test.ts
@@ -196,10 +196,10 @@ describe('locator', () => {
             expect(getAccessibleName(btn)).toBe('Submit');
         });
 
-        it('returns empty for long text content (>80 chars)', () => {
+        it('returns long text content without truncation', () => {
             const btn = document.createElement('button');
             btn.textContent = 'x'.repeat(81);
-            expect(getAccessibleName(btn)).toBe('');
+            expect(getAccessibleName(btn)).toBe('x'.repeat(81));
         });
 
         it('returns alt for IMG', () => {
@@ -487,7 +487,7 @@ describe('locator', () => {
             expect(generateLocator(buttons[1])).toContain('.nth(1)');
         });
 
-        it('falls back to .nth() when context text is too long', () => {
+        it('uses ancestor context even with long text', () => {
             const longText = 'x'.repeat(51);
             document.body.innerHTML = `
                 <ul>
@@ -495,7 +495,8 @@ describe('locator', () => {
                     <li><span>short</span><button>Delete</button></li>
                 </ul>`;
             const buttons = document.querySelectorAll('button');
-            expect(generateLocator(buttons[0])).toContain('.first()');
+            expect(generateLocator(buttons[0])).toContain('.filter(');
+            expect(generateLocator(buttons[0])).toContain(longText);
         });
 
         it('works with article container role', () => {
@@ -1212,6 +1213,47 @@ describe('locator', () => {
             const ja2 = buildCommands('check', radios[2]);
             expect(ja2!.pw).toContain('--in');
             expect(ja2!.pw).toContain('Another very long text');
+        });
+
+        it('uses informal label for combobox with long label text (#861)', () => {
+            document.body.innerHTML = `<table><tbody>
+                <tr><td>
+                    <span>Some text</span><br>
+                    <select><option>---</option><option>Option 1</option></select>
+                </td></tr>
+                <tr><td>More text</td></tr>
+                <tr><td>
+                    <span>At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren,</span><br>
+                    <select><option>keine Angabe</option><option>ja</option><option>nein</option></select>
+                </td></tr>
+            </tbody></table>`;
+            const selects = document.querySelectorAll('select');
+            const cmds0 = buildCommands('click', selects[0]);
+            expect(cmds0!.pw).toBe('click "Some text"');
+            const cmds1 = buildCommands('select', selects[1], { option: 'nein' });
+            expect(cmds1!.pw).toBe('select "At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren," "nein"');
+        });
+
+        it('disambiguates radio buttons with long label text (#863)', () => {
+            document.body.innerHTML = `<table><tbody>
+                <tr><td>
+                    <span>At vero eos et accusam et justo duo dolores et ea rebum.</span><br>
+                    <input type="radio" name="radio1" value="true" title="ja">ja&nbsp;
+                    <input type="radio" name="radio1" value="false" title="nein">nein
+                </td></tr>
+                <tr><td>
+                    <span>At vero eos et accusam et justo</span><br>
+                    <input type="radio" name="radio2" value="true" title="ja">ja&nbsp;
+                    <input type="radio" name="radio2" value="false" title="nein">nein
+                </td></tr>
+            </tbody></table>`;
+            const radios = document.querySelectorAll('input[type="radio"]');
+            const ja1 = buildCommands('check', radios[0]);
+            expect(ja1!.pw).toContain('--in');
+            expect(ja1!.pw).toContain('At vero eos et accusam et justo duo dolores et ea rebum.');
+            const ja2 = buildCommands('check', radios[2]);
+            expect(ja2!.pw).toContain('--in');
+            expect(ja2!.pw).toContain('At vero eos et accusam et justo');
         });
 
         it('uses text-only --in from heading context instead of --nth', () => {


### PR DESCRIPTION
## Summary
- Remove 50/80-char limits in `getContextText`, `findLeafText`, `getInformalLabel`, `getAccessibleName`, and `tryAncestorContext`
- These limits caused the recorder to generate wrong or ambiguous locators for elements with long label text (e.g. German form labels >50 chars)
- The runtime already uses substring matching (`hasText`), so the limits were unnecessarily conservative
- Addresses remaining issues reported in #861 and #863

## Test plan
- [x] Updated 2 existing tests to expect new behavior (long text accepted, not rejected)
- [x] Added test for combobox with long label text (#861 scenario)
- [x] Added test for radio button disambiguation with long label text (#863 scenario)
- [x] All 150 locator tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)