### PR TITLE
test: add relay mode E2E tests for extension

### DIFF
--- a/packages/extension/e2e/relay/fixtures.ts
+++ b/packages/extension/e2e/relay/fixtures.ts
@@ -1,0 +1,177 @@
+/**
+ * Relay E2E test fixtures.
+ *
+ * Launches Chromium directly (no extension) with a real Playwright page.
+ * Commands are executed via resolveCommand → AsyncFunction — same path
+ * as the CLI relay mode and VS Code relay mode.
+ *
+ * A local HTTP server serves test-page.html to eliminate network latency.
+ */
+
+import { test as base, chromium, expect, type Browser, type BrowserContext, type Page } from '@playwright/test';
+import { resolveCommand, UPDATE_COMMANDS, COMMANDS, CATEGORIES } from '../../../core/dist/index.js';
+import http from 'node:http';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+export { expect };
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const TEST_PAGE_PATH = path.resolve(__dirname, 'test-page.html');
+
+const AsyncFunction = Object.getPrototypeOf(async function () {}).constructor;
+
+type RelayContext = {
+  browser: Browser;
+  context: BrowserContext;
+  page: Page;
+  testUrl: string;
+};
+
+type CommandResult = { text?: string; isError?: boolean; image?: string };
+
+/**
+ * Execute a command via relay mode — keyword or JavaScript.
+ * Same execution path as BrowserManager._execExpr / relayExec in CLI.
+ */
+async function relayRun(
+  command: string,
+  page: Page,
+  context: BrowserContext,
+  expectFn: typeof expect,
+): Promise<CommandResult> {
+  const trimmed = command.trim();
+
+  // Help commands — handled locally (not a Playwright MCP command)
+  if (trimmed === 'help') {
+    const lines = Object.entries(CATEGORIES).map(([cat, cmds]) => `  ${cat}: ${(cmds as string[]).join(', ')}`);
+    return { text: `Available commands:\n${lines.join('\n')}`, isError: false };
+  }
+  if (trimmed.startsWith('help ')) {
+    const cmd = trimmed.slice(5).trim();
+    const info = COMMANDS[cmd] as { desc?: string; usage?: string; examples?: string[] } | undefined;
+    if (!info) return { text: `Unknown command: "${cmd}"`, isError: true };
+    const parts = [`${cmd} — ${info.desc || ''}`];
+    if (info.usage) parts.push(`Usage: ${info.usage}`);
+    return { text: parts.join('\n'), isError: false };
+  }
+
+  // Keyword command → resolveCommand → jsExpr
+  const resolved = resolveCommand(trimmed);
+  if (resolved) {
+    try {
+      const fn = new AsyncFunction('page', 'context', 'expect', resolved.jsExpr);
+      const result = await fn(page, context, expectFn);
+      return formatResult(result);
+    } catch (e: unknown) {
+      return { text: e instanceof Error ? e.message : String(e), isError: true };
+    }
+  }
+
+  // JavaScript — wrap single expressions with return
+  const isSingleExpr = !trimmed.includes('\n') && !trimmed.replace(/;$/, '').includes(';')
+    && !/^(const |let |var |if |for |while |switch |try |class |function )/.test(trimmed);
+  const script = isSingleExpr ? `return ${trimmed.replace(/;$/, '')}` : trimmed;
+  try {
+    const fn = new AsyncFunction('page', 'context', 'expect', script);
+    const result = await fn(page, context, expectFn);
+    return formatResult(result);
+  } catch (e: unknown) {
+    return { text: e instanceof Error ? e.message : String(e), isError: true };
+  }
+}
+
+async function relayRunScript(
+  script: string,
+  language: 'pw' | 'javascript',
+  page: Page,
+  context: BrowserContext,
+  expectFn: typeof expect,
+): Promise<CommandResult> {
+  if (language === 'javascript') {
+    try {
+      const fn = new AsyncFunction('page', 'context', 'expect', script);
+      const result = await fn(page, context, expectFn);
+      return formatResult(result);
+    } catch (e: unknown) {
+      return { text: e instanceof Error ? e.message : String(e), isError: true };
+    }
+  }
+  // .pw — line by line
+  const lines = script.split('\n').filter(l => l.trim() && !l.trim().startsWith('#'));
+  const results: string[] = [];
+  for (const line of lines) {
+    const r = await relayRun(line.trim(), page, context, expectFn);
+    const status = r.isError ? '\u2717' : '\u2713';
+    results.push(`${status} ${line.trim()}${r.isError && r.text ? ` \u2014 ${r.text}` : ''}`);
+    if (r.isError) return { text: results.join('\n'), isError: true };
+  }
+  return { text: results.join('\n'), isError: false };
+}
+
+function formatResult(value: unknown): CommandResult {
+  if (value === undefined || value === null) return { text: 'Done', isError: false };
+  if (typeof value === 'string') {
+    try {
+      const obj = JSON.parse(value);
+      if (obj && typeof obj === 'object' && '__image' in obj)
+        return { text: '', isError: false, image: `data:${obj.mimeType};base64,${obj.__image}` };
+    } catch { /* not JSON */ }
+    return { text: value, isError: false };
+  }
+  if (typeof value === 'object' && value !== null && '__image' in value) {
+    const img = value as { __image: string; mimeType: string };
+    return { text: '', isError: false, image: `data:${img.mimeType};base64,${img.__image}` };
+  }
+  if (typeof value === 'number' || typeof value === 'boolean') return { text: String(value), isError: false };
+  try { return { text: JSON.stringify(value, null, 2), isError: false }; }
+  catch { return { text: String(value), isError: false }; }
+}
+
+export const test = base.extend<
+  {
+    relay: { run: (cmd: string) => Promise<CommandResult>; runScript: (script: string, language: 'pw' | 'javascript') => Promise<CommandResult> };
+    testUrl: string;
+  },
+  { relayContext: RelayContext }
+>({
+  // Worker-scoped: browser + HTTP server, reused across all tests in a worker
+  relayContext: [async ({}, use) => {
+    // Start local HTTP server for test pages
+    const html = fs.readFileSync(TEST_PAGE_PATH, 'utf-8');
+    const httpServer = http.createServer((_req, res) => {
+      res.writeHead(200, { 'Content-Type': 'text/html' });
+      res.end(html);
+    });
+    await new Promise<void>(resolve => httpServer.listen(0, resolve));
+    const httpPort = (httpServer.address() as { port: number }).port;
+    const testUrl = `http://localhost:${httpPort}`;
+
+    // Launch browser directly — same as relay mode
+    const browser = await chromium.launch({
+      headless: !process.env.HEADED,
+      args: ['--no-first-run', '--no-default-browser-check'],
+    });
+    const context = await browser.newContext();
+    const page = await context.newPage();
+
+    await use({ browser, context, page, testUrl });
+
+    await browser.close();
+    httpServer.close();
+  }, { scope: 'worker' }],
+
+  // Test-scoped relay runner
+  relay: async ({ relayContext }, use) => {
+    const { page, context } = relayContext;
+    await use({
+      run: (cmd: string) => relayRun(cmd, page, context, expect),
+      runScript: (script: string, language: 'pw' | 'javascript') => relayRunScript(script, language, page, context, expect),
+    });
+  },
+
+  testUrl: async ({ relayContext }, use) => {
+    await use(relayContext.testUrl);
+  },
+});

