### PR TITLE
docs: update README for relay mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Instead of writing `page.locator('[placeholder="What needs to be done?"]').fill(
 | [Dramaturg](packages/extension/README.md) | Chrome extension — console, script editor, recorder, JS debugger |
 | [`@playwright-repl/runner`](packages/runner/README.md) | Test runner — drop-in replacement for `npx playwright test` with context reuse |
 | [`@playwright-repl/mcp`](packages/mcp/README.md) | MCP server — AI agents control your real Chrome browser |
-| [`@playwright-repl/core`](packages/core/README.md) | Shared parser, servers, and utilities |
+| [`@playwright-repl/core`](packages/core/README.md) | Shared parser, relay server, and utilities |
 
 ---
 
@@ -66,21 +66,14 @@ pw> verify text 1 item left
 pw> screenshot
 ```
 
-**Two modes:**
-
-| Mode | Flag | How it works |
-|------|------|--------------|
-| **Standalone** | *(default)* | Launches Chromium with Dramaturg extension |
-| **Bridge** | `--bridge` | Connects to your real Chrome via Dramaturg extension |
-
-Standalone launches a fresh Chromium with the extension pre-installed — keyword commands and JavaScript both work. Use `--headless` for CI/scripting.
+Launches Chromium directly with full Playwright API — keyword commands and JavaScript both work. Use `--headless` for CI/scripting, `--connect` to attach to existing Chrome.
 
 **Single-command mode** — run one command and exit, useful for automation tools like Claude Code:
 
 ```bash
-playwright-repl --bridge --command "snapshot"
-playwright-repl --bridge --command "goto https://example.com"
-playwright-repl --bridge --command "click \"Interested\""
+playwright-repl --command "snapshot"
+playwright-repl --command "goto https://example.com"
+playwright-repl --command "click \"Interested\""
 ```
 
 > **[Full CLI docs](packages/cli/README.md)**
@@ -96,7 +89,7 @@ npm install -D @playwright-repl/runner
 ```
 
 ```bash
-pw test                              # run Playwright tests (2.8x faster via extension)
+pw test                              # run Playwright tests with context reuse
 pw repl                              # interactive REPL with keyword + JS support
 pw repl --headless                   # headless mode for scripting
 ```
@@ -125,12 +118,12 @@ Install from the [Chrome Web Store](https://chromewebstore.google.com/detail/dra
 
 ## MCP Server — AI Browser Agent
 
-AI agents control the browser — standalone or connected to your real Chrome.
+AI agents control the browser — standalone or connected to your real Chrome via CDP relay.
 
 ```bash
 npm install -g @playwright-repl/mcp
 playwright-repl-mcp --standalone     # launch fresh browser (keyword + JS)
-playwright-repl-mcp                  # connect to existing Chrome via bridge
+playwright-repl-mcp --relay          # connect to existing Chrome via CDP relay
 ```
 
 | | `@playwright-repl/mcp` | Playwright MCP | Playwriter |
@@ -153,7 +146,7 @@ packages/
 ├── runner/         # @playwright-repl/runner — test runner (pw CLI)
 ├── extension/      # Dramaturg — Chrome side panel extension
 ├── mcp/            # @playwright-repl/mcp — MCP server for AI agents
-└── core/           # @playwright-repl/core — shared parser, servers, utilities
+└── core/           # @playwright-repl/core — shared parser, relay server, utilities
 ```
 
 ## Requirements

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -21,7 +21,7 @@ pw> screenshot
 ```bash
 npm install -g playwright-repl
 
-# Install Chromium (needed for standalone mode)
+# Install Chromium
 npx playwright install chromium
 ```
 
@@ -56,33 +56,31 @@ The skill defines `allowed-tools: Bash(pw-cli:*)` so the agent can run browser c
 
 | Mode | Flag | How it works |
 |------|------|--------------|
-| **Standalone** | *(default)* | Launches Chromium with Dramaturg extension — keyword + JS |
-| **Bridge** | `--bridge` | Connects to your real Chrome via Dramaturg extension — cookies and logins intact |
+| **Launch** | *(default)* | Launches Chromium directly — keyword + JS, full Playwright API |
+| **Connect** | `--connect [port]` | Connects to existing Chrome via CDP — cookies and logins intact |
 
-### Standalone
+### Launch (default)
 
