### PR TITLE
feat: MCP recording support (#829)

### DIFF
--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -7,6 +7,7 @@ import { COMMANDS, CATEGORIES } from '@playwright-repl/core';
 import pkg from '../package.json' with { type: 'json' };
 import { createStandaloneRunner } from './standalone.js';
 import { createRelayRunner } from './relay.js';
+import { withRecording } from './recording.js';
 import { logStartup, logEvent, logToolCall, logToolResult, logError, logHttp, LOG_FILE } from './logger.js';
 import type { Runner } from './types.js';
 // ─── Process exit handlers — log why the process dies ───────────────────────
@@ -48,7 +49,8 @@ if (relay) {
     runnerModule = createStandaloneRunner(headed);
 }
 
-const { runner, descriptions } = runnerModule;
+const { runner: innerRunner, descriptions } = runnerModule;
+const runner = withRecording(innerRunner);
 
 const mode = relay ? 'relay' : 'standalone';
 logStartup(mode, `log → ${LOG_FILE}`);

--- a/packages/mcp/src/recording.ts
+++ b/packages/mcp/src/recording.ts
@@ -1,0 +1,101 @@
+/**
+ * Recording wrapper for MCP runners.
+ *
+ * Wraps a Runner to intercept start-recording/stop-recording/pause-recording/
+ * discard-recording commands and record all other commands with ref-to-locator
+ * resolution using snapshot data from auto-snapshot results.
+ */
+
+import { SessionRecorder } from '@playwright-repl/core';
+import type { EngineResult } from '@playwright-repl/core';
+import type { Runner } from './types.js';
+
+const RECORDING_COMMANDS = new Set([
+  'start-recording', 'stop-recording', 'pause-recording', 'discard-recording',
+]);
+
+/** Extract the snapshot YAML from an auto-snapshot result (### Snapshot\n...) */
+function extractSnapshot(text: string): string | null {
+  const marker = '### Snapshot\n';
+  const idx = text.indexOf(marker);
+  if (idx === -1) return null;
+  return text.slice(idx + marker.length);
+}
+
+/**
+ * Wrap a runner with recording support.
+ * Returns a new runner that handles recording commands locally and
+ * records + resolves refs for all other commands.
+ */
+export function withRecording(inner: Runner): Runner {
+  const recorder = new SessionRecorder();
+
+  return {
+    async runCommand(command: string): Promise<EngineResult> {
+      const trimmed = command.trim();
+      const cmdName = trimmed.split(/\s+/)[0].toLowerCase();
+
+      // ── Recording commands — handled locally ──────────────────
+      if (RECORDING_COMMANDS.has(cmdName)) {
+        if (cmdName === 'start-recording') {
+          if (recorder.recording) {
+            return { text: 'Already recording. Use stop-recording or discard-recording first.', isError: true };
+          }
+          const filename = trimmed.split(/\s+/)[1] || undefined;
+          const file = recorder.start(filename);
+          return { text: `Recording started → ${file}`, isError: false };
+        }
+
+        if (cmdName === 'stop-recording') {
+          if (!recorder.recording) {
+            return { text: 'Not recording. Use start-recording first.', isError: true };
+          }
+          const { filename, count } = recorder.save();
+          return { text: `Recording saved: ${filename} (${count} commands)`, isError: false };
+        }
+
+        if (cmdName === 'pause-recording') {
+          if (!recorder.recording) {
+            return { text: 'Not recording.', isError: true };
+          }
+          const paused = recorder.pause();
+          return { text: paused ? 'Recording paused' : 'Recording resumed', isError: false };
+        }
+
+        if (cmdName === 'discard-recording') {
+          if (!recorder.recording) {
+            return { text: 'Not recording.', isError: true };
+          }
+          recorder.discard();
+          return { text: 'Recording discarded', isError: false };
+        }
+      }
+
+      // ── Regular command — execute, then record ────────────────
+      const result = await inner.runCommand(command);
+
+      if (recorder.recording && !result.isError) {
+        // Feed snapshot to recorder for ref-to-locator resolution
+        if (result.text) {
+          // Explicit snapshot command
+          if (cmdName === 'snapshot' || cmdName === 'snap' || cmdName === 's') {
+            recorder.setSnapshot(result.text);
+          }
+          // Auto-snapshot from update commands (### Snapshot\n...)
+          const snap = extractSnapshot(result.text);
+          if (snap) {
+            recorder.setSnapshot(snap);
+          }
+        }
+
+        recorder.record(trimmed);
+      }
+
+      return result;
+    },
+
+    async runScript(script: string, language: 'pw' | 'javascript'): Promise<EngineResult> {
+      return inner.runScript(script, language);
+    },
+  };
+}

--- a/packages/mcp/src/standalone.ts
+++ b/packages/mcp/src/standalone.ts
@@ -54,6 +54,9 @@ Update commands (click, fill, goto, press, hover, select, check, uncheck, etc.) 
 
 Use snapshot only for initial exploration or after read-only commands. Use screenshot to visually verify the current state.
 
+Recording: start-recording [filename], stop-recording, pause-recording, discard-recording
+Records commands to a .pw file with stable text locators (refs like e5 are auto-converted to role+name locators). Run snapshot before actions so refs can be resolved.
+
 IMPORTANT: Before writing .pw commands, run 'help' to get the full list of available commands. Only use commands that appear in the help output. Do not invent commands.`,
 
     runScript: `Run a multi-line script. Supports both .pw keyword commands (language='pw') and JavaScript (language='javascript').

--- a/packages/mcp/test/recording.test.ts
+++ b/packages/mcp/test/recording.test.ts
@@ -1,0 +1,199 @@
+// @ts-nocheck
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { withRecording } from '../src/recording.js';
+import type { Runner } from '../src/types.js';
+
+const SAMPLE_SNAPSHOT = `\
+- document [ref=e1]:
+  - heading "Welcome" [level=2] [ref=e2]
+  - navigation "Main":
+    - link "Home" [ref=e3]
+    - link "About" [ref=e4]
+  - main:
+    - textbox "Email" [ref=e5]
+    - button "Sign in" [ref=e6]
+`;
+
+function createMockRunner(): Runner {
+  return {
+    async runCommand(command: string) {
+      const cmd = command.trim().split(/\s+/)[0].toLowerCase();
+      if (cmd === 'snapshot') {
+        return { text: SAMPLE_SNAPSHOT, isError: false };
+      }
+      if (cmd === 'click' || cmd === 'fill' || cmd === 'goto') {
+        // Simulate auto-snapshot appended to update commands
+        return {
+          text: `### Result\nDone\n### Snapshot\n${SAMPLE_SNAPSHOT}`,
+          isError: false,
+        };
+      }
+      return { text: 'Done', isError: false };
+    },
+    async runScript(script: string, language: 'pw' | 'javascript') {
+      return { text: 'Script done', isError: false };
+    },
+  };
+}
+
+describe('withRecording', () => {
+  let tmpDir: string;
+  let runner: Runner;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pw-rec-test-'));
+    runner = withRecording(createMockRunner());
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  // ── Recording lifecycle ───────────────────────────────────────
+
+  it('start-recording returns success', async () => {
+    const result = await runner.runCommand(`start-recording ${path.join(tmpDir, 'test.pw')}`);
+    expect(result.isError).toBe(false);
+    expect(result.text).toContain('Recording started');
+    expect(result.text).toContain('test.pw');
+  });
+
+  it('stop-recording saves file', async () => {
+    const file = path.join(tmpDir, 'test.pw');
+    await runner.runCommand(`start-recording ${file}`);
+    await runner.runCommand('snapshot');
+    await runner.runCommand('click e6');
+    const result = await runner.runCommand('stop-recording');
+    expect(result.isError).toBe(false);
+    expect(result.text).toContain('Recording saved');
+    expect(result.text).toContain('2 commands');
+
+    const content = fs.readFileSync(file, 'utf-8');
+    expect(content).toContain('snapshot');
+    expect(content).toContain('click button "Sign in"');
+  });
+
+  it('pause-recording toggles pause', async () => {
+    await runner.runCommand(`start-recording ${path.join(tmpDir, 'test.pw')}`);
+    const r1 = await runner.runCommand('pause-recording');
+    expect(r1.text).toBe('Recording paused');
+    const r2 = await runner.runCommand('pause-recording');
+    expect(r2.text).toBe('Recording resumed');
+  });
+
+  it('discard-recording clears state', async () => {
+    const file = path.join(tmpDir, 'test.pw');
+    await runner.runCommand(`start-recording ${file}`);
+    await runner.runCommand('snapshot');
+    const result = await runner.runCommand('discard-recording');
+    expect(result.isError).toBe(false);
+    expect(result.text).toBe('Recording discarded');
+    expect(fs.existsSync(file)).toBe(false);
+  });
+
+  // ── Error cases ───────────────────────────────────────────────
+
+  it('stop-recording errors when not recording', async () => {
+    const result = await runner.runCommand('stop-recording');
+    expect(result.isError).toBe(true);
+    expect(result.text).toContain('Not recording');
+  });
+
+  it('start-recording errors when already recording', async () => {
+    await runner.runCommand(`start-recording ${path.join(tmpDir, 'a.pw')}`);
+    const result = await runner.runCommand(`start-recording ${path.join(tmpDir, 'b.pw')}`);
+    expect(result.isError).toBe(true);
+    expect(result.text).toContain('Already recording');
+  });
+
+  it('pause-recording errors when not recording', async () => {
+    const result = await runner.runCommand('pause-recording');
+    expect(result.isError).toBe(true);
+  });
+
+  it('discard-recording errors when not recording', async () => {
+    const result = await runner.runCommand('discard-recording');
+    expect(result.isError).toBe(true);
+  });
+
+  // ── Ref resolution from auto-snapshot ─────────────────────────
+
+  it('resolves refs using auto-snapshot from update commands', async () => {
+    const file = path.join(tmpDir, 'test.pw');
+    await runner.runCommand(`start-recording ${file}`);
+    // First command is an update command — auto-snapshot is appended
+    await runner.runCommand('goto https://example.com');
+    // Now refs from the auto-snapshot should be available
+    await runner.runCommand('click e6');
+    await runner.runCommand('fill e5 hello');
+    await runner.runCommand('stop-recording');
+
+    const content = fs.readFileSync(file, 'utf-8');
+    expect(content).toContain('goto https://example.com');
+    expect(content).toContain('click button "Sign in"');
+    expect(content).toContain('fill textbox "Email" hello');
+  });
+
+  it('resolves refs using explicit snapshot', async () => {
+    const file = path.join(tmpDir, 'test.pw');
+    await runner.runCommand(`start-recording ${file}`);
+    await runner.runCommand('snapshot');
+    await runner.runCommand('click e6');
+    await runner.runCommand('stop-recording');
+
+    const content = fs.readFileSync(file, 'utf-8');
+    expect(content).toContain('click button "Sign in"');
+  });
+
+  // ── Recording commands are not recorded ───────────────────────
+
+  it('recording commands are not included in output', async () => {
+    const file = path.join(tmpDir, 'test.pw');
+    await runner.runCommand(`start-recording ${file}`);
+    await runner.runCommand('snapshot');
+    await runner.runCommand('pause-recording');
+    await runner.runCommand('pause-recording');
+    await runner.runCommand('click e6');
+    await runner.runCommand('stop-recording');
+
+    const content = fs.readFileSync(file, 'utf-8');
+    expect(content).not.toContain('start-recording');
+    expect(content).not.toContain('stop-recording');
+    expect(content).not.toContain('pause-recording');
+    expect(content).toContain('snapshot');
+    expect(content).toContain('click button "Sign in"');
+  });
+
+  // ── Failed commands are not recorded ──────────────────────────
+
+  it('does not record failed commands', async () => {
+    const mockRunner = createMockRunner();
+    const origRunCommand = mockRunner.runCommand;
+    mockRunner.runCommand = async (cmd) => {
+      if (cmd.includes('bad-command')) return { text: 'Unknown', isError: true };
+      return origRunCommand(cmd);
+    };
+    const r = withRecording(mockRunner);
+
+    const file = path.join(tmpDir, 'test.pw');
+    await r.runCommand(`start-recording ${file}`);
+    await r.runCommand('snapshot');
+    await r.runCommand('bad-command');
+    await r.runCommand('click e6');
+    await r.runCommand('stop-recording');
+
+    const content = fs.readFileSync(file, 'utf-8');
+    expect(content).not.toContain('bad-command');
+    expect(content).toContain('click button "Sign in"');
+  });
+
+  // ── runScript passes through ──────────────────────────────────
+
+  it('runScript delegates to inner runner', async () => {
+    const result = await runner.runScript('snapshot\nclick e5', 'pw');
+    expect(result.text).toBe('Script done');
+  });
+});


### PR DESCRIPTION
## Summary
- Add `withRecording()` wrapper in `packages/mcp/src/recording.ts` that intercepts `start-recording`/`stop-recording`/`pause-recording`/`discard-recording` commands
- Wrap both standalone and relay runners in `index.ts` so recording works in all MCP modes
- Extract snapshot YAML from auto-snapshot results (`### Snapshot\n...`) for ref-to-locator resolution — no extra `snapshot` call needed after update commands
- Update tool description to document recording commands

Phase 2 of #829 — agents can now record flows via MCP that produce `.pw` files with stable text locators.

## Test plan
- [x] 13 new tests in `packages/mcp/test/recording.test.ts`
- [x] All 41 MCP tests pass
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)