### PR TITLE
chore: deprecate runner package — move cdpPreload to core

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,15 +56,15 @@ jobs:
           name: dist-${{ matrix.os }}
           path: |
             packages/core/dist/
+            packages/core/static/
             packages/cli/dist/
             packages/mcp/dist/
-            packages/runner/dist/
             packages/extension/dist/
             packages/vscode/dist/
           retention-days: 1
 
-  core-cli-runner-mcp:
-    name: core+cli+runner+mcp (${{ matrix.os }})
+  core-cli-mcp:
+    name: core+cli+mcp (${{ matrix.os }})
     needs: build
     runs-on: ${{ matrix.os }}
 
@@ -111,10 +111,6 @@ jobs:
       - name: Run CLI tests
         run: pnpm run test
         working-directory: packages/cli
-
-      - name: Run runner tests
-        run: pnpm run test
-        working-directory: packages/runner
 
       - name: Run MCP tests
         run: pnpm run test

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "packageManager": "pnpm@10.26.0",
   "scripts": {
-    "build": "tsc --build packages/core/tsconfig.build.json packages/cli/tsconfig.build.json packages/mcp/tsconfig.build.json packages/runner/tsconfig.build.json && pnpm --filter playwright-repl-vscode run build",
+    "build": "tsc --build packages/core/tsconfig.build.json packages/cli/tsconfig.build.json packages/mcp/tsconfig.build.json && pnpm --filter playwright-repl-vscode run build",
     "build:dev": "node scripts/build-dev.mjs",
     "test": "pnpm run --recursive --if-present test",
     "test:core": "pnpm --filter @playwright-repl/core run test",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -9,7 +9,8 @@
   },
   "types": "./dist/index.d.ts",
   "files": [
-    "dist/"
+    "dist/",
+    "static/"
   ],
   "scripts": {
     "build": "tsc",

--- a/packages/core/static/cdpPreload.cjs
+++ b/packages/core/static/cdpPreload.cjs
@@ -1,0 +1,44 @@
+"use strict";
+/**
+ * Preload script injected via NODE_OPTIONS --require.
+ *
+ * Patches chromium.connect() to use connectOverCDP() when the wsEndpoint
+ * is a CDP URL (contains /devtools/browser/). This allows the test runner
+ * to reuse the existing browser process without version mismatch errors.
+ *
+ * Safe no-op when connect() is called with a normal Playwright wsEndpoint.
+ */
+Object.defineProperty(exports, "__esModule", { value: true });
+const Module = require("module");
+const origLoad = Module._load;
+let patched = false;
+Module._load = function (request, parent) {
+    const mod = origLoad.apply(this, arguments);
+    // Intercept playwright-core or @playwright/test to patch chromium.connect
+    if (!patched && (request === 'playwright-core' || request === '@playwright/test') && mod?.chromium?.connect && !mod.chromium.__pwReplPatched) {
+        patched = true;
+        Module._load = origLoad; // remove hook immediately
+        const origConnect = mod.chromium.connect.bind(mod.chromium);
+        mod.chromium.connect = async function (optionsOrWsEndpoint) {
+            const wsEndpoint = typeof optionsOrWsEndpoint === 'string'
+                ? optionsOrWsEndpoint
+                : optionsOrWsEndpoint?.wsEndpoint;
+            // Only intercept CDP URLs (from --remote-debugging-port)
+            if (!wsEndpoint || !wsEndpoint.includes('/devtools/browser/'))
+                return origConnect(optionsOrWsEndpoint);
+            const browser = await mod.chromium.connectOverCDP(wsEndpoint);
+            // Reuse the persistent context so tests run in the same window
+            browser._newContextForReuse = async function () {
+                const contexts = browser.contexts();
+                return contexts[0] || await browser.newContext();
+            };
+            browser._disconnectFromReusedContext = async function () { };
+            // Don't let the test runner kill our shared browser
+            browser.close = async () => { };
+            return browser;
+        };
+        mod.chromium.__pwReplPatched = true;
+    }
+    return mod;
+};
+//# sourceMappingURL=cdpPreload.cjs.map

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -320,7 +320,6 @@
   },
   "dependencies": {
     "@playwright-repl/core": "workspace:*",
-    "@playwright-repl/runner": "workspace:*",
     "eslint": "^10.0.2",
     "eslint-plugin-playwright": "^2.10.1"
   },

--- a/packages/vscode/src/ai/agent.ts
+++ b/packages/vscode/src/ai/agent.ts
@@ -320,7 +320,7 @@ async function runTestFromFile(
   if (cdpUrl) {
     // Inject cdpPreload so Playwright reuses the running browser
     try {
-      const preloadPath = require.resolve('@playwright-repl/runner/dist/cdpPreload.cjs').replace(/\\/g, '/');
+      const preloadPath = require.resolve('@playwright-repl/core/static/cdpPreload.cjs').replace(/\\/g, '/');
       env.NODE_OPTIONS = `${env.NODE_OPTIONS || ''} --require ${preloadPath}`.trim();
     } catch { /* cdpPreload not available — run standalone */ }
     env.PW_TEST_CONNECT_WS_ENDPOINT = cdpUrl;

--- a/packages/vscode/src/playwrightTestServer.ts
+++ b/packages/vscode/src/playwrightTestServer.ts
@@ -31,7 +31,7 @@ import { TestServerInterface } from './upstream/testServerInterface';
 // Resolve from runner package; use forward slashes (backslashes stripped in NODE_OPTIONS on Windows)
 let _cdpPreloadPath = '';
 try {
-  _cdpPreloadPath = require.resolve('@playwright-repl/runner/dist/cdpPreload.cjs').replace(/\\/g, '/');
+  _cdpPreloadPath = require.resolve('@playwright-repl/core/static/cdpPreload.cjs').replace(/\\/g, '/');
 } catch {}
 
 function preloadEnv(): Record<string, string | undefined> {


### PR DESCRIPTION
## Summary

Disconnect the runner package from other packages. No package depends on `@playwright-repl/runner` anymore.

### Changes
- Move `cdpPreload.cjs` from `runner/dist/` to `core/static/`
- Update VS Code references (`playwrightTestServer.ts`, `ai/agent.ts`)
- Remove `@playwright-repl/runner` dependency from VS Code `package.json`
- Remove runner from root build script
- Remove runner tests from CI job
- Add `core/static/` to CI artifact paths

### What stays
- `packages/runner/` stays in the monorepo (can be removed in a follow-up)
- `pw` CLI binary still works if installed directly

### Test results
- All tests pass (1,151 across core/extension/cli/mcp/vscode)

Closes #881

🤖 Generated with [Claude Code](https://claude.com/claude-code)