### PR TITLE
fix: support Edge browser in Dramaturg extension

### DIFF
--- a/packages/extension/public/manifest.json
+++ b/packages/extension/public/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "Dramaturg",
   "version": "0.27.4",
-  "description": "Playwright engineer's companion — console, editor, runner, debugger, and recorder in a Chrome side panel.",
+  "description": "Playwright engineer's companion — console, editor, runner, debugger, and recorder in a browser side panel.",
   "permissions": [
     "activeTab",
     "tabs",

--- a/packages/extension/src/background.ts
+++ b/packages/extension/src/background.ts
@@ -171,6 +171,7 @@ async function ensureCrxApp(): Promise<CrxApplication> {
 function isAttachableUrl(url: string | undefined): boolean {
   if (!url) return true; // no URL info — let attachToTab decide
   if (url.startsWith('chrome://')) return false;
+  if (url.startsWith('edge://')) return false;
   if (url.startsWith('https://chromewebstore.google.com')) return false;
   if (url.startsWith('chrome-extension://') && !url.startsWith(`chrome-extension://${chrome.runtime.id}/`)) return false;
   return true;
@@ -207,14 +208,14 @@ async function attachToTab(tabId: number): Promise<{ ok: boolean; url?: string; 
     const tab = await chrome.tabs.get(tabId);
     const ownOrigin = `chrome-extension://${chrome.runtime.id}/`;
     const url = tab.url ?? '';
-    if (url.startsWith('chrome://') ||
+    if (url.startsWith('chrome://') || url.startsWith('edge://') ||
         (url.startsWith('chrome-extension://') && !url.startsWith(ownOrigin)) ||
         url.startsWith('https://chromewebstore.google.com')) {
       if (activeTabId === tabId) {
         activeTabId = null;
         currentPage = null;
       }
-      return { ok: false, error: 'Cannot attach to this page — Chrome restricts extension access. Navigate to a regular webpage first.' };
+      return { ok: false, error: 'Cannot attach to this page — browser restricts extension access. Navigate to a regular webpage first.' };
     }
 
     const app = await ensureCrxApp();

--- a/packages/extension/src/panel/components/Toolbar.tsx
+++ b/packages/extension/src/panel/components/Toolbar.tsx
@@ -35,7 +35,7 @@ function Toolbar({ editorContent, editorMode, stepLine, attachedUrl, attachedTab
 
     function isInternalUrl(url: string | undefined) {
         if (!url) return true;
-        return url.startsWith('chrome://') || url.startsWith('chrome-extension://');
+        return url.startsWith('chrome://') || url.startsWith('edge://') || url.startsWith('chrome-extension://');
     }
 
     function getTabLabel(tab: chrome.tabs.Tab): string {
@@ -43,6 +43,7 @@ function Toolbar({ editorContent, editorMode, stepLine, attachedUrl, attachedTab
             if (tab.url?.startsWith('about:')) return tab.url;
             const url = new URL(tab.url!);
             if (url.protocol === 'chrome:') return `chrome://${url.hostname}`;
+            if (url.protocol === 'edge:') return `edge://${url.hostname}`;
             return url.hostname;
         } catch {
             return tab.url ?? '(unknown)';
@@ -282,7 +283,7 @@ function Toolbar({ editorContent, editorMode, stepLine, attachedUrl, attachedTab
 
         setIsRecording(true);
 
-        if (result.url && result.url !== 'about:blank' && !result.url.startsWith('chrome://') && isEditorEmpty()) {
+        if (result.url && result.url !== 'about:blank' && !result.url.startsWith('chrome://') && !result.url.startsWith('edge://') && isEditorEmpty()) {
             const gotoCmd = editorMode === 'js'
                 ? `await page.goto(${JSON.stringify(result.url)});`
                 : `goto "${result.url}"`;


### PR DESCRIPTION
## Summary

- Block `edge://` URLs in `isAttachableUrl` and `attachToTab` (same treatment as `chrome://`)
- Update attach error message from "Chrome restricts" → "browser restricts"
- Add `edge://` guard in `isInternalUrl` and `handleRecord` in Toolbar
- Add `edge:` protocol handling in `getTabLabel` so `edge://settings` etc. display correctly in the tab dropdown
- Update manifest description: "Chrome side panel" → "browser side panel"

No permission or manifest structure changes needed — Edge is Chromium-based and uses the same `chrome-extension://` URL scheme, so existing extension filtering already works for Edge extension pages.

## Test plan

- [ ] Load extension in Edge via `edge://extensions` → extension appears
- [ ] Open side panel in Edge — toolbar and editor load correctly
- [ ] With an `edge://` tab active, attach button is disabled / shows correct error
- [ ] `edge://` tabs display with correct label in the tab dropdown
- [ ] Start recording on a normal page — no spurious `goto edge://...` emitted
- [ ] All existing Chrome behaviour unchanged

Closes #901

🤖 Generated with [Claude Code](https://claude.com/claude-code)