### PR TITLE
fix: resolve cross-origin frame selectors via postMessage

### DIFF
--- a/packages/extension/e2e/recording/recording.spec.ts
+++ b/packages/extension/e2e/recording/recording.spec.ts
@@ -185,6 +185,78 @@ test.describe('Recording flow', () => {
       expect(editorText).toContain('--frame "#oevd-iframe"');
     });
 
+    test('clicking inside a cross-origin <frame> records and replays correct --frame (#769)', async ({ sidePanel, testPage }) => {
+      const ctx = testPage.context();
+      // Parent on one origin, child on another — simulates file:// cross-origin behavior
+      await ctx.route('https://parent.local/frameset.html', route => route.fulfill({
+        contentType: 'text/html',
+        body: '<html><frameset><frame name="main" src="https://child.local/frame-content.html" /></frameset></html>',
+      }));
+      await ctx.route('https://child.local/frame-content.html', route => route.fulfill({
+        contentType: 'text/html',
+        body: '<button>Arbeitskorb</button>',
+      }));
+
+      await testPage.goto('https://parent.local/frameset.html');
+      await testPage.bringToFront();
+      await sidePanel.attachToActiveTab();
+
+      await sidePanel.startRecording();
+
+      await testPage.bringToFront();
+      await testPage.frame({ url: /child\.local/ })!.getByRole('button', { name: 'Arbeitskorb' }).click();
+
+      await sidePanel.waitForEditorText('click button "Arbeitskorb"');
+      const editorText = await sidePanel.getEditorText();
+      // Cross-origin: parent resolves selector via postMessage — uses tag + name, not hardcoded 'iframe'
+      expect(editorText).toContain('--frame "frame[name="main"]"');
+
+      // Replay: stop recording and run the recorded script
+      await sidePanel.stopRecording();
+      await sidePanel.runBtn.click();
+      await expect(sidePanel.output).toContainText('Run complete', { timeout: 15000 });
+      // No errors during playback
+      await expect(sidePanel.raw.locator('[data-type="error"]')).toHaveCount(0);
+    });
+
+    test('clicking inside cross-origin nested iframes records and replays correct --frame (#815)', async ({ sidePanel, testPage }) => {
+      const ctx = testPage.context();
+      // Three origins: top → iframe1 → iframe2 (cross-origin at each boundary)
+      await ctx.route('https://top.local/page.html', route => route.fulfill({
+        contentType: 'text/html',
+        body: '<html><body><iframe name="iframe1" src="https://mid.local/iframe1.html"></iframe></body></html>',
+      }));
+      await ctx.route('https://mid.local/iframe1.html', route => route.fulfill({
+        contentType: 'text/html',
+        body: '<html><body><iframe name="iframe2" src="https://inner.local/iframe2.html"></iframe></body></html>',
+      }));
+      await ctx.route('https://inner.local/iframe2.html', route => route.fulfill({
+        contentType: 'text/html',
+        body: '<html><body><button>Hello iframe 2</button></body></html>',
+      }));
+
+      await testPage.goto('https://top.local/page.html');
+      await testPage.bringToFront();
+      await sidePanel.attachToActiveTab();
+
+      await sidePanel.startRecording();
+
+      await testPage.bringToFront();
+      await testPage.frame({ url: /inner\.local/ })!.getByRole('button', { name: 'Hello iframe 2' }).click();
+
+      await sidePanel.waitForEditorText('click button "Hello iframe 2"');
+      const editorText = await sidePanel.getEditorText();
+      // Nested cross-origin: space-separated selectors for both levels
+      expect(editorText).toContain('--frame "iframe[name="iframe1"] iframe[name="iframe2"]"');
+
+      // Replay: stop recording and run the recorded script
+      await sidePanel.stopRecording();
+      await sidePanel.runBtn.click();
+      await expect(sidePanel.output).toContainText('Run complete', { timeout: 15000 });
+      // No errors during playback
+      await expect(sidePanel.raw.locator('[data-type="error"]')).toHaveCount(0);
+    });
+
     test('stop recording resets button state', async ({ sidePanel }) => {
       await sidePanel.recordBtn.click();
       await expect(sidePanel.recordBtn).toHaveClass(/recording/, { timeout: 10000 });

--- a/packages/extension/src/content/recorder.ts
+++ b/packages/extension/src/content/recorder.ts
@@ -19,14 +19,6 @@ export const SPECIAL_KEYS = new Set([
 // ─── Frame detection ─────────────────────────────────────────────────────
 
 /**
- * Detect if we're inside an iframe and compute a CSS selector for it.
- * Returns null if we're in the top frame.
- *
- * For same-origin iframes, `window.frameElement` gives us the <iframe> element
- * in the parent document. For cross-origin iframes, `window.frameElement` is null
- * due to security restrictions — we fall back to using the frame's src URL.
- */
-/**
  * Compute CSS selector for a frame element.
  * Uses the same selector for both --frame flag (PW) and .locator().contentFrame() (JS),
  * matching pickLocator's output format for consistency.
@@ -53,8 +45,8 @@ function selectorForFrame(frame: Element): string {
  * Returns array of CSS selectors, one per ancestor frame, outermost first.
  * Returns empty array if we're in the top frame.
  */
-function detectFrameChain(): string[] {
-    if (window === window.top) return [];
+function detectFrameChain(): { chain: string[]; complete: boolean } {
+    if (window === window.top) return { chain: [], complete: true };
 
     const chain: string[] = [];
     let win: Window = window;
@@ -64,23 +56,26 @@ function detectFrameChain(): string[] {
             if (frame) {
                 chain.push(selectorForFrame(frame));
             } else {
-                // Cross-origin: frameElement is null, use src fallback
-                try {
-                    const src = win.location.href;
-                    chain.push((src && src !== 'about:blank') ? `iframe[src="${src}"]` : 'iframe');
-                } catch { chain.push('iframe'); }
-                break; // Can't walk further up from cross-origin
+                // Cross-origin: frameElement is null — can't determine selector.
+                // Will be resolved via postMessage from parent frame's content script.
+                return { chain: chain.reverse(), complete: false };
             }
         } catch {
-            break; // cross-origin — frameElement throws
+            // cross-origin — frameElement throws
+            return { chain: chain.reverse(), complete: false };
         }
         win = win.parent;
     }
-    return chain.reverse();
+    return { chain: chain.reverse(), complete: true };
 }
 
-/** Cached frame chain — computed once on init */
+/** Cached frame chain — computed on init, may be updated via postMessage */
 let framePath: string[] = [];
+let framePathReady = false;
+const pendingChildRequests: Window[] = [];
+
+const FRAME_REQ = '__pw_repl_frame_req';
+const FRAME_PATH = '__pw_repl_frame_path';
 
 /**
  * Wrap recorded commands with frame context if we're inside an iframe.
@@ -94,6 +89,76 @@ function wrapWithFrameContext(cmds: { pw: string; js: string }): { pw: string; j
         pw: `${cmds.pw} --frame "${frameArg}"`,
         js: `await page${jsChain}.${cmds.js.replace(/^await page\./, '')}`,
     };
+}
+
+// ─── Cross-origin frame path resolution ─────────────────────────────────
+
+/**
+ * For cross-origin frames (including file:// URLs), window.frameElement is null
+ * so the child can't determine its own selector. The parent frame CAN see the
+ * <frame>/<iframe> elements in its DOM, so we use postMessage to communicate
+ * the correct selector chain from parent to child.
+ *
+ * Two redundant paths ensure resolution regardless of init ordering:
+ * 1. Parent proactively notifies children on init (handles child-inits-later)
+ * 2. Child requests from parent on init (handles parent-inits-later)
+ */
+
+let frameMessageHandler: ((e: MessageEvent) => void) | null = null;
+
+/** Send frame path to a child window by finding its frame element in our DOM */
+function sendPathToChild(childWindow: Window) {
+    const frames = document.querySelectorAll('frame, iframe');
+    for (const frame of frames) {
+        try {
+            if ((frame as HTMLIFrameElement).contentWindow === childWindow) {
+                const sel = selectorForFrame(frame);
+                childWindow.postMessage({ type: FRAME_PATH, path: [...framePath, sel] }, '*');
+                return;
+            }
+        } catch { /* contentWindow comparison might throw */ }
+    }
+}
+
+/** Proactively send frame paths to all child frames */
+function notifyChildren() {
+    const frames = document.querySelectorAll('frame, iframe');
+    for (const frame of frames) {
+        const sel = selectorForFrame(frame);
+        try {
+            (frame as HTMLIFrameElement).contentWindow?.postMessage(
+                { type: FRAME_PATH, path: [...framePath, sel] },
+                '*'
+            );
+        } catch { /* contentWindow.postMessage might throw */ }
+    }
+}
+
+function setupFrameMessaging(complete: boolean) {
+    frameMessageHandler = (e: MessageEvent) => {
+        // Parent providing our frame path (cross-origin resolution)
+        if (e.data?.type === FRAME_PATH && e.source === window.parent) {
+            framePath = e.data.path;
+            framePathReady = true;
+            for (const child of pendingChildRequests) sendPathToChild(child);
+            pendingChildRequests.length = 0;
+            notifyChildren();
+        }
+        // Child frame requesting their path from us
+        if (e.data?.type === FRAME_REQ && e.source) {
+            if (framePathReady) {
+                sendPathToChild(e.source as Window);
+            } else {
+                pendingChildRequests.push(e.source as Window);
+            }
+        }
+    };
+    window.addEventListener('message', frameMessageHandler);
+
+    if (framePathReady) notifyChildren();
+    if (window !== window.top && !complete) {
+        window.parent.postMessage({ type: FRAME_REQ }, '*');
+    }
 }
 
 /**
@@ -262,6 +327,11 @@ export function cleanup() {
     document.removeEventListener('change', onChangeCapture, true);
     document.removeEventListener('keydown', onKeyDownCapture, true);
     document.removeEventListener('focusout', onFocusOutCapture, true);
+    if (frameMessageHandler) {
+        window.removeEventListener('message', frameMessageHandler);
+        frameMessageHandler = null;
+    }
+    pendingChildRequests.length = 0;
     chrome.runtime.onMessage.removeListener(onMessage);
 }
 
@@ -276,8 +346,12 @@ export function init() {
     if (window.__pw_recorder_active) return;
     window.__pw_recorder_active = true;
 
-    // Detect iframe context once on init
-    framePath = detectFrameChain();
+    // Detect iframe context — same-origin path is synchronous and reliable;
+    // cross-origin frames (including file:// URLs) get resolved via postMessage
+    const detection = detectFrameChain();
+    framePath = detection.chain;
+    framePathReady = detection.complete;
+    setupFrameMessaging(detection.complete);
 
     // Back/forward detection via Navigation API traverse event
     type NavEntry = { index: number; url?: string };


### PR DESCRIPTION
## Summary
- Cross-origin frames (including `file://` URLs) have null `frameElement`, preventing the recorder from determining the correct CSS selector for `--frame`
- Added a postMessage protocol between parent and child content scripts to resolve the full frame chain, with two redundant paths (parent-notifies-children + child-requests-from-parent) to handle any init ordering
- Handles both `<frame>` elements and nested cross-origin `<iframe>` cases

Related: #769, #815

## Test plan
- [x] E2E test: clicking inside a cross-origin `<frame>` records and replays correct `--frame` selector
- [x] E2E test: clicking inside cross-origin nested iframes records and replays correct `--frame` selector
- [ ] Manual: verify recording in file:// pages with frames still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)