--- a/packages/extension/e2e/relay/relay.spec.ts
+++ b/packages/extension/e2e/relay/relay.spec.ts
@@ -1,0 +1,288 @@
+/**
+ * Relay E2E tests — verify every command returns meaningful results via direct Playwright.
+ *
+ * Commands flow: resolveCommand → AsyncFunction('page','context','expect', jsExpr) → result.
+ * Same execution path as CLI relay mode and VS Code relay mode.
+ *
+ * Every test is self-contained — beforeEach navigates to a fresh page.
+ */
+
+import { test, expect } from './fixtures.js';
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+type Result = { text?: string; isError?: boolean; image?: string };
+
+function expectOk(r: Result) {
+  expect(r.isError, `Expected OK but got error: ${r.text}`).toBeFalsy();
+}
+
+function expectText(r: Result, substring: string) {
+  expectOk(r);
+  expect(r.text).toContain(substring);
+}
+
+// ─── Navigation & Page ───────────────────────────────────────────────────────
+
+test.describe("Relay command tests", () => {
+  test.describe('Navigation & Page', () => {
+    test('goto navigates to URL', async ({ relay, testUrl }) => {
+      const r = await relay.run(`goto ${testUrl}`);
+      expectOk(r);
+    });
+
+    test('snapshot returns accessibility tree with refs', async ({ relay, testUrl }) => {
+      await relay.run(`goto ${testUrl}`);
+      const r = await relay.run('snapshot');
+      expectOk(r);
+      expect(r.text).toMatch(/\[ref=e\d+\]/);
+      expect(r.text).toContain('todos');
+    });
+
+    test('screenshot returns base64 image', async ({ relay, testUrl }) => {
+      await relay.run(`goto ${testUrl}`);
+      const r = await relay.run('screenshot');
+      expectOk(r);
+      expect(r.image).toMatch(/^data:image\/(jpeg|png);base64,/);
+    });
+
+    test('go-back and go-forward navigate history', async ({ relay, testUrl }) => {
+      await relay.run(`goto ${testUrl}?page=1`);
+      await relay.run(`goto ${testUrl}?page=2`);
+      const r1 = await relay.run('go-back');
+      expectOk(r1);
+      const r2 = await relay.run('go-forward');
+      expectOk(r2);
+    });
+
+    test('reload reloads page', async ({ relay, testUrl }) => {
+      await relay.run(`goto ${testUrl}`);
+      const r = await relay.run('reload');
+      expectOk(r);
+    });
+  });
+
+  // ─── Help ───────────────────────────────────────────────────────────────────
+
+  test.describe('Help', () => {
+    test('help returns command categories', async ({ relay }) => {
+      const r = await relay.run('help');
+      expectOk(r);
+      expect(r.text).toContain('Navigation');
+      expect(r.text).toContain('Interaction');
+      expect(r.text).toContain('Assertions');
+    });
+
+    test('help <command> returns command details', async ({ relay }) => {
+      const r = await relay.run('help click');
+      expectOk(r);
+      expect(r.text).toContain('click');
+      expect(r.text).toContain('Click');
+    });
+
+    test('help <unknown> returns error', async ({ relay }) => {
+      const r = await relay.run('help nonexistent_cmd');
+      expect(r.isError).toBe(true);
+      expect(r.text).toContain('Unknown command');
+    });
+  });
+
+  // ─── Interaction ─────────────────────────────────────────────────────────────
+
+  test.describe('Interaction', () => {
+    test.beforeEach(async ({ relay, testUrl }) => {
+      await relay.run(`goto ${testUrl}`);
+    });
+
+    test('fill types into input field', async ({ relay }) => {
+      const r = await relay.run('fill "What needs to be done?" "Relay todo"');
+      expectOk(r);
+    });
+
+    test('press submits with Enter', async ({ relay }) => {
+      await relay.run('fill "What needs to be done?" "press test"');
+      const r = await relay.run('press Enter');
+      expectOk(r);
+    });
+
+    test('click clicks an element by text', async ({ relay }) => {
+      await relay.run('fill "What needs to be done?" "click me"');
+      await relay.run('press Enter');
+      const r = await relay.run('click "click me"');
+      expectOk(r);
+    });
+
+    test('hover hovers over element', async ({ relay }) => {
+      await relay.run('fill "What needs to be done?" "hover me"');
+      await relay.run('press Enter');
+      const r = await relay.run('hover "hover me"');
+      expectOk(r);
+    });
+
+    test('type types text key by key', async ({ relay }) => {
+      await relay.run('click "What needs to be done?"');
+      const r = await relay.run('type "hello world"');
+      expectOk(r);
+    });
+
+    test('eval executes JavaScript and returns result', async ({ relay }) => {
+      const r = await relay.run('eval document.title');
+      expectText(r, 'Relay Test');
+    });
+  });
+
+  // ─── Verification ────────────────────────────────────────────────────────────
+
+  test.describe('Verification', () => {
+    test.beforeEach(async ({ relay, testUrl }) => {
+      await relay.run(`goto ${testUrl}`);
+    });
+
+    test('verify-text passes for visible text', async ({ relay }) => {
+      await relay.run('fill "What needs to be done?" "verify item"');
+      await relay.run('press Enter');
+      const r = await relay.run('verify-text "verify item"');
+      expectOk(r);
+      expect(r.text).toBeTruthy();
+    });
+
+    test('verify-no-text passes for absent text', async ({ relay }) => {
+      const r = await relay.run('verify-no-text "nonexistent xyz text"');
+      expectOk(r);
+    });
+
+    test('verify-title passes when title matches', async ({ relay }) => {
+      const r = await relay.run('verify-title "Relay Test"');
+      expectOk(r);
+    });
+
+    test('verify-url passes when URL matches', async ({ relay }) => {
+      const r = await relay.run('verify-url "localhost"');
+      expectOk(r);
+    });
+
+    test('verify-element passes when element exists', async ({ relay }) => {
+      const r = await relay.run('verify-element heading "todos"');
+      expectOk(r);
+    });
+
+    test('toMatchAriaSnapshot passes for matching snapshot', async ({ relay }) => {
+      const r = await relay.run(`await expect(page.locator('h1')).toMatchAriaSnapshot(\`- heading "todos" [level=1]\`)`);
+      expectOk(r);
+    });
+
+    test('toMatchAriaSnapshot fails for non-matching snapshot', async ({ relay }) => {
+      const r = await relay.run(`await expect(page.locator('h1')).toMatchAriaSnapshot(\`- heading "wrong"\`, { timeout: 1000 })`);
+      expect(r.isError).toBe(true);
+      expect(r.text).toContain('toMatchAriaSnapshot');
+    });
+
+    test('not.toMatchAriaSnapshot passes for non-matching snapshot', async ({ relay }) => {
+      const r = await relay.run(`await expect(page.locator('h1')).not.toMatchAriaSnapshot(\`- heading "wrong"\`)`);
+      expectOk(r);
+    });
+
+    test('not.toMatchAriaSnapshot fails for matching snapshot', async ({ relay }) => {
+      const r = await relay.run(`await expect(page.locator('h1')).not.toMatchAriaSnapshot(\`- heading "todos" [level=1]\`, { timeout: 1000 })`);
+      expect(r.isError).toBe(true);
+      expect(r.text).toContain('toMatchAriaSnapshot');
+    });
+  });
+
+  // ─── Script execution ─────────────────────────────────────────────────────
+
+  test.describe('Script execution', () => {
+    test('runScript executes multi-line pw commands with checkmarks', async ({ relay, testUrl }) => {
+      const script = [
+        `goto ${testUrl}`,
+        'fill "What needs to be done?" "Script todo"',
+        'press Enter',
+        'verify-text "Script todo"',
+      ].join('\n');
+      const r = await relay.runScript(script, 'pw');
+      expectOk(r);
+      expect(r.text).toContain('\u2713'); // ✓ checkmark
+    });
+
+    test('runScript with javascript language executes JS', async ({ relay, testUrl }) => {
+      await relay.run(`goto ${testUrl}`);
+      const r = await relay.runScript('return await page.title()', 'javascript');
+      expectOk(r);
+      expect(r.text).toContain('Relay Test');
+    });
+  });
+
+  // ─── JavaScript expressions ─────────────────────────────────────────────────
+
+  test.describe('JavaScript expressions', () => {
+    test.beforeEach(async ({ relay, testUrl }) => {
+      await relay.run(`goto ${testUrl}`);
+    });
+
+    test('page.title() returns title string', async ({ relay }) => {
+      const r = await relay.run('await page.title()');
+      expectOk(r);
+      expect(r.text).toContain('Relay Test');
+    });
+
+    test('page.url() returns URL string', async ({ relay }) => {
+      const r = await relay.run('await page.url()');
+      expectOk(r);
+      expect(r.text).toContain('localhost');
+    });
+
+    test('page.locator().textContent() returns element text', async ({ relay }) => {
+      const r = await relay.run("await page.locator('h1').textContent()");
+      expectOk(r);
+      expect(r.text).toContain('todos');
+    });
+
+    test('page.locator().count() returns a number', async ({ relay }) => {
+      await relay.run('fill "What needs to be done?" "JS test item"');
+      await relay.run('press Enter');
+      const r = await relay.run("await page.locator('.todo-list li').count()");
+      expectOk(r);
+      expect(Number(r.text)).toBeGreaterThan(0);
+    });
+
+    test('page.locator().getAttribute() returns attribute value', async ({ relay }) => {
+      const r = await relay.run("await page.locator('input.new-todo').getAttribute('placeholder')");
+      expectOk(r);
+      expect(r.text).toContain('What needs to be done?');
+    });
+
+    test('page.locator().isVisible() returns boolean', async ({ relay }) => {
+      const r = await relay.run("await page.locator('h1').isVisible()");
+      expectOk(r);
+      expect(r.text).toMatch(/true|false/);
+    });
+
+    test('page.evaluate() returns evaluated result', async ({ relay }) => {
+      const r = await relay.run("await page.evaluate(() => window.location.hostname)");
+      expectOk(r);
+      expect(r.text).toContain('localhost');
+    });
+
+    test('page.locator().click() executes without error', async ({ relay }) => {
+      const r = await relay.run("await page.locator('h1').click()");
+      expectOk(r);
+    });
+
+    test('arithmetic expression returns result', async ({ relay }) => {
+      const r = await relay.run('1 + 2 + 3');
+      expectOk(r);
+      expect(r.text).toContain('6');
+    });
+  });
+
+  // ─── Error handling ──────────────────────────────────────────────────────────
+
+  test.describe('Error handling', () => {
+    test('unknown command returns error', async ({ relay, testUrl }) => {
+      await relay.run(`goto ${testUrl}`);
+      const r = await relay.run('nonexistent_cmd_xyz');
+      expect(r.isError).toBe(true);
+      expect(r.text).toBeTruthy();
+    });
+  });
+});

