### PR TITLE
fix: --in flag ignored for role-based commands and uses substring matching (#863)

### DIFF
--- a/packages/core/src/command-scripts.ts
+++ b/packages/core/src/command-scripts.ts
@@ -150,10 +150,10 @@ export async function highlightByRole(page, role, name, nth, inRole?, inText?) {
   let loc = isUrl ? page.locator('a[href^="' + name + '"]:not([aria-hidden="true"])') : page.getByRole(role, roleOpts);
   if (inRole !== undefined && inText !== undefined) {
     const cr = ({ list: 'listitem' })[inRole] || inRole;
-    loc = page.getByRole(cr).filter({ hasText: inText }).getByRole(role, roleOpts);
+    loc = page.getByRole(cr).filter({ has: page.getByText(inText, { exact: true }) }).getByRole(role, roleOpts);
   } else if (inText !== undefined) {
     for (const r of ['region', 'group', 'article', 'listitem', 'dialog', 'form']) {
-      const scoped = page.getByRole(r).filter({ hasText: inText }).getByRole(role, roleOpts);
+      const scoped = page.getByRole(r).filter({ has: page.getByText(inText, { exact: true }) }).getByRole(role, roleOpts);
       if (await scoped.count() > 0) { loc = scoped; break; }
     }
   }

--- a/packages/core/src/page-scripts.ts
+++ b/packages/core/src/page-scripts.ts
@@ -42,7 +42,7 @@ export function buildRunCodeScoped(fn, inText, targetText, ...args) {
   return { _: ['run-code', `async (page) => {
   let __scope = page;
   for (const __r of ['group','article','listitem','region','dialog','form']) {
-    const __c = page.getByRole(__r).filter({ hasText: ${inSer} });
+    const __c = page.getByRole(__r).filter({ has: page.getByText(${inSer}, { exact: true }) });
     const __n = await __c.count();
     if (__n > 0) { __scope = __c.first(); break; }
   }
@@ -296,7 +296,7 @@ export async function actionByRole(page, role, name, action, nth, inRole, inText
   let loc = page.getByRole(role, { name, exact: true });
   if (inRole !== undefined && inText !== undefined) {
     const cr = ({ list: 'listitem' })[inRole] || inRole;
-    loc = page.getByRole(cr).filter({ hasText: inText }).getByRole(role, { name, exact: true });
+    loc = page.getByRole(cr).filter({ has: page.getByText(inText, { exact: true }) }).getByRole(role, { name, exact: true });
   }
   if (nth !== undefined) loc = loc.nth(nth);
   await loc[action]();
@@ -306,7 +306,7 @@ export async function fillByRole(page, role, name, value, nth, inRole, inText) {
   let loc = page.getByRole(role, { name, exact: true });
   if (inRole !== undefined && inText !== undefined) {
     const cr = ({ list: 'listitem' })[inRole] || inRole;
-    loc = page.getByRole(cr).filter({ hasText: inText }).getByRole(role, { name, exact: true });
+    loc = page.getByRole(cr).filter({ has: page.getByText(inText, { exact: true }) }).getByRole(role, { name, exact: true });
   }
   if (nth !== undefined) loc = loc.nth(nth);
   await loc.fill(value);
@@ -316,7 +316,7 @@ export async function selectByRole(page, role, name, value, nth, inRole, inText)
   let loc = page.getByRole(role, { name, exact: true });
   if (inRole !== undefined && inText !== undefined) {
     const cr = ({ list: 'listitem' })[inRole] || inRole;
-    loc = page.getByRole(cr).filter({ hasText: inText }).getByRole(role, { name, exact: true });
+    loc = page.getByRole(cr).filter({ has: page.getByText(inText, { exact: true }) }).getByRole(role, { name, exact: true });
   }
   if (nth !== undefined) loc = loc.nth(nth);
   await loc.selectOption(value);
@@ -326,7 +326,7 @@ export async function pressKeyByRole(page, role, name, key, nth, inRole, inText)
   let loc = page.getByRole(role, { name, exact: true });
   if (inRole !== undefined && inText !== undefined) {
     const cr = ({ list: 'listitem' })[inRole] || inRole;
-    loc = page.getByRole(cr).filter({ hasText: inText }).getByRole(role, { name, exact: true });
+    loc = page.getByRole(cr).filter({ has: page.getByText(inText, { exact: true }) }).getByRole(role, { name, exact: true });
   }
   if (nth !== undefined) loc = loc.nth(nth);
   await loc.press(key);

--- a/packages/core/src/parser.ts
+++ b/packages/core/src/parser.ts
@@ -302,19 +302,35 @@ export function resolveArgs(args: ParsedArgs): ParsedArgs {
     const inText = args['in-text'] !== undefined ? String(args['in-text']) : undefined;
     if (ROLE_ACTIONS[cmdName]) {
       const name = args._.slice(2).join(' ');
-      args = buildRunCode(actionByRole as PageScriptFn, role, name, ROLE_ACTIONS[cmdName], nth, inRole, inText);
+      if (inText && !inRole) {
+        args = buildRunCodeScoped(actionByRole as PageScriptFn, inText, name, role, name, ROLE_ACTIONS[cmdName], nth);
+      } else {
+        args = buildRunCode(actionByRole as PageScriptFn, role, name, ROLE_ACTIONS[cmdName], nth, inRole, inText);
+      }
     } else if (cmdName === 'fill') {
       const name = args._[2];
       const value = args._.slice(3).join(' ') || '';
-      args = buildRunCode(fillByRole as PageScriptFn, role, name, value, nth, inRole, inText);
+      if (inText && !inRole) {
+        args = buildRunCodeScoped(fillByRole as PageScriptFn, inText, name, role, name, value, nth);
+      } else {
+        args = buildRunCode(fillByRole as PageScriptFn, role, name, value, nth, inRole, inText);
+      }
     } else if (cmdName === 'select') {
       const name = args._[2];
       const value = args._.slice(3).join(' ') || '';
-      args = buildRunCode(selectByRole as PageScriptFn, role, name, value, nth, inRole, inText);
+      if (inText && !inRole) {
+        args = buildRunCodeScoped(selectByRole as PageScriptFn, inText, name, role, name, value, nth);
+      } else {
+        args = buildRunCode(selectByRole as PageScriptFn, role, name, value, nth, inRole, inText);
+      }
     } else if (cmdName === 'press') {
       const name = args._[2];
       const key = args._.slice(3).join(' ') || '';
-      args = buildRunCode(pressKeyByRole as PageScriptFn, role, name, key, nth, inRole, inText);
+      if (inText && !inRole) {
+        args = buildRunCodeScoped(pressKeyByRole as PageScriptFn, inText, name, role, name, key, nth);
+      } else {
+        args = buildRunCode(pressKeyByRole as PageScriptFn, role, name, key, nth, inRole, inText);
+      }
     }
   }
 

--- a/packages/core/src/resolve-command.ts
+++ b/packages/core/src/resolve-command.ts
@@ -73,7 +73,7 @@ function callScoped(fn, inText, _targetText, ...args) {
     let __scope = page;
     const __roles = ['group', 'article', 'listitem', 'region', 'dialog', 'form'];
     for (const __r of __roles) {
-      const __c = page.getByRole(__r).filter({ hasText: ${ser(inText)} });
+      const __c = page.getByRole(__r).filter({ has: page.getByText(${ser(inText)}, { exact: true }) });
       if (await __c.count() > 0) { __scope = __c.first(); break; }
     }
     if (__scope === page) {

--- a/packages/core/test/page-scripts.test.ts
+++ b/packages/core/test/page-scripts.test.ts
@@ -118,7 +118,9 @@ describe('buildRunCodeScoped', () => {
       getByPlaceholder: vi.fn().mockReturnValue({ count: vi.fn().mockResolvedValue(0) }),
     };
 
+    const textLocator = { _type: 'getByText-locator' };
     const page = {
+      getByText: vi.fn().mockReturnValue(textLocator),
       getByRole: vi.fn().mockImplementation((role) => {
         if (role === 'group') {
           return {
@@ -423,27 +425,47 @@ describe('actionByRole', () => {
     expect(nthLoc.click).toHaveBeenCalled();
   });
 
-  it('supports --in container context', async () => {
+  it('supports --in container context with exact text matching (#863)', async () => {
+    const textLoc = mockLocator(1);
     const innerLoc = mockLocator(1);
     const filterLoc = { ...mockLocator(1), getByRole: vi.fn().mockReturnValue(innerLoc) };
     const loc = mockLocator(1);
     loc.filter = vi.fn().mockReturnValue(filterLoc);
-    const page = { getByRole: vi.fn().mockReturnValue(loc) };
+    const page = {
+      getByRole: vi.fn().mockReturnValue(loc),
+      getByText: vi.fn().mockReturnValue(textLoc),
+    };
     await actionByRole(page, 'button', 'Save', 'click', undefined, 'dialog', 'Settings');
     expect(page.getByRole).toHaveBeenCalledWith('dialog');
-    expect(loc.filter).toHaveBeenCalledWith({ hasText: 'Settings' });
+    expect(page.getByText).toHaveBeenCalledWith('Settings', { exact: true });
+    expect(loc.filter).toHaveBeenCalledWith({ has: textLoc });
     expect(filterLoc.getByRole).toHaveBeenCalledWith('button', { name: 'Save', exact: true });
     expect(innerLoc.click).toHaveBeenCalled();
   });
 
   it('maps list to listitem for --in', async () => {
+    const textLoc = mockLocator(1);
     const innerLoc = mockLocator(1);
     const filterLoc = { ...mockLocator(1), getByRole: vi.fn().mockReturnValue(innerLoc) };
     const loc = mockLocator(1);
     loc.filter = vi.fn().mockReturnValue(filterLoc);
-    const page = { getByRole: vi.fn().mockReturnValue(loc) };
+    const page = {
+      getByRole: vi.fn().mockReturnValue(loc),
+      getByText: vi.fn().mockReturnValue(textLoc),
+    };
     await actionByRole(page, 'checkbox', 'Done', 'check', undefined, 'list', 'Tasks');
     expect(page.getByRole).toHaveBeenCalledWith('listitem');
+  });
+
+  it('ignores --in when inRole is undefined but inText is provided', async () => {
+    // Without the fix, actionByRole silently ignores inText when inRole is undefined.
+    // The fix routes through buildRunCodeScoped in parser.ts instead, so actionByRole
+    // is never called with (undefined, inText) — but verify the guard works anyway.
+    const page = mockPage(1);
+    await actionByRole(page, 'radio', 'ja', 'check', undefined, undefined, 'Very long text');
+    // Should NOT have called getByText — scoping is handled externally
+    expect(page.getByRole).toHaveBeenCalledWith('radio', { name: 'ja', exact: true });
+    expect(page._loc.check).toHaveBeenCalled();
   });
 });
 

--- a/packages/core/test/parser.test.ts
+++ b/packages/core/test/parser.test.ts
@@ -281,7 +281,7 @@ describe('--in with text locators (resolveArgs)', () => {
     const code = resolved._[1];
     // Should scope to first role element containing --in text (group before form)
     // without requiring the target text to also be present
-    expect(code).toContain('filter({ hasText: "E-Scooter" })');
+    expect(code).toContain('filter({ has: page.getByText("E-Scooter", { exact: true }) })');
     expect(code).toContain('__c.first()');
     // Should NOT check for target text in the role loop
     expect(code).not.toContain('__c.getByText');
@@ -296,6 +296,70 @@ describe('--in with text locators (resolveArgs)', () => {
     expect(code).toContain('FIELDSET');
     expect(code).toContain('SECTION');
     expect(code).toContain('a.hasAttribute');
+  });
+});
+
+describe('--in with role-based commands (#863)', () => {
+  it('scopes role-based check with --in text-only', () => {
+    // "check radio "ja" --in "Very long text"" must use buildRunCodeScoped
+    // so the radio is found within the ancestor containing "Very long text"
+    const args = parseInput('check radio "ja" --in "Very long text"');
+    const resolved = resolveArgs(args);
+    expect(resolved._[0]).toBe('run-code');
+    expect(resolved._[1]).toContain('actionByRole');
+    // Should scope via data-pw-in fallback (buildRunCodeScoped)
+    expect(resolved._[1]).toContain('data-pw-in');
+    expect(resolved._[1]).toContain('"Very long text"');
+  });
+
+  it('scopes role-based click with --in text-only', () => {
+    const args = parseInput('click radio "nein" --in "Another very long text"');
+    const resolved = resolveArgs(args);
+    expect(resolved._[0]).toBe('run-code');
+    expect(resolved._[1]).toContain('actionByRole');
+    expect(resolved._[1]).toContain('data-pw-in');
+    expect(resolved._[1]).toContain('"Another very long text"');
+  });
+
+  it('scopes role-based fill with --in text-only', () => {
+    const args = parseInput('fill textbox "Email" user@test.com --in "Contact Info"');
+    const resolved = resolveArgs(args);
+    expect(resolved._[0]).toBe('run-code');
+    expect(resolved._[1]).toContain('fillByRole');
+    expect(resolved._[1]).toContain('data-pw-in');
+    expect(resolved._[1]).toContain('"Contact Info"');
+  });
+
+  it('still uses direct --in role text for role-based commands', () => {
+    // "check radio "ja" --in row "Very long text"" should NOT use scoping
+    // but pass inRole/inText directly to actionByRole
+    const args = parseInput('check radio "ja" --in row "Very long text"');
+    const resolved = resolveArgs(args);
+    expect(resolved._[0]).toBe('run-code');
+    expect(resolved._[1]).toContain('actionByRole');
+    // Should NOT use scoped fallback — uses the direct inRole/inText path
+    expect(resolved._[1]).not.toContain('data-pw-in');
+  });
+
+  it('uses exact text matching in --in role filter (#863)', () => {
+    // "check radio "ja" --in row "Very long text"" must use
+    // has: page.getByText("Very long text", { exact: true })
+    // not hasText: "Very long text" (which is substring matching)
+    const args = parseInput('check radio "ja" --in row "Very long text"');
+    const resolved = resolveArgs(args);
+    const code = resolved._[1];
+    // actionByRole is stringified — check the filter uses exact matching
+    expect(code).toContain('getByText(inText, { exact: true })');
+    expect(code).not.toContain('hasText');
+  });
+
+  it('uses exact text matching in --in text-only scoping (#863)', () => {
+    const args = parseInput('check radio "ja" --in "Very long text"');
+    const resolved = resolveArgs(args);
+    const code = resolved._[1];
+    // buildRunCodeScoped filter should use exact text matching
+    expect(code).toContain('filter({ has: page.getByText("Very long text", { exact: true }) })');
+    expect(code).not.toContain('hasText');
   });
 });
 


### PR DESCRIPTION
## Summary
- **`--in "text"` ignored for role-based commands** — `check radio "ja" --in "Very long text"` passed `inRole=undefined` to `actionByRole`, which silently ignored the flag. Now routes through `buildRunCodeScoped` to properly scope within an ancestor element.
- **`hasText` → exact text matching** — All `--in` filters used `.filter({ hasText })` (substring matching), so `"Very long text"` also matched `"Another very long text"`. Changed to `.filter({ has: page.getByText(text, { exact: true }) })` across `page-scripts.ts`, `resolve-command.ts`, and `command-scripts.ts`.

## Test plan
- [x] 6 new parser tests covering role-based `--in "text"` scoping and exact matching
- [x] Updated existing `actionByRole` and `buildRunCodeScoped` tests for new filter shape
- [x] All 153 core tests pass

Closes #863

🤖 Generated with [Claude Code](https://claude.com/claude-code)