### PR TITLE
perf: share BrowserManager's browser with test server via CDP

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "main": "./dist/index.js",
   "exports": {
-    ".": "./dist/index.js"
+    ".": "./dist/index.js",
+    "./static/*": "./static/*"
   },
   "types": "./dist/index.d.ts",
   "files": [

--- a/packages/core/static/cdpPreload.cjs
+++ b/packages/core/static/cdpPreload.cjs
@@ -52,7 +52,7 @@ Module._load = function (request, parent) {
                             await sharedPage.unrouteAll({ behavior: 'ignoreErrors' }).catch(() => {});
                             if (defaultViewport) await sharedPage.setViewportSize(defaultViewport);
                             await sharedPage.evaluate(() => { try { localStorage.clear(); } catch {} try { sessionStorage.clear(); } catch {} }).catch(() => {});
-                            await sharedPage.goto('about:blank', { waitUntil: 'commit' });
+                            await sharedPage.evaluate(() => window.stop()).catch(() => {});
                         } catch {}
                     }
                     sharedContext.newPage = async () => sharedPage;
@@ -70,7 +70,7 @@ Module._load = function (request, parent) {
                             sharedPage = await sharedContext.newPage();
                         }
                         defaultViewport = sharedPage.viewportSize();
-                        await sharedPage.goto('about:blank', { waitUntil: 'commit' }).catch(() => {});
+                        await sharedPage.evaluate(() => window.stop()).catch(() => {});
                     } else {
                         try {
                             await sharedContext.clearCookies();
@@ -79,7 +79,7 @@ Module._load = function (request, parent) {
                             await sharedPage.unrouteAll({ behavior: 'ignoreErrors' }).catch(() => {});
                             if (defaultViewport) await sharedPage.setViewportSize(defaultViewport);
                             await sharedPage.evaluate(() => { try { localStorage.clear(); } catch {} try { sessionStorage.clear(); } catch {} }).catch(() => {});
-                            await sharedPage.goto('about:blank', { waitUntil: 'commit' });
+                            await sharedPage.evaluate(() => window.stop()).catch(() => {});
                         } catch {}
                     }
                     sharedContext.newPage = async () => sharedPage;

--- a/packages/core/static/cdpPreload.cjs
+++ b/packages/core/static/cdpPreload.cjs
@@ -2,42 +2,107 @@
 /**
  * Preload script injected via NODE_OPTIONS --require.
  *
- * Patches chromium.connect() to use connectOverCDP() when the wsEndpoint
- * is a CDP URL (contains /devtools/browser/). This allows the test runner
- * to reuse the existing browser process without version mismatch errors.
+ * Patches chromium.launch() to use connectOverCDP() when PW_REUSE_CDP is set.
+ * This allows the test runner to reuse BrowserManager's Chrome instance
+ * with shared context/page for fast test execution.
  *
- * Safe no-op when connect() is called with a normal Playwright wsEndpoint.
+ * Also patches chromium.connect() for CDP URLs (fallback path).
  */
 Object.defineProperty(exports, "__esModule", { value: true });
 const Module = require("module");
 const origLoad = Module._load;
 let patched = false;
+let sharedContext = null;
+let sharedPage = null;
+let defaultViewport = null;
 Module._load = function (request, parent) {
     const mod = origLoad.apply(this, arguments);
-    // Intercept playwright-core or @playwright/test to patch chromium.connect
-    if (!patched && (request === 'playwright-core' || request === '@playwright/test') && mod?.chromium?.connect && !mod.chromium.__pwReplPatched) {
+    if (!patched && (request === 'playwright-core' || request === '@playwright/test') && mod?.chromium?.launch && !mod.chromium.__pwReplPatched) {
         patched = true;
         Module._load = origLoad; // remove hook immediately
+        mod.chromium.__pwReplPatched = true;
+        // ─── Patch chromium.launch when PW_REUSE_CDP is set ───────────────
+        const cdpEndpoint = process.env.PW_REUSE_CDP;
+        if (cdpEndpoint) {
+            const origLaunch = mod.chromium.launch.bind(mod.chromium);
+            mod.chromium.launch = async function () {
+                let browser;
+                try {
+                    browser = await mod.chromium.connectOverCDP(cdpEndpoint);
+                } catch {
+                    return origLaunch.apply(this, arguments);
+                }
+                const origNewContext = browser.newContext.bind(browser);
+                browser.newContext = async function (contextOptions) {
+                    if (!sharedContext) {
+                        const contexts = browser.contexts();
+                        if (contexts.length > 0) {
+                            sharedContext = contexts[0];
+                            sharedPage = sharedContext.pages()[0] || await sharedContext.newPage();
+                        } else {
+                            sharedContext = await origNewContext(contextOptions);
+                            sharedPage = sharedContext.pages()[0] || await sharedContext.newPage();
+                        }
+                        defaultViewport = sharedPage.viewportSize();
+                    } else {
+                        try {
+                            await sharedContext.clearCookies();
+                            await sharedContext.clearPermissions().catch(() => {});
+                            await sharedContext.unrouteAll({ behavior: 'ignoreErrors' }).catch(() => {});
+                            await sharedPage.unrouteAll({ behavior: 'ignoreErrors' }).catch(() => {});
+                            if (defaultViewport) await sharedPage.setViewportSize(defaultViewport);
+                            await sharedPage.evaluate(() => { try { localStorage.clear(); } catch {} try { sessionStorage.clear(); } catch {} }).catch(() => {});
+                            await sharedPage.goto('about:blank', { waitUntil: 'commit' });
+                        } catch {}
+                    }
+                    sharedContext.newPage = async () => sharedPage;
+                    sharedContext.close = async () => {};
+                    return sharedContext;
+                };
+                browser._newContextForReuse = async function () {
+                    if (!sharedContext) {
+                        const contexts = browser.contexts();
+                        if (contexts.length > 0) {
+                            sharedContext = contexts[0];
+                            sharedPage = sharedContext.pages()[0] || await sharedContext.newPage();
+                        } else {
+                            sharedContext = await origNewContext({});
+                            sharedPage = await sharedContext.newPage();
+                        }
+                        defaultViewport = sharedPage.viewportSize();
+                        await sharedPage.goto('about:blank', { waitUntil: 'commit' }).catch(() => {});
+                    } else {
+                        try {
+                            await sharedContext.clearCookies();
+                            await sharedContext.clearPermissions().catch(() => {});
+                            await sharedContext.unrouteAll({ behavior: 'ignoreErrors' }).catch(() => {});
+                            await sharedPage.unrouteAll({ behavior: 'ignoreErrors' }).catch(() => {});
+                            if (defaultViewport) await sharedPage.setViewportSize(defaultViewport);
+                            await sharedPage.evaluate(() => { try { localStorage.clear(); } catch {} try { sessionStorage.clear(); } catch {} }).catch(() => {});
+                            await sharedPage.goto('about:blank', { waitUntil: 'commit' });
+                        } catch {}
+                    }
+                    sharedContext.newPage = async () => sharedPage;
+                    sharedContext.close = async () => {};
+                    return sharedContext;
+                };
+                browser._disconnectFromReusedContext = async function () {};
+                browser.close = async () => {};
+                return browser;
+            };
+        }
+        // ─── Patch chromium.connect for CDP URLs ──────────────────────────
         const origConnect = mod.chromium.connect.bind(mod.chromium);
         mod.chromium.connect = async function (optionsOrWsEndpoint) {
             const wsEndpoint = typeof optionsOrWsEndpoint === 'string'
                 ? optionsOrWsEndpoint
                 : optionsOrWsEndpoint?.wsEndpoint;
-            // Only intercept CDP URLs (from --remote-debugging-port)
             if (!wsEndpoint || !wsEndpoint.includes('/devtools/browser/'))
                 return origConnect(optionsOrWsEndpoint);
             const browser = await mod.chromium.connectOverCDP(wsEndpoint);
-            // Reuse the persistent context so tests run in the same window
-            browser._newContextForReuse = async function () {
-                const contexts = browser.contexts();
-                return contexts[0] || await browser.newContext();
-            };
-            browser._disconnectFromReusedContext = async function () { };
-            // Don't let the test runner kill our shared browser
-            browser.close = async () => { };
+            browser.close = async () => {};
             return browser;
         };
-        mod.chromium.__pwReplPatched = true;
     }
     return mod;
 };

--- a/packages/vscode/src/browser.ts
+++ b/packages/vscode/src/browser.ts
@@ -1,6 +1,7 @@
 import type * as vscode from 'vscode';
 import { createRequire } from 'node:module';
 import { createServer, type IncomingMessage, type ServerResponse, type Server } from 'node:http';
+import { spawn, execSync, type ChildProcess } from 'node:child_process';
 import path from 'node:path';
 import { resolveCommand, UPDATE_COMMANDS } from '@playwright-repl/core';
 import { recorderInit } from './relay-recorder.js';
@@ -70,6 +71,8 @@ function formatResult(value: unknown): CommandResult {
 export class BrowserManager implements IBrowserManager {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   private _browserServer: any = undefined;
+  private _chromeProcess: ChildProcess | undefined = undefined;
+  private _requireFn: NodeRequire | undefined = undefined;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   private _browser: any = undefined;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -102,26 +105,55 @@ export class BrowserManager implements IBrowserManager {
       ? createRequire(path.join(opts.workspaceFolder, 'package.json'))
       : _extRequire;
 
-    // 1. Load Playwright
-    const pw = _require('@playwright/test');
-    this._expect = pw.expect;
     const headless = opts.headless ?? false;
     this._log.appendLine(`Launching Chromium (${headless ? 'headless' : 'headed'}, relay mode)...`);
 
-    // 2. Launch browser directly — CDP pipe, no server proxy hop.
-    //    This gives the fastest possible connection: Node.js → CDP pipe → Chrome.
-    //    (launchServer + connect adds an extra WebSocket proxy layer)
-    this._browser = await pw.chromium.launch({
-      headless,
-      args: [
-        '--no-first-run',
-        '--no-default-browser-check',
-        '--disable-background-timer-throttling',
-      ],
+    // 1. Get Chrome path without loading @playwright/test in extension host
+    //    (loading it here triggers "Requiring @playwright/test second time" errors)
+    const execPath = execSync(
+      'node -p "require(\'@playwright/test\').chromium.executablePath()"',
+      { cwd: opts.workspaceFolder, encoding: 'utf8' }
+    ).trim();
+
+    // 2. Spawn Chrome with --remote-debugging-port=0, connect via CDP.
+    //    Exposes CDP URL for test workers (via PW_REUSE_CDP env var).
+    const chromeArgs = [
+      '--remote-debugging-port=0',
+      '--no-first-run',
+      '--no-default-browser-check',
+      '--disable-background-timer-throttling',
+      '--disable-extensions',
+      '--disable-default-apps',
+      '--disable-popup-blocking',
+      '--disable-translate',
+      '--disable-sync',
+      '--password-store=basic',
+      '--use-mock-keychain',
+      ...(headless ? ['--headless=new'] : []),
+      'about:blank',
+    ];
+    this._chromeProcess = spawn(execPath, chromeArgs, { stdio: ['pipe', 'pipe', 'pipe'] });
+    this._cdpUrl = await new Promise<string>((resolve, reject) => {
+      const onData = (data: Buffer) => {
+        const match = data.toString().match(/DevTools listening on (ws:\/\/\S+)/);
+        if (match) {
+          this._chromeProcess!.stderr!.off('data', onData);
+          resolve(match[1]);
+        }
+      };
+      this._chromeProcess!.stderr!.on('data', onData);
+      this._chromeProcess!.on('error', reject);
+      this._chromeProcess!.on('exit', () => reject(new Error('Chrome exited before ready')));
     });
-    this._context = await this._browser.newContext();
-    this._page = await this._context.newPage();
-    this._log.appendLine(`Chromium launched (relay mode, direct CDP pipe).`);
+
+    // Connect via playwright-core (doesn't have the "second time" guard that @playwright/test has)
+    const pwCore = _require('playwright-core');
+    this._browser = await pwCore.chromium.connectOverCDP(this._cdpUrl);
+    this._context = this._browser.contexts()[0] || await this._browser.newContext();
+    this._page = this._context.pages()[0] || await this._context.newPage();
+    this._log.appendLine(`Chromium launched (relay mode, CDP: ${this._cdpUrl}).`);
+    // Load expect lazily (avoid loading @playwright/test in extension host)
+    this._requireFn = _require;
 
     this._browser.on('disconnected', () => {
       this._log.appendLine('Browser disconnected.');
@@ -135,11 +167,6 @@ export class BrowserManager implements IBrowserManager {
     this._page.on('close', () => {
       this._log.appendLine('Page closed.');
       this._page = undefined;
-      // If no more pages, stop the browser
-      if (this._context && this._context.pages().length === 0) {
-        this._log.appendLine('Last page closed — stopping browser.');
-        this.stop().catch(() => {});
-      }
     });
 
     // 3. Set up event listeners for recording/pick (relay-style)
@@ -171,6 +198,10 @@ export class BrowserManager implements IBrowserManager {
     if (this._browserServer) {
       await this._browserServer.close().catch(() => {});
       this._browserServer = undefined;
+    }
+    if (this._chromeProcess) {
+      this._chromeProcess.kill();
+      this._chromeProcess = undefined;
     }
     this._cdpUrl = undefined;
     this._running = false;
@@ -291,6 +322,9 @@ export class BrowserManager implements IBrowserManager {
 
   private async _execExpr(jsExpr: string): Promise<CommandResult> {
     try {
+      if (!this._expect && this._requireFn) {
+        try { this._expect = this._requireFn('@playwright/test').expect; } catch {}
+      }
       const fn = new AsyncFunction('page', 'context', 'expect', jsExpr);
       const result = await fn(this._page, this._context, this._expect);
       return formatResult(result);

--- a/packages/vscode/src/browser.ts
+++ b/packages/vscode/src/browser.ts
@@ -1,7 +1,7 @@
 import type * as vscode from 'vscode';
 import { createRequire } from 'node:module';
 import { createServer, type IncomingMessage, type ServerResponse, type Server } from 'node:http';
-import { spawn, execSync, type ChildProcess } from 'node:child_process';
+import net from 'node:net';
 import path from 'node:path';
 import { resolveCommand, UPDATE_COMMANDS } from '@playwright-repl/core';
 import { recorderInit } from './relay-recorder.js';
@@ -71,7 +71,6 @@ function formatResult(value: unknown): CommandResult {
 export class BrowserManager implements IBrowserManager {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   private _browserServer: any = undefined;
-  private _chromeProcess: ChildProcess | undefined = undefined;
   private _requireFn: NodeRequire | undefined = undefined;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   private _browser: any = undefined;
@@ -108,50 +107,38 @@ export class BrowserManager implements IBrowserManager {
     const headless = opts.headless ?? false;
     this._log.appendLine(`Launching Chromium (${headless ? 'headless' : 'headed'}, relay mode)...`);
 
-    // 1. Get Chrome path without loading @playwright/test in extension host
-    //    (loading it here triggers "Requiring @playwright/test second time" errors)
-    const execPath = execSync(
-      'node -p "require(\'@playwright/test\').chromium.executablePath()"',
-      { cwd: opts.workspaceFolder, encoding: 'utf8' }
-    ).trim();
-
-    // 2. Spawn Chrome with --remote-debugging-port=0, connect via CDP.
-    //    Exposes CDP URL for test workers (via PW_REUSE_CDP env var).
-    const chromeArgs = [
-      '--remote-debugging-port=0',
-      '--no-first-run',
-      '--no-default-browser-check',
-      '--disable-background-timer-throttling',
-      '--disable-extensions',
-      '--disable-default-apps',
-      '--disable-popup-blocking',
-      '--disable-translate',
-      '--disable-sync',
-      '--password-store=basic',
-      '--use-mock-keychain',
-      ...(headless ? ['--headless=new'] : []),
-      'about:blank',
-    ];
-    this._chromeProcess = spawn(execPath, chromeArgs, { stdio: ['pipe', 'pipe', 'pipe'] });
-    this._cdpUrl = await new Promise<string>((resolve, reject) => {
-      const onData = (data: Buffer) => {
-        const match = data.toString().match(/DevTools listening on (ws:\/\/\S+)/);
-        if (match) {
-          this._chromeProcess!.stderr!.off('data', onData);
-          resolve(match[1]);
-        }
-      };
-      this._chromeProcess!.stderr!.on('data', onData);
-      this._chromeProcess!.on('error', reject);
-      this._chromeProcess!.on('exit', () => reject(new Error('Chrome exited before ready')));
+    // 1. Reserve a port, then launch via playwright-core (all default Chrome args).
+    //    Chrome listens on both pipe (Playwright) and port (test workers via CDP).
+    const debuggingPort = await new Promise<number>((resolve, reject) => {
+      const srv = net.createServer();
+      srv.listen(0, () => {
+        const port = (srv.address() as net.AddressInfo).port;
+        srv.close(() => resolve(port));
+      });
+      srv.on('error', reject);
     });
 
-    // Connect via playwright-core (doesn't have the "second time" guard that @playwright/test has)
     const pwCore = _require('playwright-core');
-    this._browser = await pwCore.chromium.connectOverCDP(this._cdpUrl);
-    this._context = this._browser.contexts()[0] || await this._browser.newContext();
-    this._page = this._context.pages()[0] || await this._context.newPage();
-    this._log.appendLine(`Chromium launched (relay mode, CDP: ${this._cdpUrl}).`);
+    this._browser = await pwCore.chromium.launch({
+      headless,
+      args: [
+        '--no-first-run',
+        '--no-default-browser-check',
+        '--disable-background-timer-throttling',
+        `--remote-debugging-port=${debuggingPort}`,
+      ],
+    });
+
+    // 2. Fetch CDP URL from the known debugging port
+    try {
+      const resp = await fetch(`http://127.0.0.1:${debuggingPort}/json/version`);
+      const { webSocketDebuggerUrl } = await resp.json() as { webSocketDebuggerUrl: string };
+      this._cdpUrl = webSocketDebuggerUrl;
+    } catch {}
+
+    this._context = await this._browser.newContext();
+    this._page = await this._context.newPage();
+    this._log.appendLine(`Chromium launched (relay mode, CDP: ${this._cdpUrl || 'n/a'}).`);
     // Load expect lazily (avoid loading @playwright/test in extension host)
     this._requireFn = _require;
 
@@ -198,10 +185,6 @@ export class BrowserManager implements IBrowserManager {
     if (this._browserServer) {
       await this._browserServer.close().catch(() => {});
       this._browserServer = undefined;
-    }
-    if (this._chromeProcess) {
-      this._chromeProcess.kill();
-      this._chromeProcess = undefined;
     }
     this._cdpUrl = undefined;
     this._running = false;

--- a/packages/vscode/src/browserController.ts
+++ b/packages/vscode/src/browserController.ts
@@ -71,10 +71,15 @@ export class BrowserController {
   }
 
   /** Returns connection info for test runner, or undefined if not in headed mode. */
-  async onWillRunTests(_workspaceFolder?: string): Promise<{ connectWsEndpoint: string; resetTestServer: boolean; reusingBrowser: boolean } | undefined> {
-    // Tests use ReusedBrowser path (Playwright's backend server) for proper
-    // context reuse and headed mode support. BrowserManager handles REPL/recording/picker.
-    return undefined;
+  async onWillRunTests(workspaceFolder?: string): Promise<{ connectWsEndpoint?: string; resetTestServer: boolean; reusingBrowser: boolean } | undefined> {
+    await this.ensureLaunched(workspaceFolder);
+    const cdpUrl = this._browserManager?.cdpUrl;
+    if (!cdpUrl)
+      return undefined;
+    // Set PW_REUSE_CDP so cdpPreload patches chromium.launch() in test workers
+    const needsReset = process.env.PW_REUSE_CDP !== cdpUrl;
+    process.env.PW_REUSE_CDP = cdpUrl;
+    return { resetTestServer: needsReset, reusingBrowser: true };
   }
 
   onDidRunTests() {

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -177,8 +177,9 @@ export class Extension implements RunHooks {
     }
 
     // Headless / debug / fallback: original Playwright extension behavior
-    const needsReset = !!this._browserController.lastCdpUrl;
+    const needsReset = !!this._browserController.lastCdpUrl || !!process.env.PW_REUSE_CDP;
     this._browserController.clearCdpUrl();
+    delete process.env.PW_REUSE_CDP;
     await this._reusedBrowser.onWillRunTests(config, debug);
     return { connectWsEndpoint: this._reusedBrowser.browserServerWSEndpoint(), resetTestServer: needsReset };
   }

--- a/packages/vscode/src/playwrightTestServer.ts
+++ b/packages/vscode/src/playwrightTestServer.ts
@@ -35,7 +35,7 @@ try {
 } catch {}
 
 function preloadEnv(): Record<string, string | undefined> {
-  if (!_cdpPreloadPath)
+  if (!_cdpPreloadPath || !process.env.PW_REUSE_CDP)
     return {};
   const existing = process.env.NODE_OPTIONS || '';
   return {

--- a/packages/vscode/tests/unit/browser-controller.test.ts
+++ b/packages/vscode/tests/unit/browser-controller.test.ts
@@ -148,9 +148,22 @@ describe('BrowserController', () => {
     expect(vscode.window.showWarningMessage).toHaveBeenCalledWith('Could not launch browser.');
   });
 
-  it('onWillRunTests should return undefined — tests use ReusedBrowser', async () => {
-    mockBm.cdpUrl = 'ws://localhost:1234';
-    mockBm.httpPort = 5678;
+  it('onWillRunTests should set PW_REUSE_CDP and return reusingBrowser', async () => {
+    mockBm.cdpUrl = 'ws://127.0.0.1:9222/devtools/browser/abc';
+    mockBm.isRunning.mockReturnValue(true);
+    await controller.ensureLaunched();
+
+    const result = await controller.onWillRunTests('/workspace');
+    expect(result).toEqual({
+      resetTestServer: true,
+      reusingBrowser: true,
+    });
+    expect(process.env.PW_REUSE_CDP).toBe('ws://127.0.0.1:9222/devtools/browser/abc');
+    delete process.env.PW_REUSE_CDP;
+  });
+
+  it('onWillRunTests should return undefined when no cdpUrl', async () => {
+    mockBm.cdpUrl = undefined;
     mockBm.isRunning.mockReturnValue(true);
     await controller.ensureLaunched();
 


### PR DESCRIPTION
## Summary

- Spawn Chrome via `playwright-core`'s `chromium.launch()` with `--remote-debugging-port` so test workers reuse the same browser via CDP
- `cdpPreload` patches `chromium.launch()` and `_newContextForReuse()` in test workers when `PW_REUSE_CDP` env var is set
- Export `./static/*` from `@playwright-repl/core` so cdpPreload resolves correctly
- Clean up `PW_REUSE_CDP` when falling back to headless mode
- Replace `about:blank` navigation with `window.stop()` to eliminate flickering

## Benchmarks (192 tests)

| Path | Time |
|---|---|
| **VS Code shared (this PR, 1 worker)** | **23.9s** |
| `npx pw test --headed` (4 workers) | 24.2s |
| VS Code bridge (old, 1 worker) | 27.3s |
| VS Code standard relay (1 worker) | 33.7s |
| `npx pw test` headless (4 workers) | 54.1s |
| `npx pw test --headed` (1 worker) | 56.7s |

## Test plan

- [x] 189/192 pass (3 skipped, same as baseline)
- [x] Frameset click test passes
- [x] Headless mode unaffected (no PW_REUSE_CDP leak)
- [x] Single browser instance shared between REPL and test runner
- [x] No visible flickering between tests
- [x] Unit tests pass (106/106)

Closes #873

🤖 Generated with [Claude Code](https://claude.com/claude-code)