-Launches Chromium with the Dramaturg extension pre-installed. Headed by default — use `--headless` for CI/scripting. Supports both keyword commands and JavaScript.
-
-```bash
-playwright-repl                # headed (default)
-playwright-repl --headless     # headless for CI/scripting
-```
-
-### Bridge
-
-The bridge mode turns your terminal into a remote console for the Chrome extension. Commands run inside your real Chrome with your existing cookies and logins.
+Launches Chromium with full Playwright API. Headed by default — use `--headless` for CI/scripting. Supports both keyword commands and JavaScript.
 
 ```bash
-playwright-repl --bridge                      # start bridge server, wait for extension
-playwright-repl --bridge --replay script.pw   # replay a script via bridge
-playwright-repl --bridge --replay examples/   # replay all .pw files
-playwright-repl --bridge --bridge-port 9877   # custom port (default 9876)
-playwright-repl --bridge --command "snapshot"  # run one command and exit
+playwright-repl                          # headed (default)
+playwright-repl --headless               # headless for CI/scripting
+playwright-repl --command "snapshot"     # run one command and exit
 ```
 
-The extension connects automatically — no need to open the side panel.
+### Connect
 
-> Requires the [Dramaturg Chrome extension](../extension/README.md).
+Connect to an existing Chrome instance via CDP. Your cookies, logins, and extensions are available.
+
+```bash
+# Start Chrome with debugging enabled:
+# chrome --remote-debugging-port=9222
+
+playwright-repl --connect                # connect to Chrome on port 9222
+playwright-repl --connect 9333           # custom port
+playwright-repl --connect --replay examples/  # replay scripts against existing Chrome
+```
 
 ### HTTP Mode
 
@@ -90,8 +88,7 @@ Add `--http` to any mode to start an HTTP server alongside the REPL. This lets o
 
 ```bash
 # Terminal 1: Start REPL with HTTP server
-playwright-repl --http                        # standalone + HTTP (port 9223)
-playwright-repl --bridge --http               # bridge + HTTP
+playwright-repl --http                        # launch + HTTP (port 9223)
 playwright-repl --http --http-port 9224       # custom port
 
 # Terminal 2: Send commands via HTTP (fast — reuses existing session)
@@ -152,7 +149,7 @@ playwright-repl --replay session.pw --step
 playwright-repl --record my-test.pw
 
 # Run a single command and exit
-playwright-repl --bridge --command "snapshot"
+playwright-repl --command "snapshot"
 
 # Pipe commands
 echo -e "goto https://example.com\nsnapshot" | playwright-repl
@@ -160,20 +157,19 @@ echo -e "goto https://example.com\nsnapshot" | playwright-repl
 
 ## Input Modes
 
-| Mode | Standalone | Bridge |
-|------|:---:|:---:|
-| **Keyword** — `click "Sign in"`, `goto https://...` | Yes | Yes |
-| **Playwright API / JS** — `await page.title()`, `1 + 1` | Yes | Yes |
+| Mode | Description |
+|------|-------------|
+| **Keyword** — `click "Sign in"`, `goto https://...` | Playwright commands in natural syntax |
+| **JavaScript** — `await page.title()`, `1 + 1` | Full Playwright API |
 
