### PR TITLE
fix: wire --http into --connect mode

### DIFF
--- a/packages/cli/src/repl.ts
+++ b/packages/cli/src/repl.ts
@@ -1251,6 +1251,23 @@ export async function startRepl(opts: ReplOpts = {}): Promise<void> {
       return;
     }
 
+    if (opts.http) {
+      const httpPort = opts.httpPort ?? DEFAULT_HTTP_PORT;
+      const runner: CommandRunner = {
+        run: async (command: string) => relayExec(command, relayPage, relayCtx, pwExpect),
+        runScript: async (script: string) => relayExec(script, relayPage, relayCtx, pwExpect),
+      };
+      await startHttpServer(httpPort, runner, log);
+      if (opts.interactive) {
+        log(`${c.dim}Type .help for commands, JavaScript supported${c.reset}\n`);
+        await startRelayLoop(opts, relay, browser, relayPage, relayCtx, pwExpect);
+      } else {
+        await waitForShutdown(log);
+        await cleanup();
+      }
+      return;
+    }
+
     log(`${c.dim}Type .help for commands, JavaScript supported${c.reset}\n`);
     await startRelayLoop(opts, relay, browser, relayPage, relayCtx, pwExpect);
     return;


### PR DESCRIPTION
--http was silently ignored in the relay/connect code path after a refactor. startHttpServer was defined but never called from that path.

Now playwright-repl --connect --http starts the HTTP server on port 9223 without showing a readline prompt. Add --interactive to also get the relay> prompt.