### PR TITLE
fix: add row to --in container role probing for table structures

### DIFF
--- a/packages/core/src/page-scripts.ts
+++ b/packages/core/src/page-scripts.ts
@@ -41,7 +41,7 @@ export function buildRunCodeScoped(fn, inText, targetText, ...args) {
   const tgtSer = JSON.stringify(targetText);
   return { _: ['run-code', `async (page) => {
   let __scope = page;
-  for (const __r of ['group','article','listitem','region','dialog','form']) {
+  for (const __r of ['row','group','article','listitem','region','dialog','form']) {
     const __c = page.getByRole(__r).filter({ has: page.getByText(${inSer}, { exact: true }) });
     const __n = await __c.count();
     if (__n > 0) { __scope = __c.first(); break; }
@@ -51,7 +51,7 @@ export function buildRunCodeScoped(fn, inText, targetText, ...args) {
       let __anchor = page.getByText(${inSer}, { exact: true });
       if (await __anchor.count() === 0) __anchor = page.getByText(${inSer});
       const __sel = await __anchor.first().evaluate((el) => {
-        const S = new Set(['FIELDSET','SECTION','ARTICLE','DETAILS','DIALOG','FORM']);
+        const S = new Set(['FIELDSET','SECTION','ARTICLE','DETAILS','DIALOG','FORM','TR']);
         let a = el.parentElement;
         while (a && a !== document.body) {
           if (S.has(a.tagName) || a.hasAttribute('role')) {
@@ -342,7 +342,7 @@ export async function actionByRole(page, role, name, action, nth, inRole, inText
     const cr = ({ list: 'listitem' })[inRole] || inRole;
     loc = page.getByRole(cr).filter({ hasText: inText }).getByRole(role, roleOpts);
   } else if (inText !== undefined) {
-    for (const r of ['region', 'group', 'article', 'listitem', 'dialog', 'form']) {
+    for (const r of ['row', 'region', 'group', 'article', 'listitem', 'dialog', 'form']) {
       const scoped = page.getByRole(r).filter({ hasText: inText }).getByRole(role, roleOpts);
       if (await scoped.count() > 0) { loc = scoped; break; }
     }
@@ -359,7 +359,7 @@ export async function fillByRole(page, role, name, value, nth, inRole, inText) {
     const cr = ({ list: 'listitem' })[inRole] || inRole;
     loc = page.getByRole(cr).filter({ hasText: inText }).getByRole(role, roleOpts);
   } else if (inText !== undefined) {
-    for (const r of ['region', 'group', 'article', 'listitem', 'dialog', 'form']) {
+    for (const r of ['row', 'region', 'group', 'article', 'listitem', 'dialog', 'form']) {
       const scoped = page.getByRole(r).filter({ hasText: inText }).getByRole(role, roleOpts);
       if (await scoped.count() > 0) { loc = scoped; break; }
     }
@@ -376,7 +376,7 @@ export async function selectByRole(page, role, name, value, nth, inRole, inText)
     const cr = ({ list: 'listitem' })[inRole] || inRole;
     loc = page.getByRole(cr).filter({ hasText: inText }).getByRole(role, roleOpts);
   } else if (inText !== undefined) {
-    for (const r of ['region', 'group', 'article', 'listitem', 'dialog', 'form']) {
+    for (const r of ['row', 'region', 'group', 'article', 'listitem', 'dialog', 'form']) {
       const scoped = page.getByRole(r).filter({ hasText: inText }).getByRole(role, roleOpts);
       if (await scoped.count() > 0) { loc = scoped; break; }
     }
@@ -393,7 +393,7 @@ export async function pressKeyByRole(page, role, name, key, nth, inRole, inText)
     const cr = ({ list: 'listitem' })[inRole] || inRole;
     loc = page.getByRole(cr).filter({ hasText: inText }).getByRole(role, roleOpts);
   } else if (inText !== undefined) {
-    for (const r of ['region', 'group', 'article', 'listitem', 'dialog', 'form']) {
+    for (const r of ['row', 'region', 'group', 'article', 'listitem', 'dialog', 'form']) {
       const scoped = page.getByRole(r).filter({ hasText: inText }).getByRole(role, roleOpts);
       if (await scoped.count() > 0) { loc = scoped; break; }
     }

--- a/packages/core/test/page-scripts.test.ts
+++ b/packages/core/test/page-scripts.test.ts
@@ -150,6 +150,16 @@ describe('buildRunCodeScoped', () => {
     // Should scope to the narrow E-Scooter fieldset, NOT the broad form
     expect(scopedTo).toEqual(['escooter-fieldset']);
   });
+
+  it('includes row in container roles for table structures (#863)', () => {
+    const dummy = async function dummyAction(scope) {};
+    const result = buildRunCodeScoped(dummy, 'Some text', 'target', 'radio', 'ja', 'check');
+    const code = result._[1];
+    // row must be in the roles list so table rows can be scoped
+    expect(code).toContain("'row'");
+    // TR must be in the fallback tag set
+    expect(code).toContain("'TR'");
+  });
 });
 
 // ─── Verify functions ───────────────────────────────────────────────────────
@@ -454,15 +464,24 @@ describe('actionByRole', () => {
     expect(page.getByRole).toHaveBeenCalledWith('listitem');
   });
 
-  it('ignores --in when inRole is undefined but inText is provided', async () => {
-    // Without the fix, actionByRole silently ignores inText when inRole is undefined.
-    // The fix routes through buildRunCodeScoped in parser.ts instead, so actionByRole
-    // is never called with (undefined, inText) — but verify the guard works anyway.
-    const page = mockPage(1);
+  it('scopes via row when inText provided without inRole (#863)', async () => {
+    const innerLoc = mockLocator(1);
+    const filterLoc = { ...mockLocator(1), getByRole: vi.fn().mockReturnValue(innerLoc) };
+    const rowLoc = mockLocator(1);
+    rowLoc.filter = vi.fn().mockReturnValue(filterLoc);
+    const radioLoc = mockLocator(1);
+    const page = {
+      getByRole: vi.fn().mockImplementation((role) => {
+        if (role === 'row') return rowLoc;
+        if (role === 'radio') return radioLoc;
+        return mockLocator(0);
+      }),
+    };
     await actionByRole(page, 'radio', 'ja', 'check', undefined, undefined, 'Very long text');
-    // Should NOT have called getByText — scoping is handled externally
-    expect(page.getByRole).toHaveBeenCalledWith('radio', { name: 'ja', exact: true });
-    expect(page._loc.check).toHaveBeenCalled();
+    expect(page.getByRole).toHaveBeenCalledWith('row');
+    expect(rowLoc.filter).toHaveBeenCalledWith({ hasText: 'Very long text' });
+    expect(filterLoc.getByRole).toHaveBeenCalledWith('radio', { name: 'ja', exact: true });
+    expect(innerLoc.check).toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
## Summary
- Add `'row'` to the container role probing lists in `buildRunCodeScoped` and all `*ByRole` functions, so `--in` scoping works for table-based layouts (`<tr>` elements)
- Add `'TR'` to the DOM fallback tag set in `buildRunCodeScoped`
- Followup to #867 — the original fix added `buildRunCodeScoped` routing but the role list didn't include `row`, so table structures silently fell through to full-page search

**Root cause**: `check radio "nein" --in "Very long text"` routes through `buildRunCodeScoped`, which probes `['group','article','listitem','region','dialog','form']` for a container matching the `--in` text. For table-based forms, the container is a `<tr>` (ARIA role `row`), which wasn't in the list. Scoping silently failed, `__scope` stayed as `page`, and `actionByRole` found both radios → strict mode violation.

**Why not caught earlier**: The existing test used `mockPage(1)` which returns the same mock for all roles with `count=1`, so it passed regardless of which roles were probed. New tests use `mockImplementation` with role-specific mocks — only `row` returns a match.

Related to #863

## Test plan
- [x] `buildRunCodeScoped` test verifies `'row'` and `'TR'` are in the generated code
- [x] `actionByRole` test verifies `row` is tried first and scoping chains correctly
- [x] All 130 core tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)