### PR TITLE
fix: restore offscreen document for video capture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## v0.27.1
+
+**2026-05-06**
+
+### Fixes
+
+- Restore offscreen document for video capture — broken since v0.26.1 when bridge removal also deleted the offscreen files. ([#899](https://github.com/stevez/playwright-repl/pull/899))
+- Remove dead bridge code from extension background (startup alarm, bridgePort listener, get-bridge-port, cdp-relay-connect handlers).
+
 ## v0.27.0
 
 **2026-05-06**

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "playwright-repl",
-  "version": "0.27.0",
+  "version": "0.27.1",
   "description": "Interactive REPL for Playwright — keyword commands, recording, and replay",
   "type": "module",
   "bin": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@playwright-repl/core",
   "description": "Shared parser, servers, and utilities for playwright-repl",
-  "version": "0.27.0",
+  "version": "0.27.1",
   "type": "module",
   "main": "./dist/index.js",
   "exports": {

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@playwright-repl/browser-extension",
-  "version": "0.27.0",
+  "version": "0.27.1",
   "description": "Dramaturg — Chrome extension with console, recorder, and element picker",
   "license": "MIT",
   "author": "Steve Zhang",

--- a/packages/extension/public/manifest.json
+++ b/packages/extension/public/manifest.json
@@ -14,7 +14,8 @@
     "scripting",
     "tabCapture",
     "webNavigation",
-    "downloads"
+    "downloads",
+    "offscreen"
   ],
   "host_permissions": [
     "<all_urls>"

--- a/packages/extension/public/manifest.json
+++ b/packages/extension/public/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Dramaturg",
-  "version": "0.27.0",
+  "version": "0.27.1",
   "description": "Playwright engineer's companion — console, editor, runner, debugger, and recorder in a Chrome side panel.",
   "permissions": [
     "activeTab",

--- a/packages/extension/src/background.ts
+++ b/packages/extension/src/background.ts
@@ -93,37 +93,6 @@ const patchedExpect: typeof expect = Object.assign(
 import { installFramework } from './test-framework';
 installFramework();
 
-// ─── Offscreen Document (CLI Bridge) ─────────────────────────────────────────
-
-async function ensureOffscreen() {
-  if (await chrome.offscreen.hasDocument()) return;
-  await chrome.offscreen.createDocument({
-    url: 'offscreen/offscreen.html',
-    reasons: [chrome.offscreen.Reason.BLOBS, chrome.offscreen.Reason.USER_MEDIA],
-    justification: 'Maintains WebSocket connection to CLI/MCP bridge server and handles video capture',
-  });
-}
-
-// Web Store installs: always create offscreen doc (auto-connect to bridge).
-// Development installs (--load-extension): only create if bridgePort was previously
-// configured, to avoid connecting to a real bridge during CLI/tests/VS Code.
-chrome.management.getSelf().then(async (info) => {
-  if (info.installType === 'normal') {
-    ensureOffscreen().catch(e => console.warn('[pw-repl] offscreen document creation failed:', e));
-  } else {
-    const { bridgePort } = await chrome.storage.local.get(['bridgePort']);
-    if (bridgePort) ensureOffscreen().catch(e => console.warn('[pw-repl] offscreen document creation failed:', e));
-  }
-});
-
-// Re-check offscreen doc periodically — Chrome may kill it after idle.
-chrome.alarms.create('ensure-offscreen', { periodInMinutes: 1 });
-chrome.alarms.onAlarm.addListener((alarm) => {
-  if (alarm.name === 'ensure-offscreen') {
-    ensureOffscreen().catch(() => {});
-  }
-});
-
 // ─── Settings + Action (sidepanel / popup) ───────────────────────────────────
 
 // Disable auto-open so action.onClicked fires (Chrome persists this across reloads)
@@ -135,12 +104,6 @@ loadSettings().then(s => cachedSettings = s).catch(e => console.warn('[pw-repl] 
 chrome.storage.onChanged.addListener((changes, area) => {
   if (area === 'local' && changes.openAs) {
     cachedSettings.openAs = changes.openAs.newValue;
-  }
-  if (area === 'local' && changes.bridgePort) {
-    // Ensure offscreen doc exists before telling it to reconnect (may not exist in development mode)
-    ensureOffscreen().then(() => {
-      chrome.runtime.sendMessage({ type: 'bridge-port-changed', port: changes.bridgePort.newValue }).catch(() => {});
-    }).catch(() => {});
   }
 });
 
@@ -345,6 +308,15 @@ chrome.tabs.onRemoved.addListener((tabId) => {
 
 // ─── Video Capture ──────────────────────────────────────────────────────────
 
+async function ensureOffscreen() {
+  if (await chrome.offscreen.hasDocument()) return;
+  await chrome.offscreen.createDocument({
+    url: 'offscreen/offscreen.html',
+    reasons: [chrome.offscreen.Reason.BLOBS, chrome.offscreen.Reason.USER_MEDIA],
+    justification: 'Video capture requires getUserMedia and MediaRecorder (unavailable in service workers)',
+  });
+}
+
 let videoRecording = false;
 let videoStartTime = 0;
 
@@ -368,7 +340,7 @@ async function startVideoCapture(): Promise<{ ok: boolean; error?: string }> {
       videoRecording = true;
       videoStartTime = Date.now();
     }
-    return result ?? { ok: false, error: 'No response from offscreen document' };
+    return result ?? { ok: false, error: 'No response' };
   } catch (e) {
     return { ok: false, error: String(e) };
   }
@@ -385,7 +357,7 @@ async function stopVideoCapture(): Promise<{ ok: boolean; error?: string; blobUr
     return { ok: true, blobUrl: result.blobUrl, duration, size: result.size };
   }
 
-  return result ?? { ok: false, error: 'No response from offscreen document' };
+  return result ?? { ok: false, error: 'No response' };
 }
 
 // ─── Tracing ─────────────────────────────────────────────────────────────────
@@ -881,18 +853,6 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
     })();
     sendResponse({ ok: true });
     return false;
-  }
-  if (msg.type === 'cdp-relay-connect') {
-    // Forward relay URL to offscreen document
-    ensureOffscreen().then(() => {
-      chrome.runtime.sendMessage({ type: 'cdp-relay-connect', relayUrl: msg.relayUrl });
-    });
-    sendResponse({ ok: true });
-    return false;
-  }
-  if (msg.type === 'get-bridge-port') {
-    chrome.storage.local.get(['bridgePort']).then(s => sendResponse((s.bridgePort as number) || 9876));
-    return true;
   }
   if (msg.type === 'ping') { sendResponse({ pong: true }); return false; }
 

--- a/packages/extension/src/offscreen/offscreen.html
+++ b/packages/extension/src/offscreen/offscreen.html
@@ -1,0 +1,4 @@
+<!DOCTYPE html>
+<html><head><meta charset="utf-8"><title>Video Capture</title></head>
+<body><script type="module" src="./offscreen.js"></script></body>
+</html>

--- a/packages/extension/src/offscreen/offscreen.ts
+++ b/packages/extension/src/offscreen/offscreen.ts
@@ -1,0 +1,79 @@
+// ─── Video Capture (offscreen document) ─────────────────────────────────────
+// Offscreen document for tabCapture video recording.
+// Service workers can't access getUserMedia/MediaRecorder — this document provides that context.
+
+let recorder: MediaRecorder | undefined;
+let recordedChunks: Blob[] = [];
+let lastBlobUrl: string | null = null;
+
+function revokeLastBlob() {
+  if (lastBlobUrl) {
+    URL.revokeObjectURL(lastBlobUrl);
+    lastBlobUrl = null;
+  }
+}
+
+async function startVideoCapture(streamId: string) {
+  if (recorder?.state === 'recording') {
+    throw new Error('Already recording');
+  }
+  revokeLastBlob();
+
+  const constraints = {
+    audio: { mandatory: { chromeMediaSource: 'tab', chromeMediaSourceId: streamId } },
+    video: { mandatory: { chromeMediaSource: 'tab', chromeMediaSourceId: streamId } },
+  } as unknown as MediaStreamConstraints;
+  const media = await navigator.mediaDevices.getUserMedia(constraints);
+
+  // Continue playing captured audio to the user
+  const output = new AudioContext();
+  const source = output.createMediaStreamSource(media);
+  source.connect(output.destination);
+
+  recorder = new MediaRecorder(media, { mimeType: 'video/webm' });
+  recorder.ondataavailable = (event) => recordedChunks.push(event.data);
+  recorder.start();
+}
+
+async function stopVideoCapture(): Promise<{ blobUrl: string; size: number }> {
+  if (!recorder || recorder.state !== 'recording') {
+    throw new Error('Not recording');
+  }
+
+  return new Promise<{ blobUrl: string; size: number }>((resolve) => {
+    recorder!.onstop = () => {
+      const blob = new Blob(recordedChunks, { type: 'video/webm' });
+      const blobUrl = URL.createObjectURL(blob);
+      lastBlobUrl = blobUrl;
+      const size = blob.size;
+
+      recorder = undefined;
+      recordedChunks = [];
+
+      resolve({ blobUrl, size });
+    };
+
+    recorder!.stop();
+    recorder!.stream.getTracks().forEach((t) => t.stop());
+  });
+}
+
+// ─── Message routing from background SW ─────────────────────────────────────
+
+chrome.runtime.onMessage.addListener((msg: { type: string; streamId?: string }, _sender, sendResponse) => {
+  if (msg.type === 'video-capture-start') {
+    startVideoCapture(msg.streamId as string)
+      .then(() => sendResponse({ ok: true }))
+      .catch((e: Error) => sendResponse({ ok: false, error: e.message }));
+    return true;
+  }
+  if (msg.type === 'video-capture-stop') {
+    stopVideoCapture()
+      .then(({ blobUrl, size }) => sendResponse({ ok: true, blobUrl, size }))
+      .catch((e: Error) => sendResponse({ ok: false, error: e.message }));
+    return true;
+  }
+  if (msg.type === 'video-revoke') {
+    revokeLastBlob();
+  }
+});

--- a/packages/extension/test/background.test.ts
+++ b/packages/extension/test/background.test.ts
@@ -272,20 +272,6 @@ describe("background.ts message handlers", () => {
     expect(result).toEqual({ pong: true });
   });
 
-  // ─── get-bridge-port ──────────────────────────────────────────────────────
-
-  it("get-bridge-port returns stored port", async () => {
-    (chrome.storage.local.get as ReturnType<typeof vi.fn>).mockResolvedValue({ bridgePort: 1234 });
-    const result = await sendMessage({ type: 'get-bridge-port' });
-    expect(result).toBe(1234);
-  });
-
-  it("get-bridge-port returns default 9876 when not set", async () => {
-    (chrome.storage.local.get as ReturnType<typeof vi.fn>).mockResolvedValue({});
-    const result = await sendMessage({ type: 'get-bridge-port' });
-    expect(result).toBe(9876);
-  });
-
   // ─── attach: Frame detached retry ─────────────────────────────────────────
 
   it("attach retries on 'Frame has been detached' error via detachAll", async () => {
@@ -460,15 +446,6 @@ describe("background.ts message handlers", () => {
     await onActionClicked({ id: 42, windowId: 1 });
     expect(chrome.windows.create).toHaveBeenCalledWith(
       expect.objectContaining({ type: 'popup' })
-    );
-  });
-
-  it("storage onChanged sends bridge-port-changed message", async () => {
-    onStorageChanged({ bridgePort: { newValue: 5555 } }, 'local');
-    // ensureOffscreen is async — flush promises before checking sendMessage
-    await new Promise(r => setTimeout(r, 0));
-    expect(chrome.runtime.sendMessage).toHaveBeenCalledWith(
-      expect.objectContaining({ type: 'bridge-port-changed', port: 5555 })
     );
   });
 

--- a/packages/extension/vite.config.ts
+++ b/packages/extension/vite.config.ts
@@ -61,6 +61,7 @@ export default defineConfig({
         "preferences/preferences": resolve(__dirname, "src/preferences/preferences.html"),
         "devtools/devtools": resolve(__dirname, "src/devtools/devtools.html"),
         "devtools/console": resolve(__dirname, "src/devtools/console.html"),
+        "offscreen/offscreen": resolve(__dirname, "src/offscreen/offscreen.html"),
       },
       output: {
         entryFileNames: "[name].js",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@playwright-repl/mcp",
     "description": "MCP server — AI agents control your real Chrome browser",
-    "version": "0.27.0",
+    "version": "0.27.1",
     "type": "module",
     "bin": {
         "playwright-repl-mcp": "./dist/index.js"

--- a/packages/stagecraft/package.json
+++ b/packages/stagecraft/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@playwright-repl/stagecraft",
   "description": "Skill library and agent runtime for playwright-repl",
-  "version": "0.27.0",
+  "version": "0.27.1",
   "type": "module",
   "main": "./dist/index.js",
   "exports": {

--- a/packages/vscode/CHANGELOG.md
+++ b/packages/vscode/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.27.1
+
+**2026-05-06**
+
+### Fixes
+
+- Restore offscreen document for video capture in Chrome extension.
+
 ## 0.27.0
 
 **2026-05-06**

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -7,7 +7,7 @@
     "color": "#ffffff",
     "theme": "light"
   },
-  "version": "0.27.0",
+  "version": "0.27.1",
   "private": true,
   "publisher": "playwright-repl",
   "repository": {


### PR DESCRIPTION
## Summary

- Restore offscreen document for video capture (broken since #880 removed it along with bridge code)
- Clean up dead bridge code from `background.ts` (startup alarm, bridgePort listener, get-bridge-port, cdp-relay-connect)
- Add `"offscreen"` permission to manifest
- Remove 3 dead bridge tests

## Test plan

- [x] Extension builds (`pnpm run build`)
- [x] All 698 extension tests pass
- [ ] Manual: open side panel, run `video-start`, interact with page, run `video-stop` — verify recording saves

🤖 Generated with [Claude Code](https://claude.com/claude-code)