### PR TITLE
fix: remove alarms permission from Chrome extension

### DIFF
--- a/packages/extension/public/manifest.json
+++ b/packages/extension/public/manifest.json
@@ -10,7 +10,6 @@
     "debugger",
     "storage",
     "windows",
-    "alarms",
     "scripting",
     "tabCapture",
     "webNavigation",

--- a/packages/extension/src/background.ts
+++ b/packages/extension/src/background.ts
@@ -116,14 +116,6 @@ chrome.management.getSelf().then(async (info) => {
   }
 });
 
-// Re-check offscreen doc periodically — Chrome may kill it after idle.
-chrome.alarms.create('ensure-offscreen', { periodInMinutes: 1 });
-chrome.alarms.onAlarm.addListener((alarm) => {
-  if (alarm.name === 'ensure-offscreen') {
-    ensureOffscreenRelay().catch(() => {});
-  }
-});
-
 // ─── Settings + Action (sidepanel / popup) ───────────────────────────────────
 
 // Disable auto-open so action.onClicked fires (Chrome persists this across reloads)


### PR DESCRIPTION
## Summary

- Remove `alarms` permission from manifest.json — rejected by Chrome Web Store review
- Remove alarm code from background.ts that periodically recreated the offscreen document
- The offscreen document's own `setInterval` (10s health check in offscreen.ts:128) keeps it alive and handles WebSocket reconnection, making the alarm redundant

## Context

The alarm was added in #650 for the bridge WebSocket keepalive. The bridge was removed in v0.27.0 but the alarm remained as dead code.

## Test plan

- [x] `pnpm run build` passes
- [x] `pnpm test` — all unit tests pass
- [x] Extension E2E — 216 passed
- [x] CLI E2E replay passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)