-Both modes auto-detect keyword commands and JavaScript expressions. For DOM access use `await page.evaluate(() => document.title)`. For keyword commands, see [Command Reference](#command-reference).
+The REPL auto-detects keyword commands and JavaScript expressions. For DOM access use `await page.evaluate(() => document.title)`. For keyword commands, see [Command Reference](#command-reference).
 
 ## CLI Options
 
 | Option | Description |
 |--------|-------------|
 | `--headless` | Run browser in headless mode (default: headed) |
-| `--bridge` | Connect to existing Chrome via WebSocket bridge |
-| `--bridge-port <port>` | Bridge server port (default: `9876`) |
+| `--connect [port]` | Connect to existing Chrome via CDP (default: `9222`) |
 | `--http` | Start HTTP server for external command access (port `9223`) |
 | `--http-port <port>` | HTTP server port (default: `9223`) |
 | `--command <cmd>` | Run a single command, print output, and exit |
@@ -417,8 +413,7 @@ pw> click "Submit" --frame "#my-iframe"      # click inside an iframe
 | `video-stop` | Stop recording and save video |
 | `video-chapter <title>` | Add chapter marker to recording |
 
-In **standalone mode**, video uses Playwright's screencast API and saves to `~/pw-videos/`.
-In **bridge mode**, video uses Chrome's tab capture and saves to `Downloads/pw-videos/`.
+Video uses Playwright's screencast API and saves to `~/pw-videos/`.
 
 ### Browser Control
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,6 +1,6 @@
 # @playwright-repl/core
 
-Shared parser, connections, and utilities for the playwright-repl ecosystem.
+Shared parser, relay server, and utilities for the playwright-repl ecosystem.
 
 Used by [`playwright-repl`](../cli/README.md) (CLI), [`@playwright-repl/runner`](../runner/README.md) (runner), [`@playwright-repl/mcp`](../mcp/README.md) (MCP server), and the [VS Code extension](../vscode/README.md).
 
@@ -12,68 +12,29 @@ npm install @playwright-repl/core
 
 ## Key Exports
 
-### `EvaluateConnection`
+### `CDPRelayServer`
 
-Launch Chromium with the Dramaturg extension and execute commands via `serviceWorker.evaluate()`. No WebSocket bridge needed.
-
-```typescript
-import { EvaluateConnection, findExtensionPath } from '@playwright-repl/core';
-
-const conn = new EvaluateConnection();
-const { chromium } = await import('@playwright/test');
-const extPath = findExtensionPath(import.meta.url);
-
-await conn.start(extPath, { headed: true, chromium });
-
-const result = await conn.run('snapshot');
-console.log(result.text);
-
-await conn.runScript('await page.title()', 'javascript');
-
-await conn.close();
-```
-
-**Methods:**
-
-| Method | Description |
-|--------|-------------|
-| `start(extensionPath, opts)` | Launch Chromium with extension |
-| `run(command, opts?)` | Execute a keyword command or JS expression |
-| `runScript(script, language)` | Execute a multi-line script (`'pw'` or `'javascript'`) |
-| `evaluate(fn, arg?)` | Run arbitrary code in the service worker |
-| `connected` | `boolean` — whether the connection is active |
-| `context` | Playwright browser context |
-| `serviceWorker` | Extension service worker handle |
-| `close()` | Close the browser |
-
-### `BridgeServer`
-
-WebSocket server for connecting to an existing Chrome with the Dramaturg extension installed. Used by CLI `--bridge` mode and MCP bridge mode.
+CDP relay server for connecting Node.js (Playwright) to an existing Chrome with the Dramaturg extension. Used by CLI `--connect` mode and MCP relay mode.
 
 ```typescript
-import { BridgeServer } from '@playwright-repl/core';
+import { CDPRelayServer } from '@playwright-repl/core';
 
-const bridge = new BridgeServer();
-await bridge.start(9876);
-
-await bridge.waitForConnection();
-const result = await bridge.run('snapshot');
-
-await bridge.close();
+const relay = new CDPRelayServer();
+await relay.start(9877);
+console.log(relay.cdpEndpoint());     // ws://localhost:...
+console.log(relay.relayEndpoint());   // ws://localhost:...
 ```
 
-### `findExtensionPath`
+### `resolveCommand`
 
-Find the Dramaturg Chrome extension dist path. Checks monorepo first, then bundled npm location.
+Resolve a keyword command to a Playwright JS expression.
 
 ```typescript
-import { findExtensionPath } from '@playwright-repl/core';
+import { resolveCommand } from '@playwright-repl/core';
 
-const extPath = findExtensionPath(import.meta.url);
-// → '/path/to/packages/extension/dist' or null
+const resolved = resolveCommand('click "Submit"');
+// → { jsExpr: 'await page.getByText("Submit").click()' }
 ```
-
----
 
 ### `parseInput`
 
@@ -107,9 +68,9 @@ interface ParsedArgs {
 
 ```
 src/
-├── evaluate-connection.ts # serviceWorker.evaluate() connection + findExtensionPath
-├── bridge-server.ts       # WebSocket bridge server (BridgeServer)
+├── cdp-relay-server.ts    # CDP relay server (CDPRelayServer)
 ├── parser.ts              # Command parsing, alias resolution, resolveArgs
+├── resolve-command.ts     # Keyword → JS expression resolution
 ├── page-scripts.ts        # Text locators + assertion helpers
 ├── completion-data.ts     # Autocomplete items for all commands
 ├── snapshot-parser.ts     # Snapshot tree parsing + ref-to-locator


### PR DESCRIPTION
## Summary

Update documentation to reflect relay mode as the default execution path.

### Root README
- Remove bridge/standalone mode references
- Update CLI section: launch (default) + connect modes
- Update MCP section: standalone + relay modes
- Update core description: "relay server" instead of "bridge server"

### Core README
- Replace `BridgeServer`/`EvaluateConnection`/`findExtensionPath` docs with `CDPRelayServer`/`resolveCommand`
- Update file structure

### CLI README
- Replace standalone/bridge modes with launch/connect
- Remove `--bridge`/`--bridge-port` from CLI options
- Update examples and video section

Closes #871

🤖 Generated with [Claude Code](https://claude.com/claude-code)