--- a/packages/extension/e2e/relay/test-page.html
+++ b/packages/extension/e2e/relay/test-page.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Relay Test</title>
+</head>
+<body>
+  <h1>todos</h1>
+  <input class="new-todo" placeholder="What needs to be done?" autofocus>
+  <ul class="todo-list"></ul>
+  <script>
+    document.querySelector('.new-todo').addEventListener('keydown', (e) => {
+      if (e.key === 'Enter' && e.target.value.trim()) {
+        const li = document.createElement('li');
+        li.textContent = e.target.value.trim();
+        document.querySelector('.todo-list').appendChild(li);
+        e.target.value = '';
+      }
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

Add 35 relay mode E2E tests replacing the 44 bridge tests removed in #876. Tests use direct Playwright (no extension needed) — same execution path as CLI relay and VS Code relay.

### Coverage
- Navigation: goto, snapshot, screenshot, go-back/forward, reload
- Help: help, help \<command\>, help \<unknown\>
- Interaction: fill, press, click, hover, type, eval
- Verification: verify-text/no-text/title/url/element, toMatchAriaSnapshot
- Script execution: pw keyword scripts, JavaScript scripts
- JavaScript expressions: page methods, locator methods, evaluate, arithmetic
- Error handling: unknown commands

### Test results
- 35 new relay tests pass (7.9s)
- 147 total extension E2E tests pass (112 existing + 35 new)

Closes #877

🤖 Generated with [Claude Code](https://claude.com/claude-code)